### PR TITLE
fix: status bar contrast

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/MainActivity.kt
@@ -49,6 +49,9 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         installSplashScreen()
         enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(
+                scrim = android.graphics.Color.TRANSPARENT,
+            ),
             navigationBarStyle = SystemBarStyle.dark(
                 scrim = 0xFF020404.toInt(),
             ),

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -57,6 +57,10 @@ final class RootComposeViewController: UIViewController {
         immersiveController(in: contentController)?.prefersStatusBarHidden ?? false
     }
 
+    override var preferredStatusBarStyle: UIStatusBarStyle {
+        .lightContent
+    }
+
     override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {
         .fade
     }


### PR DESCRIPTION
## Summary

Make the status bar in a contrasting color to the app theme

## PR type

- Bug fix

## Why

The status bar was black, which results in very low contrast, making it nearly invisible.

## Policy check

- [X] This PR is not cosmetic-only, unless it is a translation PR.
- [X] This PR does not add a new major feature without prior approval.
- [X] This PR is small in scope and focused on one problem.
- [X] If this is a larger or directional change, I linked the **approved** feature request issue below.

> **Large PRs without a linked, approved feature request issue will be closed immediately without review. No exceptions.**

## Approved feature request (required for large/non-trivial PRs)

<!-- Link the approved feature request issue. Delete this section ONLY for small bug fixes. -->
<!-- Example: Approved in #123 -->

## Testing

Tested on an Android device and an emulator

## Screenshots / Video (UI changes only)

| Before  | After  |
|---|---|
| <img width="370" height="795" alt="image" src="https://github.com/user-attachments/assets/b2917c15-3c9d-44ce-ae17-0b3a29b528ba" /> | <img width="368" height="793" alt="image" src="https://github.com/user-attachments/assets/5943f8ef-6fd6-4a57-81b0-1d59279e0da4" /> |

## Breaking changes

None. Only visual changes for iOS & Android status bar color.

## Linked issues

Fixes #946
