### PR TITLE
fix(image): register SvgDecoder so SVG logos actually render

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -260,6 +260,7 @@ kotlin {
         commonMain.dependencies {
             implementation(libs.coil.compose)
             implementation(libs.coil.network.ktor3)
+            implementation(libs.coil.svg)
             implementation("dev.chrisbanes.haze:haze:1.7.2")
             implementation(libs.compose.runtime)
             implementation(libs.compose.foundation)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -73,6 +73,7 @@ import coil3.ImageLoader
 import coil3.compose.setSingletonImageLoaderFactory
 import coil3.request.CachePolicy
 import coil3.request.crossfade
+import coil3.svg.SvgDecoder
 import com.nuvio.app.core.build.AppFeaturePolicy
 import com.nuvio.app.core.auth.AuthRepository
 import com.nuvio.app.core.auth.AuthState
@@ -300,6 +301,9 @@ fun App() {
             .crossfade(true)
             .diskCachePolicy(CachePolicy.ENABLED)
             .memoryCachePolicy(CachePolicy.ENABLED)
+            .components {
+                add(SvgDecoder.Factory())
+            }
             .configurePlatformImageLoader()
             .build()
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-previ
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
 kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }


### PR DESCRIPTION
## Summary

Mirrors NuvioTV PR #1772 for the mobile app. Adds the missing `coil-svg` Kotlin Multiplatform dependency and registers `SvgDecoder.Factory()` on the singleton `ImageLoader` in `App.kt`. Coil 3.x's `coil-svg` is a KMP module, so the factory registration in `commonMain` covers **Android and iOS** in a single place.

Three-line change spread across three files:

```toml
# gradle/libs.versions.toml
coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
```

```kotlin
// composeApp/build.gradle.kts (commonMain.dependencies)
implementation(libs.coil.svg)
```

```kotlin
// App.kt
import coil3.svg.SvgDecoder
…
ImageLoader.Builder(context)
    .crossfade(true)
    .diskCachePolicy(CachePolicy.ENABLED)
    .memoryCachePolicy(CachePolicy.ENABLED)
    .components {
        add(SvgDecoder.Factory())  // ← new
    }
    .configurePlatformImageLoader()
    .build()
```

## Why

Worse than NuvioTV: not only was the decoder unregistered, but `coil-svg` was never even declared in `libs.versions.toml`. So every SVG image silently fell through Coil's decoder chain into `BitmapFactory`, which returned `null` on SVG bytes, raising an `ImageDecoderException` swallowed by `AsyncImage` (no `error` painter on most call sites).

This affects:
- **TMDB network / channel logos** — TMDB serves a mix of PNG and SVG depending on the asset; the SVG variants currently never display.
- **Any addon manifest** that uses an SVG `logo` field (the Stremio spec allows it).
- **Any custom artwork URL** the user pastes in the collection editor that happens to be SVG.

## Testing

- The change is a wiring-only addition: pure additive to the `ImageLoader.Builder`. Coil only invokes a decoder factory when previous decoders decline the source, so existing PNG / JPEG / WebP / GIF artwork takes the same path as before.
- Verified the fix mirrors NuvioTV PR #1772 (already merged), which confirmed correct rendering on real SVG logos on Android TV.
- Local Gradle sync succeeds; `:composeApp:assembleFullDebug` builds; `:composeApp:linkPodReleaseFrameworkIosArm64` builds.

## Breaking changes

None. Pure additive wiring.

## Linked issues

None. Mirrors NuvioMedia/NuvioTV#1772.