### PR TITLE
feat(network): send Accept-Language header to addons

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AcceptLanguage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AcceptLanguage.android.kt
@@ -1,0 +1,6 @@
+package com.nuvio.app.features.addons
+
+import java.util.Locale
+
+internal actual fun deviceLanguageTag(): String? =
+    Locale.getDefault().toLanguageTag().takeIf { it.isNotBlank() }

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
@@ -71,6 +71,13 @@ private fun Map<String, String>.withoutAcceptEncoding(): Map<String, String> =
 private fun Map<String, String>.getHeaderIgnoreCase(name: String): String? =
     entries.firstOrNull { (key, _) -> key.equals(name, ignoreCase = true) }?.value
 
+private fun Map<String, String>.withDefaultAcceptLanguage(): Map<String, String> =
+    if (getHeaderIgnoreCase("Accept-Language") != null) {
+        this
+    } else {
+        this + ("Accept-Language" to buildAcceptLanguageHeader())
+    }
+
 private data class LimitedReadResult(
     val bytes: ByteArray,
     val truncated: Boolean,
@@ -134,7 +141,7 @@ private suspend fun executeTextRequest(
     body: String = "",
 ): String = withContext(Dispatchers.IO) {
     val normalizedMethod = method.uppercase()
-    val sanitizedHeaders = headers.withoutAcceptEncoding()
+    val sanitizedHeaders = headers.withoutAcceptEncoding().withDefaultAcceptLanguage()
     val builder = Request.Builder().url(url)
     sanitizedHeaders.forEach { (key, value) ->
         builder.header(key, value)
@@ -214,7 +221,7 @@ actual suspend fun httpRequestRaw(
 ): RawHttpResponse =
     withContext(Dispatchers.IO) {
         val normalizedMethod = method.uppercase()
-        val sanitizedHeaders = headers.withoutAcceptEncoding()
+        val sanitizedHeaders = headers.withoutAcceptEncoding().withDefaultAcceptLanguage()
         val builder = Request.Builder().url(url)
         sanitizedHeaders.forEach { (key, value) ->
             builder.header(key, value)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AcceptLanguage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AcceptLanguage.kt
@@ -1,0 +1,50 @@
+package com.nuvio.app.features.addons
+
+import com.nuvio.app.features.settings.ThemeSettingsStorage
+
+/**
+ * Returns the device's primary BCP-47 language tag (e.g. "fr-FR", "en", "es-MX"),
+ * or `null` if the platform can't determine one.
+ */
+internal expect fun deviceLanguageTag(): String?
+
+/**
+ * Builds the value of the HTTP `Accept-Language` header that the addon HTTP
+ * client should send.
+ *
+ * Resolution rules:
+ * - If the user has explicitly picked an in-app language, that code wins
+ *   (the in-app language is always region-less, e.g. `fr`).
+ * - Otherwise the device locale tag is used.
+ *
+ * Header format:
+ * - Regional locale (`fr-FR`, `pt-BR`, `es-MX`): strict chain
+ *   `fr-FR, fr;q=0.9, en;q=0.5` — accept the exact region first, then any
+ *   variant of the same language, then English. Cross-region variants
+ *   (e.g. `fr-CA`) are not preferred.
+ * - Language only (`fr`): legacy behaviour `fr, en;q=0.7` — any French variant
+ *   the addon serves is acceptable.
+ * - English (with or without region): just the tag itself, no q-suffix.
+ */
+internal fun buildAcceptLanguageHeader(): String {
+    val rawTag = ThemeSettingsStorage.loadSelectedAppLanguage()?.takeIf { it.isNotBlank() }
+        ?: deviceLanguageTag()?.takeIf {
+            it.isNotBlank() && !it.equals("und", ignoreCase = true)
+        }
+        ?: return "en"
+
+    val normalized = rawTag.replace('_', '-').trim()
+    val parts = normalized.split('-', limit = 2)
+    val language = parts[0].lowercase().takeIf { it.isNotBlank() } ?: return "en"
+    val region = parts.getOrNull(1)?.takeIf { it.isNotBlank() }?.uppercase()
+
+    if (language == "en") {
+        return if (region != null) "en-$region, en" else "en"
+    }
+
+    return if (region != null) {
+        "$language-$region, $language;q=0.9, en;q=0.5"
+    } else {
+        "$language, en;q=0.7"
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AcceptLanguage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AcceptLanguage.ios.kt
@@ -1,0 +1,9 @@
+package com.nuvio.app.features.addons
+
+import platform.Foundation.NSLocale
+import platform.Foundation.preferredLanguages
+
+internal actual fun deviceLanguageTag(): String? {
+    val preferred = NSLocale.preferredLanguages.firstOrNull() as? String
+    return preferred?.takeIf { it.isNotBlank() }
+}

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt
@@ -46,10 +46,21 @@ private val addonHttpClient = HttpClient(Darwin) {
     expectSuccess = false
 }
 
+private fun Map<String, String>.hasHeaderIgnoreCase(name: String): Boolean =
+    keys.any { it.equals(name, ignoreCase = true) }
+
+private fun Map<String, String>.withDefaultAcceptLanguage(): Map<String, String> =
+    if (hasHeaderIgnoreCase("Accept-Language")) {
+        this
+    } else {
+        this + ("Accept-Language" to buildAcceptLanguageHeader())
+    }
+
 actual suspend fun httpGetText(url: String): String =
     addonHttpClient
         .get(url) {
             accept(ContentType.Application.Json)
+            header(HttpHeaders.AcceptLanguage, buildAcceptLanguageHeader())
         }
         .let { response ->
             val payload = response.bodyAsText()
@@ -67,6 +78,7 @@ actual suspend fun httpPostJson(url: String, body: String): String =
         .post(url) {
             accept(ContentType.Application.Json)
             header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+            header(HttpHeaders.AcceptLanguage, buildAcceptLanguageHeader())
             setBody(body)
         }
         .let { response ->
@@ -87,7 +99,7 @@ actual suspend fun httpGetTextWithHeaders(
     addonHttpClient
         .get(url) {
             accept(ContentType.Application.Json)
-            headers.forEach { (key, value) ->
+            headers.withDefaultAcceptLanguage().forEach { (key, value) ->
                 header(key, value)
             }
         }
@@ -111,7 +123,7 @@ actual suspend fun httpPostJsonWithHeaders(
         .post(url) {
             accept(ContentType.Application.Json)
             header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
-            headers.forEach { (key, value) ->
+            headers.withDefaultAcceptLanguage().forEach { (key, value) ->
                 header(key, value)
             }
             setBody(body)
@@ -138,7 +150,7 @@ actual suspend fun httpRequestRaw(
         .request {
             url(url)
             this.method = HttpMethod.parse(method.uppercase())
-            headers.forEach { (key, value) ->
+            headers.withDefaultAcceptLanguage().forEach { (key, value) ->
                 header(key, value)
             }
             if (this.method == HttpMethod.Post || this.method == HttpMethod.Put || this.method == HttpMethod.Patch) {


### PR DESCRIPTION
## Summary

Sends an `Accept-Language` HTTP header on every addon-bound request so Stremio-compatible addons that maintain localized payloads (catalog names, descriptions, …) can serve them in the user's language. Covers Android + iOS in one shot via Kotlin Multiplatform. Pure additive wiring — addons that don't read the header keep returning identical payloads.

### Resolution rules

Priority for the source tag:
1. User-picked in-app language code (`ThemeSettingsStorage.loadSelectedAppLanguage()`) — always region-less (`fr`, `de`, `es`, `pt`, `it`, `tr`, `el`, `pl`, `en`).
2. Device locale tag (`Locale.getDefault().toLanguageTag()` on Android, `NSLocale.preferredLanguages.first` on iOS).
3. `en` if both are blank/`und`.

Header format from the resolved tag:

| Source tag | Header value | Behaviour |
|---|---|---|
| `fr-FR`, `pt-BR`, `es-MX`, … (regional) | `fr-FR, fr;q=0.9, en;q=0.5` | Exact region first, then language-only fallback, then English. Cross-region variants (e.g. `fr-CA`) are not preferred. |
| `fr`, `de`, `pt`, … (language only) | `fr, en;q=0.7` | Legacy: any variant of the language is acceptable, English fallback. |
| `en` / `en-US` / `en-GB` | `en-US, en` or `en` | English already matches the default; no q-suffix. |

The header is added as a default — if a caller already supplied an `Accept-Language` (case-insensitive), it is preserved untouched.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

The FR locale currently shows English catalog row names (e.g. `TMDB Popular - Séries`, `TMDB Trending - Films`) because addons get no language hint. Addons like AIO Metadata that already maintain localized catalog titles cannot know what the user wants. Sending `Accept-Language` is the standard HTTP way to negotiate this. Mirrors the same change already shipped on NuvioTV (NuvioTV PR #1766).

## Issue or approval

Approved in NuvioTV PR #1766 — the equivalent change for NuvioTV was reviewed and merged; this PR ports the same approach to NuvioMobile with KMP coverage instead of Android-only.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to: a new common helper (`AcceptLanguage.kt` + `expect fun deviceLanguageTag()`), Android/iOS actual implementations, and one-line header injection in `AddonPlatform.{android,ios}.kt`. No other addon, player, library, sync, or settings code touched.

## Testing

- Manually traced the resolution for `fr-FR`, `pt-BR`, `es-MX`, `fr`, `en-US`, `en` — header values match the table above.
- Verified the helper preserves caller-supplied `Accept-Language` (so trailers / YouTube extractor's existing `en-US,en;q=0.9` are not clobbered).
- Adding a request header is fully backward-compatible: addons that ignore it return identical payloads, verified against a few legacy addons that don't read `Accept-Language`.

## Screenshots / Video

Not a UI change — header-only wiring, no visible UI difference until addons take advantage of the header.

## Breaking changes

None.

## Linked issues

Approved in NuvioTV PR #1766.
