### PR TITLE
fix(tmdb): localize collection part artwork via /images endpoint

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/collection/TmdbCollectionSourceResolver.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/collection/TmdbCollectionSourceResolver.kt
@@ -5,10 +5,15 @@ import com.nuvio.app.features.addons.httpGetText
 import com.nuvio.app.features.catalog.CatalogPage
 import com.nuvio.app.features.home.MetaPreview
 import com.nuvio.app.features.home.PosterShape
+import com.nuvio.app.features.tmdb.TmdbLocalizedArtwork
+import com.nuvio.app.features.tmdb.TmdbMetadataService
 import com.nuvio.app.features.tmdb.TmdbSettingsRepository
 import com.nuvio.app.features.tmdb.buildTmdbUrl
 import com.nuvio.app.features.tmdb.normalizeTmdbLanguage
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -228,8 +233,19 @@ object TmdbCollectionSourceResolver {
             apiKey = apiKey,
             query = mapOf("language" to language),
         ) ?: error("TMDB collection not found")
-        val items = body.parts.orEmpty()
-            .mapNotNull { it.toPreview(TmdbCollectionMediaType.MOVIE) }
+        val parts = body.parts.orEmpty()
+        val items = coroutineScope {
+            parts.map { part ->
+                async {
+                    val artwork = TmdbMetadataService.fetchLocalizedArtwork(
+                        tmdbId = part.id,
+                        mediaType = "movie",
+                        language = language,
+                    )
+                    part.toPreview(TmdbCollectionMediaType.MOVIE, artwork)
+                }
+            }.awaitAll().filterNotNull()
+        }
             .sortedFor(source.sortBy)
             .distinctBy { it.id }
         return CatalogPage(items = items, rawItemCount = items.size, nextSkip = null)
@@ -406,14 +422,21 @@ object TmdbCollectionSourceResolver {
         )
     }
 
-    private fun TmdbCollectionPart.toPreview(mediaType: TmdbCollectionMediaType): MetaPreview? {
+    private fun TmdbCollectionPart.toPreview(
+        mediaType: TmdbCollectionMediaType,
+        localizedArtwork: TmdbLocalizedArtwork = TmdbLocalizedArtwork(null, null),
+    ): MetaPreview? {
         val title = title?.takeIf { it.isNotBlank() } ?: return null
+        val localizedPoster = TmdbMetadataService.imageUrl(localizedArtwork.poster, "w500")
+        val localizedBackdrop = TmdbMetadataService.imageUrl(localizedArtwork.backdrop, "w1280")
         return MetaPreview(
             id = "tmdb:$id",
             type = if (mediaType == TmdbCollectionMediaType.TV) "series" else "movie",
             name = title,
-            poster = imageUrl(posterPath, "w500") ?: imageUrl(backdropPath, "w780"),
-            banner = imageUrl(backdropPath, "w1280"),
+            poster = localizedPoster
+                ?: imageUrl(posterPath, "w500")
+                ?: imageUrl(backdropPath, "w780"),
+            banner = localizedBackdrop ?: imageUrl(backdropPath, "w1280"),
             posterShape = PosterShape.Poster,
             description = overview?.takeIf { it.isNotBlank() },
             releaseInfo = releaseDate?.take(4),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -36,6 +36,7 @@ object TmdbMetadataService {
     private val entityHeaderCache = mutableMapOf<String, TmdbEntityHeader>()
     private val entityRailCache = mutableMapOf<String, List<MetaPreview>>()
     private val previewArtworkCache = mutableMapOf<String, TmdbPreviewArtwork>()
+    private val localizedArtworkCache = mutableMapOf<String, TmdbLocalizedArtwork>()
 
     suspend fun fetchPersonDetail(
         personId: Int,
@@ -529,6 +530,56 @@ object TmdbMetadataService {
         val backdrop: String?,
         val logo: String?,
     )
+
+    /**
+     * Fetches a localized poster + backdrop for a movie or TV id from
+     * `/{mediaType}/{id}/images?include_image_language=<lang>,null,en`.
+     *
+     * TMDB's collection / list / credits endpoints only return one default
+     * poster path per part — usually the English-favored one regardless of the
+     * `language=fr` query param. Calling `/images` separately is the only way
+     * to get artwork actually localized in the user's language. Results cached
+     * per `(tmdbId, mediaType, language)` to avoid hammering TMDB.
+     *
+     * For English locales the call is skipped: the default poster is already
+     * the English-favored one.
+     */
+    internal suspend fun fetchLocalizedArtwork(
+        tmdbId: Int,
+        mediaType: String,
+        language: String,
+    ): TmdbLocalizedArtwork = withContext(Dispatchers.Default) {
+        val normalizedLanguage = normalizeTmdbLanguage(language)
+        if (normalizedLanguage.startsWith("en", ignoreCase = true)) {
+            return@withContext TmdbLocalizedArtwork(poster = null, backdrop = null)
+        }
+        val cacheKey = "$tmdbId:$mediaType:$normalizedLanguage"
+        localizedArtworkCache[cacheKey]?.let { return@withContext it }
+
+        val includeImageLanguage = buildString {
+            append(normalizedLanguage.substringBefore("-"))
+            append(",")
+            append(normalizedLanguage)
+            append(",en,null")
+        }
+        val images = fetch<TmdbImagesResponse>(
+            endpoint = "$mediaType/$tmdbId/images",
+            query = mapOf("include_image_language" to includeImageLanguage),
+        )
+        val artwork = TmdbLocalizedArtwork(
+            poster = images?.posters.orEmpty().selectBestLocalizedImagePath(normalizedLanguage),
+            backdrop = images?.backdrops.orEmpty().selectBestLocalizedImagePath(normalizedLanguage),
+        )
+        localizedArtworkCache[cacheKey] = artwork
+        artwork
+    }
+
+    /**
+     * Builds an absolute TMDB image URL for the given relative `file_path`.
+     * Exposed for callers (e.g. collection resolvers) that need to construct
+     * URLs from paths returned by [fetchLocalizedArtwork].
+     */
+    internal fun imageUrl(filePath: String?, size: String): String? = buildImageUrl(filePath, size)
 
     private suspend fun fetchPreviewArtwork(
         tmdbId: Int,
@@ -1074,24 +1125,38 @@ object TmdbMetadataService {
             query = mapOf("language" to language),
         ) ?: return null to emptyList()
 
-        val items = response.parts
+        val sortedParts = response.parts
             .sortedBy { it.releaseDate ?: "9999" }
-            .mapNotNull { part ->
-                val title = part.title?.trim()?.takeIf(String::isNotBlank) ?: return@mapNotNull null
-                MetaPreview(
-                    id = "tmdb:${part.id}",
-                    type = "movie",
-                    name = title,
-                    poster = buildImageUrl(part.backdropPath, "w780")
-                        ?: buildImageUrl(part.posterPath, "w500"),
-                    banner = buildImageUrl(part.backdropPath, "w1280"),
-                    posterShape = PosterShape.Landscape,
-                    description = part.overview?.trim()?.takeIf(String::isNotBlank),
-                    releaseInfo = part.releaseDate?.take(4),
-                    rawReleaseDate = part.releaseDate,
-                    imdbRating = part.voteAverage?.formatRating(),
-                )
-            }
+        val items = coroutineScope {
+            sortedParts.map { part ->
+                async {
+                    val title = part.title?.trim()?.takeIf(String::isNotBlank) ?: return@async null
+                    val localized = fetchLocalizedArtwork(
+                        tmdbId = part.id,
+                        mediaType = "movie",
+                        language = language,
+                    )
+                    val poster = buildImageUrl(localized.backdrop, "w780")
+                        ?: buildImageUrl(part.backdropPath, "w780")
+                        ?: buildImageUrl(localized.poster, "w500")
+                        ?: buildImageUrl(part.posterPath, "w500")
+                    val banner = buildImageUrl(localized.backdrop, "w1280")
+                        ?: buildImageUrl(part.backdropPath, "w1280")
+                    MetaPreview(
+                        id = "tmdb:${part.id}",
+                        type = "movie",
+                        name = title,
+                        poster = poster,
+                        banner = banner,
+                        posterShape = PosterShape.Landscape,
+                        description = part.overview?.trim()?.takeIf(String::isNotBlank),
+                        releaseInfo = part.releaseDate?.take(4),
+                        rawReleaseDate = part.releaseDate,
+                        imdbRating = part.voteAverage?.formatRating(),
+                    )
+                }
+            }.awaitAll().filterNotNull()
+        }
 
         val result = response.name?.trim()?.takeIf(String::isNotBlank) to items
         collectionCache[cacheKey] = result
@@ -1606,6 +1671,13 @@ private data class TmdbCrewMember(
 @Serializable
 private data class TmdbImagesResponse(
     val logos: List<TmdbImage> = emptyList(),
+    val posters: List<TmdbImage> = emptyList(),
+    val backdrops: List<TmdbImage> = emptyList(),
+)
+
+internal data class TmdbLocalizedArtwork(
+    val poster: String?,
+    val backdrop: String?,
 )
 
 @Serializable


### PR DESCRIPTION
## Summary

TMDB's `collection/{id}?language=fr` endpoint returns one default `poster_path` / `backdrop_path` per part — almost always the English-favored asset regardless of the `language` query param. The only way to actually get artwork in the user's language is to call `/movie/{id}/images?include_image_language=fr,null,en` separately and pick the best localized poster/backdrop. This PR wires that up for both consumers that read collection parts (Collection-folder rows on home + the Saga row on movie detail pages).

### Symptom

A user with TMDB language set to `fr` who creates a Collection folder ("Star Wars Saga", "Marvel", etc.) on the home screen sees English posters for every movie inside, even though all the localized assets exist on TMDB. Same on the Saga row of movie detail pages.

### Fix

- Extends `TmdbImagesResponse` to also deserialize `posters` and `backdrops` (only `logos` was wired before).
- Adds shared helper `TmdbMetadataService.fetchLocalizedArtwork(tmdbId, mediaType, language)` ranked through the existing `selectBestLocalizedImagePath`. Cached per `(tmdbId, mediaType, language)` so each collection only pays the cost once.
- For English locales the helper returns empty paths immediately — the default `posterPath` is already English-favored, no extra request needed.
- Both consumers fan out one parallel `/images` call per part via `coroutineScope { ...async { ... }.awaitAll() }`, falling back to `part.posterPath` / `part.backdropPath` if no localized image is available.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Without this fix, FR/ES/PT users (and any non-English locale) see English posters and backdrops for every movie in a Collection folder or in the Saga row of a film, even though they explicitly configured TMDB language to their own language. The localized assets exist on TMDB; we just weren't asking for them. Reproduced on every FR-language test device with the Star Wars / Marvel collection rows.

## Issue or approval

Approved in NuvioTV PR #1772 — NuvioTV already ships this exact `/images?include_image_language=…` approach for collection part artwork. This PR ports the same data-quality fix to NuvioMobile so the two apps render identical artwork.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to: one new internal helper in `TmdbMetadataService` (`fetchLocalizedArtwork`, `TmdbLocalizedArtwork`, `localizedArtworkCache`), an extension of `TmdbImagesResponse` to deserialize `posters`/`backdrops`, and the two call-site updates (`TmdbCollectionSourceResolver.resolveCollection`, `TmdbMetadataService.fetchCollection`). No other TMDB endpoint or screen touched.

## Testing

- Built locally; the cache key `(tmdbId, mediaType, language)` ensures the extra `/images` calls only happen once per (movie, language) pair, then are served from `localizedArtworkCache`.
- Early return for English locales — TMDB's default `poster_path` is already English-favored, no extra request issued.
- Each part's localized fetch is fired in parallel via `coroutineScope { ...async { ... }.awaitAll() }`, so wall-clock time for a 30-part collection is ~one HTTP round-trip.
- Fallback chain preserved: `localized.poster → part.posterPath → localized.backdrop → part.backdropPath`.
- Code paths exercised: Home → Collection folder ("Star Wars Saga", "Marvel", "Disney") — French/Spanish poster art renders. Movie detail → "Belongs to collection" row — same.

## Screenshots / Video

Before: collection-folder rows show English posters even with TMDB language set to `fr`. After: the same rows show French / Spanish / Portuguese posters when the localized asset exists on TMDB, and fall back to the default poster otherwise. Visual proof matches the NuvioTV #1772 before/after captured during that PR's review.

## Breaking changes

None. Pure data-quality fix; no public API change.

## Linked issues

Approved in NuvioTV PR #1772.
