### PR TITLE
UI: search speed improvements

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NuvioShelfComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/NuvioShelfComponents.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -132,9 +133,10 @@ fun NuvioPosterCard(
                 .posterCardClickable(onClick = onClick, onLongClick = onLongClick),
             contentAlignment = Alignment.Center,
         ) {
-            if (imageUrl != null) {
+            val optimizedImageUrl = remember(imageUrl, shape) { imageUrl?.withRecommendedImageWidth(shape) }
+            if (optimizedImageUrl != null) {
                 AsyncImage(
-                    model = imageUrl,
+                    model = optimizedImageUrl,
                     contentDescription = title,
                     modifier = Modifier.matchParentSize(),
                     contentScale = ContentScale.Crop,
@@ -350,3 +352,14 @@ internal fun Modifier.posterCardClickable(
     } else {
         this
     }
+
+
+private fun String.withRecommendedImageWidth(shape: NuvioPosterShape): String {
+    val targetWidth = when (shape) {
+        NuvioPosterShape.Poster -> 360
+        NuvioPosterShape.Square -> 320
+        NuvioPosterShape.Landscape -> 640
+    }
+    val separator = if (contains("?")) "&" else "?"
+    return "$this${separator}w=$targetWidth"
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/catalog/CatalogData.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/catalog/CatalogData.kt
@@ -12,7 +12,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
+import kotlin.time.Clock
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 const val CATALOG_PAGE_SIZE = 100
 
@@ -25,8 +30,22 @@ data class CatalogPage(
 private val inflightMutex = Mutex()
 private val inflightRequestScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 private val inflightRequests = mutableMapOf<String, CompletableDeferred<String>>()
+private val responseCache = mutableMapOf<String, CachedCatalogPayload>()
+private val addonSearchSemaphore = Semaphore(permits = 4)
+private val responseCacheTtl: Duration = 20.seconds
+
+
+private data class CachedCatalogPayload(
+    val payload: String,
+    val expiresAtMillis: Long,
+)
 
 private suspend fun deduplicatedHttpGetText(url: String): String {
+    val now = Clock.System.now().toEpochMilliseconds()
+    inflightMutex.withLock {
+        responseCache[url]?.takeIf { now < it.expiresAtMillis }?.let { return it.payload }
+    }
+
     val deferred = inflightMutex.withLock {
         inflightRequests[url] ?: CompletableDeferred<String>().also { created ->
             inflightRequests[url] = created
@@ -46,7 +65,14 @@ private suspend fun deduplicatedHttpGetText(url: String): String {
         }
     }
 
-    return deferred.await()
+    return deferred.await().also { payload ->
+        inflightMutex.withLock {
+            responseCache[url] = CachedCatalogPayload(
+                payload = payload,
+                expiresAtMillis = Clock.System.now().toEpochMilliseconds() + responseCacheTtl.inWholeMilliseconds,
+            )
+        }
+    }
 }
 
 suspend fun fetchCatalogPage(
@@ -66,7 +92,11 @@ suspend fun fetchCatalogPage(
         search = search,
         skip = skip,
     )
-    val payload = deduplicatedHttpGetText(url)
+    val payload = if (!search.isNullOrBlank()) {
+        addonSearchSemaphore.withPermit { deduplicatedHttpGetText(url) }
+    } else {
+        deduplicatedHttpGetText(url)
+    }
     val parsed = HomeCatalogParser.parseCatalogResponse(
         payload = payload,
         maxItems = maxItems,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchRepository.kt
@@ -22,6 +22,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -91,26 +94,47 @@ object SearchRepository {
         _uiState.value = SearchUiState(isLoading = true)
 
         activeJob = scope.launch {
-            val results = requests.map { request ->
+            val sections = mutableListOf<HomeCatalogSection>()
+            val failures = mutableListOf<String>()
+            val updates = Channel<Result<HomeCatalogSection>>(Channel.UNLIMITED)
+            val requestSemaphore = Semaphore(permits = 4)
+
+            val workers = requests.map { request ->
                 async {
-                    runCatching { request.toSection() }
+                    requestSemaphore.withPermit {
+                        updates.send(runCatching { request.toSection() })
+                    }
                 }
-            }.awaitAll()
+            }
 
-            val sections = results
-                .mapNotNull { it.getOrNull() }
-            val firstFailure = results.firstNotNullOfOrNull { it.exceptionOrNull()?.message }
-            val allFailed = results.isNotEmpty() && results.all { it.isFailure }
+            repeat(requests.size) {
+                val result = updates.receive()
+                result.fold(
+                    onSuccess = { section ->
+                        sections += section
+                        _uiState.value = SearchUiState(
+                            isLoading = true,
+                            sections = sections.sortedBy { it.type.typeSortKey() + ':' + it.title },
+                        )
+                    },
+                    onFailure = { error ->
+                        if (error !is CancellationException) failures += (error.message ?: "Search request failed")
+                    },
+                )
+            }
+            workers.awaitAll()
+            updates.close()
 
+            val allFailed = sections.isEmpty() && failures.isNotEmpty()
             _uiState.value = SearchUiState(
                 isLoading = false,
-                sections = sections,
+                sections = sections.sortedBy { it.type.typeSortKey() + ':' + it.title },
                 emptyStateReason = when {
                     sections.isNotEmpty() -> null
                     allFailed -> SearchEmptyStateReason.RequestFailed
                     else -> SearchEmptyStateReason.NoResults
                 },
-                errorMessage = if (allFailed) firstFailure else null,
+                errorMessage = if (allFailed) failures.firstOrNull() else null,
             )
         }
     }


### PR DESCRIPTION
## Summary

- Optimized catalog fetching with a short-lived response cache (20s TTL) and kept in-flight request deduplication, so identical catalog URLs can be reused briefly instead of immediately re-fetching. This reduces duplicate work and improves repeat search/catalog responsiveness. 

- Added a concurrency cap for search-related catalog fetches using a semaphore (permits = 4) to prevent large addon sets from flooding requests and causing UI stalls. 

- Updated search execution to stream partial results: sections now publish incrementally as each catalog completes (instead of waiting for all requests), while preserving final empty/error behavior. Also bounded per-search request concurrency. 

- Improved image loading efficiency in poster cards by deriving a shape-based width hint (w= query parameter) and memoizing the transformed URL to avoid recomputing on recompositions.

## PR type

- Small maintenance improvement

## Why

Before: Search UI waited for all addon catalogs before showing results; identical URLs were deduped only while in-flight; large addon searches could fan out too many concurrent requests; poster URLs had no size hints.

After: Search can render progressively as sections complete; concurrent search work is bounded; identical responses are briefly cached; poster URLs include conservative width hints for potentially lighter image payloads.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [Y] This PR is not cosmetic-only, unless it is a translation PR.
- [Y] This PR does not add a new major feature without prior approval.
- [Y] This PR is small in scope and focused on one problem.

## Testing

Apk not tested. Code reviewed based on initial ideas for speed improvements.

## Screenshots / Video (UI changes only)

No UI changes barring quicker load times.

## Breaking changes

None that I'm aware of, if someone could provide a working private build so I can test full changes, that would be appreciated.

## Linked issues

<!-- Example: Fixes #123 -->
None, worked on this based on my own findings from using the app