### PR TITLE
fix(i18n): correct doubled '%' in FR download progress

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -720,7 +720,7 @@
     <string name="settings_playback_threshold_mode_percentage">Pourcentage</string>
     <string name="settings_playback_threshold_percentage">Pourcentage de seuil</string>
     <string name="settings_playback_threshold_percentage_description">Afficher la carte de l'épisode suivant lorsque la lecture atteint ce pourcentage.</string>
-    <string name="settings_playback_threshold_percentage_value">%1$s%</string>
+    <string name="settings_playback_threshold_percentage_value">%1$s %</string>
     <string name="settings_playback_timeout_instant">Instantané</string>
     <string name="settings_playback_timeout_seconds">%1$ss</string>
     <string name="settings_playback_timeout_unlimited">Illimité</string>
@@ -1017,7 +1017,7 @@
     <string name="streams_no_direct_link">Aucun lien direct du stream disponible</string>
     <string name="streams_no_metadata">Aucune métadonnée disponible</string>
     <string name="streams_refresh">Actualiser les streams</string>
-    <string name="streams_resume_from_percent">Reprendre depuis %1$d%</string>
+    <string name="streams_resume_from_percent">Reprendre depuis %1$d %</string>
     <string name="streams_resume_from_time">Reprendre depuis %1$s</string>
     <string name="streams_size">TAILLE %1$s</string>
     <string name="trailer_close">Fermer la bande-annonce</string>
@@ -1027,7 +1027,7 @@
     <string name="updates_asset_line">%1$s • %2$s</string>
     <string name="updates_check_failed">Échec de la vérification des mises à jour</string>
     <string name="updates_download_failed">Échec du téléchargement</string>
-    <string name="updates_downloading_progress">Téléchargement %1$d%%</string>
+    <string name="updates_downloading_progress">Téléchargement %1$d %</string>
     <string name="updates_install_failed">Impossible de démarrer l'installation</string>
     <string name="updates_latest_version">Vous utilisez la version la plus récente.</string>
     <string name="updates_message_allow_installs">Activez l'installation d'applications pour Nuvio puis revenez pour continuer.</string>


### PR DESCRIPTION
## Summary

The FR translation of `updates_downloading_progress` stored `Téléchargement %1\$d%%`. Compose Multiplatform Resources does **not** interpret `%%` as an escape — `getString(Res.string.xxx, arg)` substitutes positional placeholders (`%1\$d`, `%1\$s`, …) and leaves every other character literal. As a result, the user sees:

```
Téléchargement 26%%
```

instead of `Téléchargement 26 %` when an update is downloading.

This PR replaces the doubled `%%` with a single `%` preceded by a non-breaking space (U+00A0), to match the French typographic convention `26 %` (vs. English `26%`).

Same NBSP-before-`%` correction applied to two neighbouring FR keys for consistency (they did not have the doubled bug but were rendering as `26%` without the NBSP):

- `streams_resume_from_percent`: `Reprendre depuis %1\$d%` → `Reprendre depuis %1\$d %`
- `settings_playback_threshold_percentage_value`: `%1\$s%` → `%1\$s %`

EN strings stay untouched: `Downloading %1\$d%`, `Resume from %1\$d%`, `%1\$s%` — English convention has no space before `%`.

## Why

Live regression seen in the app: a user on FR locale starting an update download sees `Téléchargement 26%%` in the in-app toast / dialog while the APK downloads. The doubled `%` is the only visible symptom, but it indicates a misuse of the Android `%%` escape inside a Compose MP resource — `%%` is not an escape in this runtime.

The companion NBSP additions follow the existing French typography rules already applied across this `values-fr/strings.xml` (NBSP before `:` `;` `?` `!` `»`, French guillemets `« »`).

## Testing

- `xmllint --noout` on `values-fr/strings.xml` — well-formed.
- Verified the 3 NBSP characters (U+00A0) are physically present before `%` in the file:
  `python -c 'data = open(\"…/values-fr/strings.xml\",\"rb\").read(); print(data.count(b\"\\xc2\\xa0%\"))'` → `3`.
- No source code change; pure resource diff. No public API change.

## Breaking changes

None. Resource-only fix.

## Linked issues

None.