### PR TITLE
Plugin configuration support

### DIFF
--- a/composeApp/src/androidFull/kotlin/com/nuvio/app/features/plugins/PluginPlatform.android.kt
+++ b/composeApp/src/androidFull/kotlin/com/nuvio/app/features/plugins/PluginPlatform.android.kt
@@ -2,11 +2,15 @@ package com.nuvio.app.features.plugins
 
 import android.content.Context
 import android.content.SharedPreferences
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 internal object PluginStorage {
     private const val preferencesName = "nuvio_plugins"
     private const val pluginsStateKey = "plugins_state"
+    private const val pluginConfigKey = "plugin_config"
 
+    private val json = Json { ignoreUnknownKeys = true }
     private var preferences: SharedPreferences? = null
 
     fun initialize(context: Context) {
@@ -20,6 +24,23 @@ internal object PluginStorage {
         preferences
             ?.edit()
             ?.putString("${pluginsStateKey}_$profileId", payload)
+            ?.apply()
+    }
+
+    fun loadConfig(manifestUrl: String): Map<String, String> {
+        val key = "${pluginConfigKey}_${manifestUrl.hashCode()}"
+        val raw = preferences?.getString(key, null)?.trim().orEmpty()
+        if (raw.isBlank()) return emptyMap()
+        return runCatching {
+            json.decodeFromString<Map<String, String>>(raw)
+        }.getOrDefault(emptyMap())
+    }
+
+    fun saveConfig(manifestUrl: String, values: Map<String, String>) {
+        val key = "${pluginConfigKey}_${manifestUrl.hashCode()}"
+        preferences
+            ?.edit()
+            ?.putString(key, json.encodeToString(values))
             ?.apply()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/plugins/PluginModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/plugins/PluginModels.kt
@@ -4,11 +4,22 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class PluginConfigField(
+    val key: String,
+    val label: String,
+    val description: String? = null,
+    val type: String = "text",
+    val required: Boolean = false,
+    val default: String? = null,
+)
+
+@Serializable
 data class PluginManifest(
     val name: String,
     val version: String,
     val description: String? = null,
     val author: String? = null,
+    val settings: List<PluginConfigField> = emptyList(),
     val scrapers: List<PluginManifestScraper> = emptyList(),
 )
 
@@ -40,6 +51,7 @@ data class PluginRepositoryItem(
     val lastUpdated: Long = 0L,
     val isRefreshing: Boolean = false,
     val errorMessage: String? = null,
+    val settings: List<PluginConfigField> = emptyList(),
 )
 
 data class PluginScraper(
@@ -106,6 +118,7 @@ internal data class StoredPluginRepository(
     val version: String? = null,
     val scraperCount: Int = 0,
     val lastUpdated: Long = 0L,
+    val settings: List<PluginConfigField> = emptyList(),
 )
 
 @Serializable

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
@@ -319,6 +319,7 @@ actual object PluginRepository {
             tmdbId = tmdbId,
             mediaType = mediaType,
         )
+        val userSettings = PluginStorage.loadConfig(scraper.repositoryUrl)
 
         return runCatching {
             PluginRuntime.executePlugin(
@@ -328,7 +329,7 @@ actual object PluginRepository {
                 season = season,
                 episode = episode,
                 scraperId = scraper.id,
-                scraperSettings = emptyMap(),
+                scraperSettings = userSettings,
             )
         }
     }
@@ -399,6 +400,7 @@ actual object PluginRepository {
             lastUpdated = currentEpochMillis(),
             isRefreshing = false,
             errorMessage = null,
+            settings = manifest.settings,
         )
         repo to scrapers
     }
@@ -462,6 +464,7 @@ actual object PluginRepository {
                     version = repo.version,
                     scraperCount = repo.scraperCount,
                     lastUpdated = repo.lastUpdated,
+                    settings = repo.settings,
                 )
             },
             scrapers = state.scrapers.map { scraper ->
@@ -527,6 +530,7 @@ actual object PluginRepository {
                         lastUpdated = it.lastUpdated,
                         isRefreshing = false,
                         errorMessage = null,
+                        settings = it.settings,
                     )
                 }
                 ?: emptyList(),

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginsSettingsScreen.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginsSettingsScreen.kt
@@ -12,11 +12,17 @@ import androidx.compose.material.icons.rounded.Bolt
 import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material.icons.rounded.Extension
 import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Settings
+import androidx.compose.material.icons.rounded.Visibility
+import androidx.compose.material.icons.rounded.VisibilityOff
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -29,6 +35,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -63,6 +71,8 @@ fun PluginsSettingsPageContent(
     var testingScraperId by remember { mutableStateOf<String?>(null) }
     val testResults = remember { mutableStateMapOf<String, List<PluginRuntimeResult>>() }
 
+    var configuringRepo by remember { mutableStateOf<PluginRepositoryItem?>(null) }
+
     val sortedRepos = remember(uiState.repositories) {
         uiState.repositories.sortedBy { it.name.lowercase() }
     }
@@ -76,6 +86,17 @@ fun PluginsSettingsPageContent(
                 { repositoryNameByUrl[it.repositoryUrl]?.lowercase() ?: it.repositoryUrl.lowercase() },
                 { it.name.lowercase() },
             ),
+        )
+    }
+
+    configuringRepo?.let { repo ->
+        PluginConfigDialog(
+            repo = repo,
+            onDismiss = { configuringRepo = null },
+            onSave = { values ->
+                PluginStorage.saveConfig(repo.manifestUrl, values)
+                configuringRepo = null
+            },
         )
     }
 
@@ -257,6 +278,14 @@ fun PluginsSettingsPageContent(
                             )
                         }
                         Row(verticalAlignment = Alignment.CenterVertically) {
+                            if (repo.settings.isNotEmpty()) {
+                                NuvioIconActionButton(
+                                    icon = Icons.Rounded.Settings,
+                                    contentDescription = "Configure plugin repository",
+                                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    onClick = { configuringRepo = repo },
+                                )
+                            }
                             NuvioIconActionButton(
                                 icon = Icons.Rounded.Refresh,
                                 contentDescription = "Refresh plugin repository",
@@ -277,6 +306,9 @@ fun PluginsSettingsPageContent(
                         horizontalArrangement = Arrangement.spacedBy(10.dp),
                     ) {
                         NuvioInfoBadge(text = "${repo.scraperCount} providers")
+                        if (repo.settings.isNotEmpty()) {
+                            NuvioInfoBadge(text = "Configurable")
+                        }
                         if (repo.isRefreshing) {
                             NuvioInfoBadge(text = "Refreshing")
                         }
@@ -439,6 +471,101 @@ fun PluginsSettingsPageContent(
             }
         }
     }
+}
+
+@Composable
+private fun PluginConfigDialog(
+    repo: PluginRepositoryItem,
+    onDismiss: () -> Unit,
+    onSave: (Map<String, String>) -> Unit,
+) {
+    val savedValues = remember(repo.manifestUrl) {
+        PluginStorage.loadConfig(repo.manifestUrl)
+    }
+    val fieldValues = remember(repo.manifestUrl) {
+        mutableStateMapOf<String, String>().apply {
+            repo.settings.forEach { field ->
+                put(field.key, savedValues[field.key] ?: field.default.orEmpty())
+            }
+        }
+    }
+    val passwordVisibility = remember(repo.manifestUrl) {
+        mutableStateMapOf<String, Boolean>().apply {
+            repo.settings.forEach { field -> put(field.key, false) }
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(
+                text = "${repo.name} — Settings",
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onSurface,
+            )
+        },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                repo.settings.forEach { field ->
+                    val isPassword = field.type == "password"
+                    val isVisible = passwordVisibility[field.key] == true
+                    Column {
+                        Text(
+                            text = field.label,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = MaterialTheme.colorScheme.onSurface,
+                        )
+                        field.description?.let { desc ->
+                            Spacer(modifier = Modifier.height(2.dp))
+                            Text(
+                                text = desc,
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                        }
+                        Spacer(modifier = Modifier.height(6.dp))
+                        NuvioInputField(
+                            value = fieldValues[field.key].orEmpty(),
+                            onValueChange = { fieldValues[field.key] = it },
+                            placeholder = field.label,
+                            trailingContent = if (isPassword) {
+                                {
+                                    IconButton(onClick = {
+                                        passwordVisibility[field.key] = !isVisible
+                                    }) {
+                                        Icon(
+                                            imageVector = if (isVisible) Icons.Rounded.VisibilityOff else Icons.Rounded.Visibility,
+                                            contentDescription = if (isVisible) "Hide" else "Show",
+                                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        )
+                                    }
+                                }
+                            } else null,
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onSave(fieldValues.toMap()) }) {
+                Text(
+                    text = "Save",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(
+                    text = "Cancel",
+                    style = MaterialTheme.typography.labelLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.surface,
+    )
 }
 
 private fun String.fallbackRepositoryLabel(): String {

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginsSettingsScreen.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginsSettingsScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import com.nuvio.app.core.ui.NuvioIconActionButton
 import com.nuvio.app.core.ui.NuvioInfoBadge
 import com.nuvio.app.core.ui.NuvioInputField
@@ -505,7 +507,10 @@ private fun PluginConfigDialog(
             )
         },
         text = {
-            Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            val scrollState = rememberScrollState()
+            Column(
+                modifier = Modifier.verticalScroll(scrollState),    
+                verticalArrangement = Arrangement.spacedBy(16.dp)) {
                 repo.settings.forEach { field ->
                     val isPassword = field.type == "password"
                     val isVisible = passwordVisibility[field.key] == true

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginsSettingsScreen.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginsSettingsScreen.kt
@@ -15,11 +15,16 @@ import androidx.compose.material.icons.rounded.Refresh
 import androidx.compose.material.icons.rounded.Settings
 import androidx.compose.material.icons.rounded.Visibility
 import androidx.compose.material.icons.rounded.VisibilityOff
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -40,8 +45,6 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import com.nuvio.app.core.ui.NuvioIconActionButton
 import com.nuvio.app.core.ui.NuvioInfoBadge
 import com.nuvio.app.core.ui.NuvioInputField
@@ -509,8 +512,9 @@ private fun PluginConfigDialog(
         text = {
             val scrollState = rememberScrollState()
             Column(
-                modifier = Modifier.verticalScroll(scrollState),    
-                verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                modifier = Modifier.verticalScroll(scrollState),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
                 repo.settings.forEach { field ->
                     val isPassword = field.type == "password"
                     val isVisible = passwordVisibility[field.key] == true
@@ -529,12 +533,25 @@ private fun PluginConfigDialog(
                             )
                         }
                         Spacer(modifier = Modifier.height(6.dp))
-                        NuvioInputField(
-                            value = fieldValues[field.key].orEmpty(),
-                            onValueChange = { fieldValues[field.key] = it },
-                            placeholder = field.label,
-                            trailingContent = if (isPassword) {
-                                {
+                        if (isPassword) {
+                            OutlinedTextField(
+                                value = fieldValues[field.key].orEmpty(),
+                                onValueChange = { fieldValues[field.key] = it },
+                                modifier = Modifier.fillMaxWidth(),
+                                singleLine = true,
+                                shape = RoundedCornerShape(14.dp),
+                                placeholder = {
+                                    Text(
+                                        text = field.label,
+                                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        style = MaterialTheme.typography.bodyLarge,
+                                    )
+                                },
+                                textStyle = MaterialTheme.typography.bodyLarge.copy(
+                                    color = MaterialTheme.colorScheme.onSurface,
+                                ),
+                                visualTransformation = if (isVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                                trailingIcon = {
                                     IconButton(onClick = {
                                         passwordVisibility[field.key] = !isVisible
                                     }) {
@@ -544,9 +561,22 @@ private fun PluginConfigDialog(
                                             tint = MaterialTheme.colorScheme.onSurfaceVariant,
                                         )
                                     }
-                                }
-                            } else null,
-                        )
+                                },
+                                colors = OutlinedTextFieldDefaults.colors(
+                                    focusedBorderColor = MaterialTheme.colorScheme.outline,
+                                    unfocusedBorderColor = MaterialTheme.colorScheme.outline,
+                                    focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                    unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant,
+                                    cursorColor = MaterialTheme.colorScheme.primary,
+                                ),
+                            )
+                        } else {
+                            NuvioInputField(
+                                value = fieldValues[field.key].orEmpty(),
+                                onValueChange = { fieldValues[field.key] = it },
+                                placeholder = field.label,
+                            )
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

- I've added support for custom plugin configuration. Plugin developers can now add a new settings key to the manifest.json file, which will contain an array of objects with the following 5 properties:
  1: "key": "api_token",     <--- Main identifier of the key 
  2: "label": "API Key",   <--- Label shown to user
  3: "description": "Find it at torbox.app/settings",  <--- Optional description
  4: "type": "password", <--- Key type. Can be "text" or "password"
  5: "required": false 

- These keys will be available in the plugin context by using something like
`globalThis.SCRAPER_SETTINGS.api_token` <-- Main identifier of the key

- There is no limit to how many settings keys can be used. The custom dialog already features a scrollable component to ensure proper visibility and accessibility.

- On plugin installation, the app will detect the new 'settings' key and will add a gear button next to refresh plugin button.

- Gear button will open a dialog showing a text input for all the keys

- Users can paste the keys and save them locally

## PR type
 
- Small maintenance improvement

## Why

- Giving users the ability to add secret keys can increase the number of potential new plugins:

1) Debrid-based plugins (with public and custom Jackett support)
2) Plugins for Cloudflare-blocked websites (a custom proxy can be added and used to proxy requests, bypassing this limit)
3) language filtering for multi-language plugins

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

## Approved feature request (required for large/non-trivial PRs)

- As already mentioned, original code is almost the same ( no breaking changes ) 

## Testing

- After successfully compiled the app, i've tried testing what i've added. Here's the results:
1) Keys saved persist during app restarts.
2) Keys are correctly passed inside scraper during stream fetching ( as no scraper has implemented this new feature i simply tested by adding a console.warn(globalThis.SCRAPER_SETTINGS.api_token) to ensure the key is visible and indeed it is)
3) No error or warning logs regarding this new feature are shown in edge cases (e.g., a missing required key).

## Screenshots / Video (UI changes only)

- https://i.imgur.com/amKqi7E.png <-- Shows the new button
- https://i.imgur.com/pMk6zeO.png <-- Shows how the new dialog is rendered (note that password-type fields are correctly masked as ****) 
- https://i.imgur.com/BETeSbj.png <-- Shows what the new manifest looks like

## Breaking changes

This feature adds 150+ lines of code, editing only a single pre-existing line from `scraperSettings = emptyMap()` to `scraperSettings = userSettings` in the file PluginRepository.kt at `composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins` . Therefore, no breaking changes are to be expected (the settings button won't appear for malformed or incomplete manifests). Null/empty strings must be handled within the plugin context .

## Linked issues

Implements feature request in #956 (https://github.com/NuvioMedia/NuvioMobile/issues/956)

Debug Build is available for testing at : https://buzzheavier.com/myqtyjfzdeng
The following plugin can be used to see new UI Changes : https://raw.githubusercontent.com/albyalex96/EasyStreams/refs/heads/dev-2/manifest.json . Keys won't be used by the plugin .
Final message: Tap please approve this 😆 