### PR TITLE
fix: hide IMDb 0.0 rating on unreleased content

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailMetaInfo.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailMetaInfo.kt
@@ -80,10 +80,12 @@ fun DetailMetaInfo(
         val runtimeText = formatRuntimeForDisplay(meta.runtime)
         val ageBadge = meta.ageRating?.trim()?.takeIf { it.isNotBlank() }
         val hasMdbImdbRating = meta.externalRatings.any { it.source == PROVIDER_IMDB }
+        val validImdbRating = meta.imdbRating
+            ?.takeIf { raw -> raw.toDoubleOrNull()?.let { it > 0.0 } == true }
         val hasMetaRow = releaseLine != null ||
             runtimeText != null ||
             ageBadge != null ||
-            (meta.imdbRating != null && !hasMdbImdbRating)
+            (validImdbRating != null && !hasMdbImdbRating)
         if (hasMetaRow) {
             Row(
                 verticalAlignment = Alignment.CenterVertically,
@@ -108,7 +110,7 @@ fun DetailMetaInfo(
                 ageBadge?.let { badge ->
                     DetailHeroMetaBadge(text = badge)
                 }
-                if (meta.imdbRating != null && !hasMdbImdbRating) {
+                if (validImdbRating != null && !hasMdbImdbRating) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
@@ -129,7 +131,7 @@ fun DetailMetaInfo(
                         }
                         Spacer(modifier = Modifier.width(5.dp))
                         Text(
-                            text = meta.imdbRating,
+                            text = validImdbRating,
                             style = MaterialTheme.typography.titleMedium,
                             color = ImdbYellow,
                             fontWeight = FontWeight.Bold,


### PR DESCRIPTION
## Summary

Hide IMDb rating badge when API returns "0" or "0.0" for unreleased content (Wildwood).

## PR type

- Bug fix

## Why

Unreleased movies return `imdbRating: "0"` from the API. The existing null check lets this through, displaying a misleading "0.0" IMDb badge.

## Policy check

- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the approved feature request issue below.

## Testing
I am not able to test but the code looks correct to me and this is a pretty small change anyways.

## Breaking changes

None

## Linked issues

Fixes #1046