### PR TITLE
fix: back button on profile screens closes app instead of navigating back

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -467,6 +467,11 @@ fun App() {
                     AuthScreen(modifier = Modifier.fillMaxSize())
                 }
                 AppGateScreen.ProfileSelection.name -> {
+                    PlatformBackHandler(enabled = gateScreen == AppGateScreen.ProfileSelection.name) {
+                        if (!autoSkipProfileSelection) {
+                            gateScreen = AppGateScreen.Main.name
+                        }
+                    }
                     ProfileSelectionScreen(
                         onProfileSelected = { profile ->
                             ProfileRepository.selectProfile(profile.profileIndex)
@@ -489,6 +494,9 @@ fun App() {
                     )
                 }
                 AppGateScreen.ProfileEdit.name -> {
+                    PlatformBackHandler(enabled = gateScreen == AppGateScreen.ProfileEdit.name) {
+                        gateScreen = AppGateScreen.ProfileSelection.name
+                    }
                     ProfileEditScreen(
                         profile = editingProfile,
                         onBack = { gateScreen = AppGateScreen.ProfileSelection.name },


### PR DESCRIPTION
## Summary
I updated the back button logic in App.kt for the profile screens. Now the system back button correctly navigates to the previous screen state instead of closing the app.

## PR type
- Bug fix

## Why
This makes the navigation more consistent with the rest of the app.

## Policy check
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the approved feature request issue below.

## Testing
I am not able to test it but the code looks correct to me so I will assume all is good.

## Screenshots / Video (UI changes only)
N/A

## Breaking changes
None

## Linked issues
Fixes #1058