### PR TITLE
fix: decoder fallback when primary decoder fails

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -102,6 +102,7 @@ actual fun PlatformPlayerSurface(
     val exoPlayer = remember(sourceUrl, sourceAudioUrl, sanitizedSourceHeaders, sanitizedSourceResponseHeaders) {
         val renderersFactory = DefaultRenderersFactory(context)
             .setExtensionRendererMode(playerSettings.decoderPriority)
+            .setEnableDecoderFallback(playerSettings.decoderPriority != DefaultRenderersFactory.EXTENSION_RENDERER_MODE_OFF)
             .setMapDV7ToHevc(playerSettings.mapDV7ToHevc)
 
         val trackSelector = DefaultTrackSelector(context).apply {


### PR DESCRIPTION
## Summary
ExoPlayer can crash on unsupported formats with the error `NO_EXCEEDS_CAPABILITIES`. Instead of letting the playback fail, this allows it to first try the alternate decoder while still respecting the "Device decoder only" setting:
- Preferred hardware decoder fails > tries software decoder
- Preferred software decoder fails > tries hardware decoder

## PR type
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
It allows devices that have issues with `NO_EXCEEDS_CAPABILITIES` to effortlessly play content without forcing the user to manually change their global decoder settings.

## Issue or approval
None.

## UI / behavior impact
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
Only modifies ExoPlayer decoder initialization and fallback logic. No UI changes or changes to other playback engines.

## Testing
Code is simple enough to know it will work.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
Related to #1052, #1039, and #826