### PR TITLE
feat: show "Watch Again" on play button for watched media.

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -690,6 +690,11 @@
     <string name="settings_playback_duration_hours">%1$d hours</string>
     <string name="settings_playback_enable_libass">Use libass for ASS/SSA subtitles</string>
     <string name="settings_playback_enable_libass_description">Experimental: advanced ASS/SSA rendering (styles, positioning, animations)</string>
+    <string name="settings_playback_external_player">External Player</string>
+    <string name="settings_playback_external_player_app">External Player App</string>
+    <string name="settings_playback_external_player_description_android">Open new playback with Android&apos;s default video app or system chooser.</string>
+    <string name="settings_playback_external_player_description_ios">Open new playback with the selected installed player.</string>
+    <string name="settings_playback_external_player_none_available">No supported external players installed</string>
     <string name="settings_playback_hold_speed">Hold Speed</string>
     <string name="settings_playback_hold_to_speed">Hold To Speed</string>
     <string name="settings_playback_hold_to_speed_description">Long-press anywhere on the player surface to temporarily boost playback speed.</string>
@@ -1082,6 +1087,8 @@
     <string name="streams_checking_more_addons">Checking more addons…</string>
     <string name="streams_copy_link">Copy stream link</string>
     <string name="streams_download_file">Download file</string>
+    <string name="streams_open_external_player">Open in external player</string>
+    <string name="streams_open_internal_player">Open in internal player</string>
     <string name="streams_empty_load_failed_message">The installed stream addons failed to return a valid stream response.</string>
     <string name="streams_empty_load_failed_title">Could not load streams</string>
     <string name="streams_empty_no_addons_message">Install an addon first to load streams for this title.</string>
@@ -1102,6 +1109,9 @@
     <string name="streams_resume_from_time">Resume from %1$s</string>
     <string name="streams_size">SIZE %1$s</string>
     <string name="streams_torrent_not_supported">Torrent streams are not supported</string>
+    <string name="external_player_failed">Couldn&apos;t open external player</string>
+    <string name="external_player_not_configured">Choose an external player in settings first</string>
+    <string name="external_player_unavailable">No external player is available</string>
     <string name="trailer_close">Close trailer</string>
     <string name="trailer_unable_to_play">Unable to play trailer</string>
     <string name="trakt_lists_load_failed">Failed to load Trakt lists</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="action_next">Next</string>
     <string name="action_ok">OK</string>
     <string name="action_play">Play</string>
+    <string name="action_watch_again">Watch Again</string>
     <string name="action_previous">Previous</string>
     <string name="action_remove">Remove</string>
     <string name="action_reorder">Reorder</string>
@@ -689,11 +690,6 @@
     <string name="settings_playback_duration_hours">%1$d hours</string>
     <string name="settings_playback_enable_libass">Use libass for ASS/SSA subtitles</string>
     <string name="settings_playback_enable_libass_description">Experimental: advanced ASS/SSA rendering (styles, positioning, animations)</string>
-    <string name="settings_playback_external_player">External Player</string>
-    <string name="settings_playback_external_player_app">External Player App</string>
-    <string name="settings_playback_external_player_description_android">Open new playback with Android&apos;s default video app or system chooser.</string>
-    <string name="settings_playback_external_player_description_ios">Open new playback with the selected installed player.</string>
-    <string name="settings_playback_external_player_none_available">No supported external players installed</string>
     <string name="settings_playback_hold_speed">Hold Speed</string>
     <string name="settings_playback_hold_to_speed">Hold To Speed</string>
     <string name="settings_playback_hold_to_speed_description">Long-press anywhere on the player surface to temporarily boost playback speed.</string>
@@ -1086,8 +1082,6 @@
     <string name="streams_checking_more_addons">Checking more addons…</string>
     <string name="streams_copy_link">Copy stream link</string>
     <string name="streams_download_file">Download file</string>
-    <string name="streams_open_external_player">Open in external player</string>
-    <string name="streams_open_internal_player">Open in internal player</string>
     <string name="streams_empty_load_failed_message">The installed stream addons failed to return a valid stream response.</string>
     <string name="streams_empty_load_failed_title">Could not load streams</string>
     <string name="streams_empty_no_addons_message">Install an addon first to load streams for this title.</string>
@@ -1108,9 +1102,6 @@
     <string name="streams_resume_from_time">Resume from %1$s</string>
     <string name="streams_size">SIZE %1$s</string>
     <string name="streams_torrent_not_supported">Torrent streams are not supported</string>
-    <string name="external_player_failed">Couldn&apos;t open external player</string>
-    <string name="external_player_not_configured">Choose an external player in settings first</string>
-    <string name="external_player_unavailable">No external player is available</string>
     <string name="trailer_close">Close trailer</string>
     <string name="trailer_unable_to_play">Unable to play trailer</string>
     <string name="trakt_lists_load_failed">Failed to load Trakt lists</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -434,12 +434,21 @@ fun MetaDetailsScreen(
                 }
                 val playText = stringResource(Res.string.action_play)
                 val resumeText = stringResource(Res.string.action_resume)
-                val playButtonLabel = remember(movieProgress, seriesAction, meta.type, hasEpisodes, playText, resumeText) {
+                val watchAgainText = stringResource(Res.string.action_watch_again)
+                val isMovieWatched = remember(meta.id, meta.type, hasEpisodes, watchedUiState.watchedKeys) {
+                    meta.type != "series" && !hasEpisodes && WatchedRepository.isWatched(
+                        id = meta.id,
+                        type = meta.type,
+                    )
+                }
+                val playButtonLabel = remember(movieProgress, isMovieWatched, seriesAction, meta.type, hasEpisodes, playText, resumeText, watchAgainText) {
                     when {
                         (meta.type == "series" || hasEpisodes) && seriesAction != null ->
                             seriesAction.label
                         meta.type != "series" && !hasEpisodes && movieProgress != null ->
                             resumeText
+                        isMovieWatched ->
+                            watchAgainText
                         else -> playText
                     }
                 }


### PR DESCRIPTION
## Summary

Replace the Play button text with "Watch Again" on the detail screen when the content has already been fully watched.

## PR type

<!-- Pick one and delete the others -->

- Small maintenance improvement

## Why

When a user has already watched a movie and returns to its detail screen, the Play button still shows "Play" — giving no indication that they've seen it before. Showing "Watch Again" improves UX by acknowledging the watched state and setting the right expectation before playback.

The is a not only the improve UX but important to give info of is watched or not.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] This PR is not cosmetic-only, unless it is a translation PR.
- [x] This PR does not add a new major feature without prior approval.
- [x] This PR is small in scope and focused on one problem.
- [x] If this is a larger or directional change, I linked the **approved** feature request issue below.

> This is not larger or directional change.

## Testing

Manually marked a movie as watched via the watched toggle

- Returned to the detail screen and confirmed the Play button now shows "Watch Again"
- Confirmed "Resume" still appears correctly for in-progress (not completed) movies
- Confirmed "Play" still appears for movies never started
- Confirmed series detail screens are unaffected — episode action labels remain unchanged
- Confirmed unmarking a watched movie reverts the button back to "Play"

## Screenshots / Video (UI changes only)

## UI Changes: Before vs After

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/f27c8cba-3f87-421e-826a-0b958510c25e" width="245" alt="Before Update" /> | <img src="https://github.com/user-attachments/assets/beb3244e-fc09-437e-8e69-1701409464bf" width="242" alt="After Update" /> |


## Breaking changes

No API, schema, or config changes. playButtonLabel is a purely internal val inside MetaDetailsScreen — no composable signatures were changed and all existing call sites compile unchanged.

## Linked issues

Fixes #1038
