### PR TITLE
fix: hide status bar when locked to landscape on iPad

### DIFF
--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -370,15 +370,15 @@ final class RootComposeViewController: UIViewController, UITabBarDelegate {
     }
 
     override var childForHomeIndicatorAutoHidden: UIViewController? {
-        immersiveController(in: contentController) ?? contentController
+        OrientationLockCoordinator.shared.supportedOrientations == .landscape ? nil : (immersiveController(in: contentController) ?? contentController)
     }
 
     override var childForScreenEdgesDeferringSystemGestures: UIViewController? {
-        immersiveController(in: contentController) ?? contentController
+        OrientationLockCoordinator.shared.supportedOrientations == .landscape ? nil : (immersiveController(in: contentController) ?? contentController)
     }
 
     override var childForStatusBarHidden: UIViewController? {
-        immersiveController(in: contentController) ?? contentController
+        OrientationLockCoordinator.shared.supportedOrientations == .landscape ? nil : (immersiveController(in: contentController) ?? contentController)
     }
 
     override var prefersHomeIndicatorAutoHidden: Bool {
@@ -390,7 +390,7 @@ final class RootComposeViewController: UIViewController, UITabBarDelegate {
     }
 
     override var prefersStatusBarHidden: Bool {
-        immersiveController(in: contentController)?.prefersStatusBarHidden ?? false
+        OrientationLockCoordinator.shared.supportedOrientations == .landscape ? true : (immersiveController(in: contentController)?.prefersStatusBarHidden ?? false)
     }
 
     override var preferredStatusBarUpdateAnimation: UIStatusBarAnimation {

--- a/iosApp/iosApp/OrientationLockCoordinator.swift
+++ b/iosApp/iosApp/OrientationLockCoordinator.swift
@@ -102,7 +102,7 @@ final class OrientationLockCoordinator {
                 .compactMap { $0 as? UIWindowScene }
                 .flatMap(\.windows)
                 .forEach { window in
-                    window.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations()
+                    window.rootViewController?.setNeedsUpdateOfSupportedInterfaceOrientations(); window.rootViewController?.setNeedsStatusBarAppearanceUpdate()
                 }
         } else {
             if forceRotate {


### PR DESCRIPTION
## Summary
The code was forcing landscape orientation but never told iOS to recheck the status bar visibility. This adds the missing setNeedsStatusBarAppearanceUpdate() call and makes the root view controller hide the status bar whenever orientation is locked to landscape.


## PR type
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
It allows for people using iPads to watch content full screen without the status bar annoyingly being there.

## Issue or approval
Fixes #821 

## UI / behavior impact
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
Only touches OrientationLockCoordinator.swift and ContentView.swift. No other files or logic changed.

## Testing
I am not able to test it but logic is sound and it looks good to me

## Screenshots / Video
Not available

## Breaking changes
None.

## Linked issues
Fixes #821