### PR TITLE
fix: iOS mouse scrolling when AssistiveTouch and Perform Touch Gestures is on

### DIFF
--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -31,5 +31,7 @@
 	</array>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
iOS treats mice as fake finger touches when AssistiveTouch is on, so Compose scrolling breaks. This adds the UIApplicationSupportsIndirectInputEvents plist key so iOS sends proper pointer events instead

When AssistiveTouch and Perform Touch Gestures is enabled, iOS reports mouse/trackpad input as UITouchType.direct (same as a finger). Compose Multiplatform then turns every scroll into a tap. Setting UIApplicationSupportsIndirectInputEvents to true tells iOS to use UITouchType.indirectPointer, which lets Compose handle scrolling and dragging normally.

## PR type
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
Allows people who use these settings to use Nuvio like intended.

## Issue or approval
Fixes #1075 

## UI / behavior impact
- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
Only adds one key to iosApp/iosApp/Info.plist. No other files touched.

## Testing
I am not able to test

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
Fixes #1075