### PR TITLE
fix: ExoPlayer unpausing when leaving the app and coming back

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -81,7 +81,9 @@ actual fun PlatformPlayerSurface(
     val lifecycleOwner = LocalLifecycleOwner.current
     val latestOnSnapshot = rememberUpdatedState(onSnapshot)
     val latestOnError = rememberUpdatedState(onError)
+    val latestPlayWhenReady = rememberUpdatedState(playWhenReady)
     val coroutineScope = rememberCoroutineScope()
+    val latestPlayWhenReady = rememberUpdatedState(playWhenReady)
 
     val playerSettings = remember {
         PlayerSettingsRepository.ensureLoaded()
@@ -251,7 +253,7 @@ actual fun PlatformPlayerSurface(
         val activity = context.findActivity()
         val observer = LifecycleEventObserver { _, event ->
             when (event) {
-                Lifecycle.Event.ON_START -> exoPlayer.playWhenReady = playWhenReady
+                Lifecycle.Event.ON_START -> exoPlayer.playWhenReady = latestPlayWhenReady.value
                 Lifecycle.Event.ON_STOP -> {
                     val isInPictureInPicture =
                         Build.VERSION.SDK_INT >= Build.VERSION_CODES.N && activity?.isInPictureInPictureMode == true
@@ -271,7 +273,7 @@ actual fun PlatformPlayerSurface(
     }
 
     LaunchedEffect(exoPlayer, playWhenReady) {
-        exoPlayer.playWhenReady = playWhenReady
+        exoPlayer.playWhenReady = latestPlayWhenReady.value
         syncPlayerViewKeepScreenOn()
         latestOnSnapshot.value(exoPlayer.snapshot())
     }


### PR DESCRIPTION
## Summary
Even when you exit the application and pause the video manually, ExoPlayer picks up from where it left off upon your return. In essence, ExoPlayer forgets that you have paused it once you leave the app.

The LifecycleEventObserver was only obtaining the playWhenReady value for one time, which is at the time the effect runs. Once the event ON_START occurs, it takes that old value instead of getting the latest one.

In short, when you paused the video even before the ON_START fired, the observer would assume that you are still wanting to watch. I replaced its implementation with rememberingUpdatedState so it will obtain the live value each time the observer reads the value.

## PR type
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
It should respect when you pause.

## Issue or approval
Fixes #1080 

## UI / behavior impact
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
Only touches PlayerEngine.android.kt. Added one rememberUpdatedState line and updated the lifecycle observer to use .value. No other playback engines or UI files were touched.

## Testing
I am not able to test

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
Fixes #1080