### PR TITLE
fix: Mark as watched manually directly on long press posters(library)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryScreen.kt
@@ -21,10 +21,10 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nuvio.app.core.network.NetworkCondition
 import com.nuvio.app.core.network.NetworkStatusRepository
+import com.nuvio.app.core.ui.NuvioPosterActionSheet
 import com.nuvio.app.core.ui.NuvioScreen
 import com.nuvio.app.core.ui.NuvioNetworkOfflineCard
 import com.nuvio.app.core.ui.NuvioScreenHeader
-import com.nuvio.app.core.ui.NuvioStatusModal
 import com.nuvio.app.core.ui.NuvioToastController
 import com.nuvio.app.core.ui.NuvioViewAllPillSize
 import com.nuvio.app.core.ui.NuvioShelfSection
@@ -32,15 +32,17 @@ import com.nuvio.app.features.home.components.HomeEmptyStateCard
 import com.nuvio.app.features.home.components.HomePosterCard
 import com.nuvio.app.features.home.components.HomeSkeletonRow
 import com.nuvio.app.features.profiles.ProfileRepository
+import com.nuvio.app.features.watched.WatchedRepository
+import com.nuvio.app.features.watching.application.WatchingActions
+import com.nuvio.app.features.watching.application.WatchingState
 import kotlinx.coroutines.launch
 import nuvio.composeapp.generated.resources.*
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 
-private data class LibraryRemovalTarget(
+private data class LibraryActionTarget(
     val item: LibraryItem,
-    val listKey: String? = null,
-    val listTitle: String? = null,
+    val section: LibrarySection,
 )
 
 @Composable
@@ -54,7 +56,11 @@ fun LibraryScreen(
         LibraryRepository.uiState
     }.collectAsStateWithLifecycle()
     val networkStatusUiState by NetworkStatusRepository.uiState.collectAsStateWithLifecycle()
-    var pendingRemovalTarget by remember { mutableStateOf<LibraryRemovalTarget?>(null) }
+    val watchedUiState by remember {
+        WatchedRepository.ensureLoaded()
+        WatchedRepository.uiState
+    }.collectAsStateWithLifecycle()
+    var actionTarget by remember { mutableStateOf<LibraryActionTarget?>(null) }
     var observedOfflineState by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
     val isTraktSource = uiState.sourceMode == LibrarySourceMode.TRAKT
@@ -69,7 +75,7 @@ fun LibraryScreen(
         when (networkStatusUiState.condition) {
             NetworkCondition.NoInternet,
             NetworkCondition.ServersUnreachable,
-            -> {
+                -> {
                 observedOfflineState = true
             }
 
@@ -85,7 +91,7 @@ fun LibraryScreen(
 
             NetworkCondition.Unknown,
             NetworkCondition.Checking,
-            -> Unit
+                -> Unit
         }
     }
 
@@ -171,63 +177,62 @@ fun LibraryScreen(
             else -> {
                 librarySections(
                     sections = uiState.sections,
+                    watchedKeys = watchedUiState.watchedKeys,
                     onPosterClick = onPosterClick,
                     onSectionViewAllClick = onSectionViewAllClick,
                     onPosterLongClick = { item, section ->
-                        pendingRemovalTarget = if (isTraktSource) {
-                            LibraryRemovalTarget(
-                                item = item,
-                                listKey = section.type,
-                                listTitle = section.displayTitle,
-                            )
-                        } else {
-                            LibraryRemovalTarget(item = item)
-                        }
+                        actionTarget = LibraryActionTarget(item = item, section = section)
                     },
                 )
             }
         }
     }
 
-    NuvioStatusModal(
-        title = stringResource(Res.string.library_remove_title),
-        message = pendingRemovalTarget?.let { target ->
-            val listTitle = target.listTitle
-            if (listTitle.isNullOrBlank()) {
-                stringResource(Res.string.library_remove_message, target.item.name)
-            } else {
-                stringResource(Res.string.library_remove_from_list_message, target.item.name, listTitle)
-            }
-        }.orEmpty(),
-        isVisible = pendingRemovalTarget != null,
-        confirmText = stringResource(Res.string.library_remove_confirm),
-        dismissText = stringResource(Res.string.action_cancel),
-        onConfirm = {
-            val target = pendingRemovalTarget
-            pendingRemovalTarget = null
-            target?.let {
-                val listKey = target.listKey
-                if (listKey.isNullOrBlank()) {
-                    LibraryRepository.remove(target.item.id)
-                } else {
+    // Action sheet — same UI as home screen poster long-press
+    val target = actionTarget
+    if (target != null) {
+        val preview = target.item.toMetaPreview()
+        NuvioPosterActionSheet(
+            item = preview,
+            isSaved = LibraryRepository.isSaved(preview.id, preview.type),
+            isWatched = WatchingState.isPosterWatched(
+                watchedKeys = watchedUiState.watchedKeys,
+                item = preview,
+            ),
+            onDismiss = { actionTarget = null },
+            onToggleLibrary = {
+                actionTarget = null
+                val libraryItem = target.item
+                if (isTraktSource) {
                     coroutineScope.launch {
                         runCatching {
-                            LibraryRepository.removeFromList(target.item, listKey)
+                            LibraryRepository.removeFromList(
+                                libraryItem,
+                                target.section.type,
+                            )
                         }.onFailure { error ->
                             NuvioToastController.show(
                                 error.message ?: getString(Res.string.trakt_lists_update_failed),
                             )
                         }
                     }
+                } else {
+                    LibraryRepository.toggleSaved(libraryItem)
                 }
-            }
-        },
-        onDismiss = { pendingRemovalTarget = null },
-    )
+            },
+            onToggleWatched = {
+                actionTarget = null
+                coroutineScope.launch {
+                    WatchingActions.togglePosterWatched(preview)
+                }
+            },
+        )
+    }
 }
 
 private fun LazyListScope.librarySections(
     sections: List<LibrarySection>,
+    watchedKeys: Set<String>,
     onPosterClick: ((LibraryItem) -> Unit)?,
     onSectionViewAllClick: ((LibrarySection) -> Unit)?,
     onPosterLongClick: (LibraryItem, LibrarySection) -> Unit,
@@ -250,8 +255,13 @@ private fun LazyListScope.librarySections(
             viewAllPillSize = NuvioViewAllPillSize.Compact,
             key = { item -> "${item.type}:${item.id}" },
         ) { item ->
+            val preview = item.toMetaPreview()
             HomePosterCard(
-                item = item.toMetaPreview(),
+                item = preview,
+                isWatched = WatchingState.isPosterWatched(
+                    watchedKeys = watchedKeys,
+                    item = preview,
+                ),
                 onClick = onPosterClick?.let { { it(item) } },
                 onLongClick = { onPosterLongClick(item, section) },
             )


### PR DESCRIPTION
## Summary

Replaced the long-press removal confirmation modal (NuvioStatusModal) on library posters with NuvioPosterActionSheet, matching the home and catalog screen behaviour. Also fixed the watched tick indicator not appearing on library posters after marking as watched.

This will give the ability to mark as watched manually in library directly.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Two bugs existed on the library screen:

1. Long-pressing a poster showed a plain confirmation dialog to remove the item, while the home and catalog screens show the full NuvioPosterActionSheet (save/unsave + mark as watched). The experience was inconsistent and the action sheet was missing entirely from the library.
2. The watched tick overlay never appeared on library posters after marking an item as watched, because WatchedRepository.ensureLoaded() was never called and isWatched was never passed to HomePosterCard.

## Issue or approval

Fixes #1082 

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

- No changes to LibraryRepository, LibraryModels, or any other file outside LibraryScreen.kt.
- No changes to NuvioPosterActionSheet itself.
- No UI polish or style changes beyond replacing the modal with the action sheet.
- Trakt list removal logic is preserved exactly; only the trigger UI changed.

## Testing

- Long-pressed a poster in local library — NuvioPosterActionSheet opens correctly with save and watched options.
- Long-pressed a poster in Trakt library — action sheet opens and removes item from the correct Trakt list on confirm.
- Marked a poster as watched from the action sheet — watched tick appeared on the poster immediately.
- Unmarked watched — tick disappeared correctly.
- Short tap on poster still navigates to detail screen.
- Verified home and catalog screen long-press behaviour is unaffected.
- Tested on Android emulator (API 34) and physical device.

## Screenshots / Video

See the image for better understanding of changes.

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/f91d51d9-8d5a-49aa-b2d5-6398cd4335e0" width="245" alt="Before Update" /> | <img src="https://github.com/user-attachments/assets/78098033-4b77-4ed2-bf25-e017d80d786c" width="242" alt="After Update" /> |




## Breaking changes

None.

## Linked issues

Fixes #1082 
