### PR TITLE
fix: prevent multiple Trakt rewatches on progress update

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watching/application/WatchingActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watching/application/WatchingActions.kt
@@ -106,7 +106,8 @@ object WatchingActions {
         )
     }
 
-    fun onProgressEntryUpdated(entry: WatchProgressEntry) {
+    fun onProgressEntryUpdated(entry: WatchProgressEntry, wasCompleted: Boolean = false) {
+        if (wasCompleted) return
         if (!entry.isCompleted) return
 
         val watchedItem = WatchedItem(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/WatchProgressRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/WatchProgressRepository.kt
@@ -342,6 +342,7 @@ object WatchProgressRepository {
         snapshot: PlayerPlaybackSnapshot,
         persist: Boolean,
     ) {
+        val wasCompleted = progressForVideo(session.videoId)?.isCompleted == true
         val positionMs = snapshot.positionMs.coerceAtLeast(0L)
         val durationMs = snapshot.durationMs.coerceAtLeast(0L)
         val isCompleted = isWatchProgressComplete(
@@ -392,7 +393,7 @@ object WatchProgressRepository {
             resolveRemoteMetadata()
         }
         pushScrobbleToServer(entry)
-        WatchingActions.onProgressEntryUpdated(entry)
+        WatchingActions.onProgressEntryUpdated(entry, wasCompleted)
     }
 
     private fun pushScrobbleToServer(entry: WatchProgressEntry) {


### PR DESCRIPTION
## Summary
Trakt was receiving duplicate history entries because `onProgressEntryUpdated` reprocessed completed videos every time progress synced. We now bail out early if the entry was already completed before this update.

Adds a `wasCompleted` check so already completed progress entries don't get readded to Trakt history on every update.

It does not break genuine rewatches. If you rewatch, it will correctly show up in Trakt.

## PR type
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
It prevents Trakt history from being polluted.

## Issue or approval
Fixes #934

## UI / behavior impact
- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries
Intentionally limited to the two files directly involved in the rewatch bug.

## Testing
I am not able to test.

## Screenshots / Video
None.

## Breaking changes
None.

## Linked issues
Fixes #934