### PR TITLE
fix: download progress throttle

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/downloads/DownloadsPlatformDownloader.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/downloads/DownloadsPlatformDownloader.android.kt
@@ -27,6 +27,9 @@ private val downloadHttpClient = OkHttpClient.Builder()
     .followSslRedirects(true)
     .build()
 
+private const val PROGRESS_MIN_INTERVAL_SECONDS = 0.5
+private const val PROGRESS_MIN_BYTE_DELTA = 512L * 1024L
+
 internal actual object DownloadsPlatformDownloader {
     private var appContext: Context? = null
 
@@ -54,6 +57,23 @@ internal actual object DownloadsPlatformDownloader {
             val downloadsDir = File(context.filesDir, "downloads").apply { mkdirs() }
             val destination = File(downloadsDir, request.destinationFileName)
             val tempFile = File(downloadsDir, "${request.destinationFileName}.part")
+
+            var lastProgressBytes = -1L
+            var lastProgressTimestampMs = 0L
+
+            fun reportProgress(downloadedBytes: Long, totalBytes: Long?) {
+                val now = System.currentTimeMillis()
+                if (lastProgressBytes >= 0L) {
+                    val byteDelta = downloadedBytes - lastProgressBytes
+                    val timeDelta = (now - lastProgressTimestampMs) / 1000.0
+                    val reachedEnd = totalBytes != null && downloadedBytes >= totalBytes
+                        return
+                    }
+                }
+                lastProgressBytes = downloadedBytes
+                lastProgressTimestampMs = now
+                onProgress(downloadedBytes, totalBytes)
+            }
 
             try {
                 var resumeFromBytes = tempFile.takeIf { it.exists() }?.length()?.coerceAtLeast(0L) ?: 0L
@@ -115,7 +135,7 @@ internal actual object DownloadsPlatformDownloader {
                         contentLength = body.contentLength().takeIf { it > 0L },
                     )
                     var downloadedBytes = startingBytes
-                    onProgress(downloadedBytes, totalBytes)
+                    reportProgress(downloadedBytes, totalBytes)
 
                     body.byteStream().use { input ->
                         FileOutputStream(tempFile, appendToTemp).use { output ->
@@ -126,7 +146,7 @@ internal actual object DownloadsPlatformDownloader {
                                 if (read <= 0) break
                                 output.write(buffer, 0, read)
                                 downloadedBytes += read.toLong()
-                                onProgress(downloadedBytes, totalBytes)
+                                reportProgress(downloadedBytes, totalBytes)
                             }
                             output.flush()
                         }


### PR DESCRIPTION
## Summary
The iOS downloader had an inverted progress throttle. It skipped updates when the byte delta was big instead of small. Once `lastProgressBytes` went positive, the guard never fired again, so every single `NSURLSession` chunk triggered `onProgress` → `mutateItem` → `persist()` → `NSUserDefaults` write + `NSNotificationCenter` post. On a fast connection that's hundreds of times per second, which could get the app killed by the iOS watchdog after several seconds and leaves downloads stuck at 0B on relaunch.

Android had the same unthrottled loop, so I added the same 512KB / 0.5s throttle there for parity. It probably won't crash on Android, but it was still wasting CPU and battery doing useless work.

This should fix #888, but I can't be 100% sure without crash logs. Either way, unthrottled progress spam is definitely wrong.

## PR type
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
It will likely fix the crashing when downloading on iOS, and also improve performance and battery usage for both iOS and Android


## Issue or approval
Likely fixes #888

## UI / behavior impact
- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries
Only changed how often the platform downloaders emit progress updates.

## Testing
I am not able to test

## Screenshots / Video
None.

## Breaking changes
None.

## Linked issues
Likely fixes #888