### PR TITLE
Improve library filters and grid layout

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1197,6 +1197,11 @@
     <string name="library_remove_from_list_message">Remove %1$s from %2$s?</string>
     <string name="library_remove_message">Remove %1$s from your library?</string>
     <string name="library_remove_title">Remove from Library?</string>
+    <string name="library_filter_all">All</string>
+    <string name="library_filter_count">%1$d items</string>
+    <string name="library_filter_empty_message">Try another Library filter.</string>
+    <string name="library_filter_empty_title">No matching titles</string>
+    <string name="library_filter_unwatched">Unwatched</string>
     <string name="media_movie">Movie</string>
     <string name="notifications_channel_episode_releases_description">Alerts when a saved show's new episode is released.</string>
     <string name="notifications_test_preview_body">Preview episode release alert.</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryScreen.kt
@@ -1,24 +1,43 @@
 package com.nuvio.app.features.library
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil3.compose.AsyncImage
+import com.nuvio.app.core.format.formatReleaseDateForDisplay
 import com.nuvio.app.core.network.NetworkCondition
 import com.nuvio.app.core.network.NetworkStatusRepository
 import com.nuvio.app.core.ui.NuvioScreen
@@ -26,12 +45,15 @@ import com.nuvio.app.core.ui.NuvioNetworkOfflineCard
 import com.nuvio.app.core.ui.NuvioScreenHeader
 import com.nuvio.app.core.ui.NuvioStatusModal
 import com.nuvio.app.core.ui.NuvioToastController
-import com.nuvio.app.core.ui.NuvioViewAllPillSize
-import com.nuvio.app.core.ui.NuvioShelfSection
+import com.nuvio.app.core.ui.NuvioAnimatedWatchedBadge
+import com.nuvio.app.core.ui.posterCardClickable
+import com.nuvio.app.core.ui.rememberPosterCardStyleUiState
 import com.nuvio.app.features.home.components.HomeEmptyStateCard
-import com.nuvio.app.features.home.components.HomePosterCard
 import com.nuvio.app.features.home.components.HomeSkeletonRow
+import com.nuvio.app.features.home.PosterShape
 import com.nuvio.app.features.profiles.ProfileRepository
+import com.nuvio.app.features.watched.WatchedRepository
+import com.nuvio.app.features.watching.application.WatchingState
 import kotlinx.coroutines.launch
 import nuvio.composeapp.generated.resources.*
 import org.jetbrains.compose.resources.getString
@@ -43,6 +65,14 @@ private data class LibraryRemovalTarget(
     val listTitle: String? = null,
 )
 
+private enum class LibraryFilter {
+    All,
+    Movies,
+    Series,
+    Watched,
+    Unwatched,
+}
+
 @Composable
 fun LibraryScreen(
     modifier: Modifier = Modifier,
@@ -53,8 +83,24 @@ fun LibraryScreen(
         LibraryRepository.ensureLoaded()
         LibraryRepository.uiState
     }.collectAsStateWithLifecycle()
+    val watchedUiState by remember {
+        WatchedRepository.ensureLoaded()
+        WatchedRepository.uiState
+    }.collectAsStateWithLifecycle()
     val networkStatusUiState by NetworkStatusRepository.uiState.collectAsStateWithLifecycle()
     var pendingRemovalTarget by remember { mutableStateOf<LibraryRemovalTarget?>(null) }
+    var selectedFilterName by rememberSaveable { mutableStateOf(LibraryFilter.All.name) }
+    val selectedFilter = remember(selectedFilterName) {
+        runCatching { LibraryFilter.valueOf(selectedFilterName) }.getOrDefault(LibraryFilter.All)
+    }
+    val filteredSections = remember(uiState.sections, watchedUiState.watchedKeys, selectedFilter) {
+        uiState.sections.filteredBy(selectedFilter, watchedUiState.watchedKeys)
+    }
+    val filteredItems = remember(filteredSections) {
+        filteredSections
+            .flatMap { section -> section.items }
+            .distinctBy { item -> "${item.type}:${item.id}" }
+    }
     var observedOfflineState by remember { mutableStateOf(false) }
     val coroutineScope = rememberCoroutineScope()
     val isTraktSource = uiState.sourceMode == LibrarySourceMode.TRAKT
@@ -108,6 +154,26 @@ fun LibraryScreen(
                     modifier = Modifier.padding(horizontal = 16.dp),
                 )
                 Spacer(modifier = Modifier.height(6.dp))
+                if (uiState.sections.isNotEmpty()) {
+                    LibraryFilterRow(
+                        selectedFilter = selectedFilter,
+                        onSelectFilter = { selectedFilterName = it.name },
+                    )
+                    Text(
+                        text = stringResource(Res.string.library_filter_count, filteredItems.size),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(
+                            start = 16.dp,
+                            top = 14.dp,
+                            end = 16.dp,
+                        ),
+                        style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        textAlign = androidx.compose.ui.text.style.TextAlign.End,
+                    )
+                    Spacer(modifier = Modifier.height(20.dp))
+                }
             }
         }
 
@@ -169,22 +235,30 @@ fun LibraryScreen(
             }
 
             else -> {
-                librarySections(
-                    sections = uiState.sections,
-                    onPosterClick = onPosterClick,
-                    onSectionViewAllClick = onSectionViewAllClick,
-                    onPosterLongClick = { item, section ->
-                        pendingRemovalTarget = if (isTraktSource) {
-                            LibraryRemovalTarget(
-                                item = item,
-                                listKey = section.type,
-                                listTitle = section.displayTitle,
-                            )
-                        } else {
-                            LibraryRemovalTarget(item = item)
-                        }
-                    },
-                )
+                if (filteredItems.isEmpty()) {
+                    item {
+                        HomeEmptyStateCard(
+                            modifier = Modifier.padding(horizontal = 16.dp),
+                            title = stringResource(Res.string.library_filter_empty_title),
+                            message = stringResource(Res.string.library_filter_empty_message),
+                        )
+                    }
+                } else {
+                    libraryGrid(
+                        items = filteredItems,
+                        watchedKeys = watchedUiState.watchedKeys,
+                        onPosterClick = onPosterClick,
+                        onPosterLongClick = { item ->
+                            pendingRemovalTarget = if (isTraktSource) {
+                                LibraryRemovalTarget(
+                                    item = item,
+                                )
+                            } else {
+                                LibraryRemovalTarget(item = item)
+                            }
+                        },
+                    )
+                }
             }
         }
     }
@@ -226,37 +300,174 @@ fun LibraryScreen(
     )
 }
 
-private fun LazyListScope.librarySections(
-    sections: List<LibrarySection>,
-    onPosterClick: ((LibraryItem) -> Unit)?,
-    onSectionViewAllClick: ((LibrarySection) -> Unit)?,
-    onPosterLongClick: (LibraryItem, LibrarySection) -> Unit,
+@Composable
+private fun LibraryFilterRow(
+    selectedFilter: LibraryFilter,
+    onSelectFilter: (LibraryFilter) -> Unit,
 ) {
-    items(
-        items = sections,
-        key = { section -> section.type },
-    ) { section ->
-        val previewItems = section.items.take(LIBRARY_SECTION_PREVIEW_LIMIT)
-        NuvioShelfSection(
-            title = section.displayTitle,
-            entries = previewItems,
-            headerHorizontalPadding = 16.dp,
-            rowContentPadding = PaddingValues(horizontal = 16.dp),
-            onViewAllClick = if (section.items.size > LIBRARY_SECTION_PREVIEW_LIMIT) {
-                onSectionViewAllClick?.let { { it(section) } }
-            } else {
-                null
-            },
-            viewAllPillSize = NuvioViewAllPillSize.Compact,
-            key = { item -> "${item.type}:${item.id}" },
-        ) { item ->
-            HomePosterCard(
-                item = item.toMetaPreview(),
-                onClick = onPosterClick?.let { { it(item) } },
-                onLongClick = { onPosterLongClick(item, section) },
-            )
+    LazyRow(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        items(
+            items = LibraryFilter.entries,
+            key = { filter -> filter.name },
+        ) { filter ->
+            val selected = filter == selectedFilter
+            Surface(
+                modifier = Modifier.clickable { onSelectFilter(filter) },
+                shape = MaterialTheme.shapes.small,
+                color = if (selected) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.surface
+                },
+                contentColor = if (selected) {
+                    MaterialTheme.colorScheme.onPrimary
+                } else {
+                    MaterialTheme.colorScheme.onSurface
+                },
+            ) {
+                Text(
+                    text = filter.label(),
+                    modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
+                    style = MaterialTheme.typography.labelLarge,
+                )
+            }
         }
     }
 }
 
-private const val LIBRARY_SECTION_PREVIEW_LIMIT = 18
+@Composable
+private fun LibraryFilter.label(): String =
+    when (this) {
+        LibraryFilter.All -> stringResource(Res.string.library_filter_all)
+        LibraryFilter.Movies -> stringResource(Res.string.media_movies)
+        LibraryFilter.Series -> stringResource(Res.string.media_series)
+        LibraryFilter.Watched -> stringResource(Res.string.episodes_cd_watched)
+        LibraryFilter.Unwatched -> stringResource(Res.string.library_filter_unwatched)
+    }
+
+private fun List<LibrarySection>.filteredBy(
+    filter: LibraryFilter,
+    watchedKeys: Set<String>,
+): List<LibrarySection> =
+    mapNotNull { section ->
+        val filteredItems = section.items.filter { item ->
+            when (filter) {
+                LibraryFilter.All -> true
+                LibraryFilter.Movies -> item.type == "movie"
+                LibraryFilter.Series -> item.type == "series"
+                LibraryFilter.Watched -> item.isWatched(watchedKeys)
+                LibraryFilter.Unwatched -> !item.isWatched(watchedKeys)
+            }
+        }
+        section.copy(items = filteredItems).takeIf { it.items.isNotEmpty() }
+    }
+
+private fun LibraryItem.isWatched(watchedKeys: Set<String>): Boolean =
+    WatchingState.isPosterWatched(
+        watchedKeys = watchedKeys,
+        item = toMetaPreview(),
+    )
+
+private fun LazyListScope.libraryGrid(
+    items: List<LibraryItem>,
+    watchedKeys: Set<String>,
+    onPosterClick: ((LibraryItem) -> Unit)?,
+    onPosterLongClick: (LibraryItem) -> Unit,
+) {
+    items(
+        items = items.chunked(LIBRARY_GRID_COLUMNS),
+    ) { rowItems ->
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            rowItems.forEach { item ->
+                LibraryGridPosterTile(
+                    item = item,
+                    isWatched = item.isWatched(watchedKeys),
+                    modifier = Modifier.weight(1f),
+                    onClick = onPosterClick?.let { { it(item) } },
+                    onLongClick = { onPosterLongClick(item) },
+                )
+            }
+            repeat(LIBRARY_GRID_COLUMNS - rowItems.size) {
+                Spacer(modifier = Modifier.weight(1f))
+            }
+        }
+    }
+}
+
+@Composable
+private fun LibraryGridPosterTile(
+    item: LibraryItem,
+    isWatched: Boolean,
+    modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
+    onLongClick: (() -> Unit)? = null,
+) {
+    val posterCardStyle = rememberPosterCardStyleUiState()
+    val hideLabels = posterCardStyle.hideLabelsEnabled
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(item.posterShape.libraryAspectRatio())
+                .clip(RoundedCornerShape(posterCardStyle.cornerRadiusDp.dp))
+                .background(MaterialTheme.colorScheme.surface)
+                .posterCardClickable(onClick = onClick, onLongClick = onLongClick),
+        ) {
+            if (item.poster != null) {
+                AsyncImage(
+                    model = item.poster,
+                    contentDescription = item.name,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Crop,
+                )
+            }
+            NuvioAnimatedWatchedBadge(
+                isVisible = isWatched,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(6.dp),
+            )
+        }
+        if (!hideLabels) {
+            Text(
+                text = item.name,
+                style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
+                color = MaterialTheme.colorScheme.onBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            val detail = item.releaseInfo?.let { formatReleaseDateForDisplay(it) }
+            if (detail != null) {
+                Text(
+                    text = detail,
+                    style = MaterialTheme.typography.labelSmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+private fun PosterShape.libraryAspectRatio(): Float =
+    when (this) {
+        PosterShape.Poster -> 0.68f
+        PosterShape.Square -> 1f
+        PosterShape.Landscape -> 16f / 9f
+    }
+
+private const val LIBRARY_GRID_COLUMNS = 3


### PR DESCRIPTION
## Summary

Improves the Library screen browsing layout.

- Adds Library filters for All, Movies, Series, Watched, and Unwatched
- Shows the selected filter item count under the filter tabs
- Changes Library results from horizontal shelves to a 3-column vertical grid
- Keeps watched indicators visible on watched items

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The Library screen was difficult to browse when items were split into horizontal shelves. A vertical grid makes saved content easier to scan, while filters keep movies, series, watched, and unwatched content easy to access.

## Issue or approval

No linked issue: small focused Library browsing UI improvement.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only updates the Library browsing layout and filtering UI. No player, playback, account, sync, or data model behavior was changed.

## Testing

Tested on Android debug build.

Commands run:

- `./gradlew.bat :composeApp:compilePlaystoreDebugKotlinAndroid`
- `./gradlew.bat :composeApp:assemblePlaystoreDebug`

Manual checks:

- Opened Library
- Switched between All, Movies, Series, Watched, and Unwatched filters
- Confirmed the item count updates for the selected filter
- Confirmed Library items display in a vertical 3-column grid
- Confirmed watched items still show the watched indicator

## Screenshots / Video (UI changes only)

<img width="385" height="852" alt="image" src="https://github.com/user-attachments/assets/4eca3010-49e7-4927-87c9-598b105f0d7a" />
<img width="420" height="861" alt="image" src="https://github.com/user-attachments/assets/9e9c86b0-25e9-466a-b316-fa98d982cacc" />
<img width="389" height="843" alt="image" src="https://github.com/user-attachments/assets/86f3152e-ea16-4382-b443-738cbc02f3f3" />

## Breaking changes

None.

## Linked issues

No linked issue: small focused Library browsing UI improvement.


