### PR TITLE
Add recent search history controls

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/search/SearchHistoryStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/search/SearchHistoryStorage.android.kt
@@ -7,6 +7,7 @@ import com.nuvio.app.core.storage.ProfileScopedKey
 actual object SearchHistoryStorage {
     private const val preferencesName = "nuvio_search_history"
     private const val payloadKey = "search_history_payload"
+    private const val limitOverrideKey = "search_history_limit_override"
 
     private var preferences: SharedPreferences? = null
 
@@ -21,6 +22,26 @@ actual object SearchHistoryStorage {
         preferences
             ?.edit()
             ?.putString(ProfileScopedKey.of(payloadKey), payload)
+            ?.apply()
+    }
+
+    actual fun loadLimitOverride(): Int? {
+        val key = ProfileScopedKey.of(limitOverrideKey)
+        val prefs = preferences ?: return null
+        return if (prefs.contains(key)) prefs.getInt(key, SearchHistoryDefaultLimit) else null
+    }
+
+    actual fun saveLimitOverride(limit: Int?) {
+        val key = ProfileScopedKey.of(limitOverrideKey)
+        preferences
+            ?.edit()
+            ?.apply {
+                if (limit == null) {
+                    remove(key)
+                } else {
+                    putInt(key, limit)
+                }
+            }
             ?.apply()
     }
 }

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -371,6 +371,7 @@
     <string name="compose_search_empty_no_search_catalogs_title">No searchable catalogs</string>
     <string name="compose_search_placeholder">Search movies, shows...</string>
     <string name="compose_search_recent_searches">Recent Searches</string>
+    <string name="compose_search_clear_recent_searches">Clear recent searches</string>
     <string name="compose_search_remove_recent_search">Remove recent search</string>
     <string name="compose_settings_category_about">About</string>
     <string name="compose_settings_category_general">General</string>
@@ -579,12 +580,15 @@
     <string name="settings_continue_watching_use_episode_thumbnails_description">Prefer episode thumbnails when available.</string>
     <string name="settings_continue_watching_use_episode_thumbnails_title">Prefer Episode Thumbnails in Continue Watching</string>
     <string name="settings_content_discovery_section_home">HOME</string>
+    <string name="settings_content_discovery_section_search">SEARCH</string>
     <string name="settings_content_discovery_section_sources">SOURCES</string>
     <string name="settings_content_discovery_addons_description">Install, remove, refresh, and sort your content sources.</string>
     <string name="settings_content_discovery_plugins_description">Install JavaScript scraper repositories and test providers internally.</string>
     <string name="settings_content_discovery_homescreen_description">Adjust home layout, content visibility, and poster behavior</string>
     <string name="settings_content_discovery_meta_screen_description">Settings for the detail and episode screens.</string>
     <string name="settings_content_discovery_collections_description">Create custom catalog groupings with folders shown on Home.</string>
+    <string name="settings_search_history_limit_description">Only keep and show the 5 most recent searches.</string>
+    <string name="settings_search_history_limit_title">Show only last 5 searches</string>
     <string name="settings_integrations_section_title">Integrations</string>
     <string name="settings_integrations_tmdb_description">Metadata enrichment controls</string>
     <string name="settings_integrations_mdblist_description">External ratings providers</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchHistoryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchHistoryRepository.kt
@@ -8,8 +8,6 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 object SearchHistoryRepository {
-    private const val MAX_RECENT_SEARCHES = 10
-
     private val json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = true
@@ -18,8 +16,12 @@ object SearchHistoryRepository {
     private val _uiState = MutableStateFlow<List<String>>(emptyList())
     val uiState: StateFlow<List<String>> = _uiState.asStateFlow()
 
+    private val _settingsUiState = MutableStateFlow(SearchHistorySettingsUiState())
+    val settingsUiState: StateFlow<SearchHistorySettingsUiState> = _settingsUiState.asStateFlow()
+
     private var hasLoaded = false
     private var recentSearches: List<String> = emptyList()
+    private var limitOverride: Int? = null
 
     fun ensureLoaded() {
         if (hasLoaded) return
@@ -38,7 +40,7 @@ object SearchHistoryRepository {
         val updatedSearches = applySearchHistoryEntry(
             current = recentSearches,
             query = normalizedQuery,
-            limit = MAX_RECENT_SEARCHES,
+            limit = effectiveLimit(),
         )
         if (updatedSearches == recentSearches) return
 
@@ -57,8 +59,36 @@ object SearchHistoryRepository {
         persist()
     }
 
+    fun clearSearches() {
+        ensureLoaded()
+        if (recentSearches.isEmpty()) return
+
+        recentSearches = emptyList()
+        publish()
+        persist()
+    }
+
+    fun setLimitOverride(limit: Int?) {
+        ensureLoaded()
+        val normalizedLimit = limit.normalizedSearchHistoryLimitOverride()
+        if (limitOverride == normalizedLimit) return
+
+        limitOverride = normalizedLimit
+        SearchHistoryStorage.saveLimitOverride(normalizedLimit)
+        _settingsUiState.value = SearchHistorySettingsUiState(normalizedLimit)
+
+        val trimmedSearches = recentSearches.applyLimit(effectiveLimit())
+        if (trimmedSearches != recentSearches) {
+            recentSearches = trimmedSearches
+            publish()
+            persist()
+        }
+    }
+
     private fun loadFromDisk() {
         hasLoaded = true
+        limitOverride = SearchHistoryStorage.loadLimitOverride().normalizedSearchHistoryLimitOverride()
+        _settingsUiState.value = SearchHistorySettingsUiState(limitOverride)
         val payload = SearchHistoryStorage.loadPayload().orEmpty().trim()
         recentSearches = if (payload.isEmpty()) {
             emptyList()
@@ -69,10 +99,16 @@ object SearchHistoryRepository {
                 .map { it.trim() }
                 .filter { it.length >= 2 }
                 .distinct()
-                .take(MAX_RECENT_SEARCHES)
+                .applyLimit(effectiveLimit())
         }
         publish()
     }
+
+    private fun effectiveLimit(): Int? =
+        when (limitOverride) {
+            null -> SearchHistoryDefaultLimit
+            else -> limitOverride
+        }
 
     private fun publish() {
         _uiState.value = recentSearches
@@ -83,16 +119,33 @@ object SearchHistoryRepository {
     }
 }
 
+data class SearchHistorySettingsUiState(
+    val limitOverride: Int? = null,
+)
+
+const val SearchHistoryDefaultLimit = 10
+const val SearchHistoryRecentSearchLimit = 5
+
 internal fun applySearchHistoryEntry(
     current: List<String>,
     query: String,
-    limit: Int,
+    limit: Int?,
 ): List<String> =
     buildList {
         add(query)
         current.forEach { existing ->
-            if (existing != query && size < limit) {
+            if (existing != query && (limit == null || size < limit)) {
                 add(existing)
             }
         }
+    }
+
+private fun List<String>.applyLimit(limit: Int?): List<String> =
+    if (limit == null) this else take(limit)
+
+private fun Int?.normalizedSearchHistoryLimitOverride(): Int? =
+    when (this) {
+        null -> null
+        SearchHistoryRecentSearchLimit -> SearchHistoryRecentSearchLimit
+        else -> null
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchHistoryStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchHistoryStorage.kt
@@ -3,4 +3,6 @@ package com.nuvio.app.features.search
 internal expect object SearchHistoryStorage {
     fun loadPayload(): String?
     fun savePayload(payload: String)
+    fun loadLimitOverride(): Int?
+    fun saveLimitOverride(limit: Int?)
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.History
+import androidx.compose.material.icons.rounded.Delete
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -63,6 +64,7 @@ import kotlinx.coroutines.flow.map
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.compose_nav_search
 import nuvio.composeapp.generated.resources.compose_search_clear
+import nuvio.composeapp.generated.resources.compose_search_clear_recent_searches
 import nuvio.composeapp.generated.resources.compose_search_discover_title
 import nuvio.composeapp.generated.resources.compose_search_empty_failed_message
 import nuvio.composeapp.generated.resources.compose_search_empty_failed_title
@@ -278,6 +280,7 @@ fun SearchScreen(
                         recentSearches = recentSearches,
                         onSearchPress = { recentQuery -> query = recentQuery },
                         onRemoveSearch = SearchHistoryRepository::removeSearch,
+                        onClearSearches = SearchHistoryRepository::clearSearches,
                     )
                 }
             }
@@ -421,6 +424,7 @@ private fun SearchRecentSection(
     recentSearches: List<String>,
     onSearchPress: (String) -> Unit,
     onRemoveSearch: (String) -> Unit,
+    onClearSearches: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -429,11 +433,24 @@ private fun SearchRecentSection(
             .padding(horizontal = 16.dp, vertical = 4.dp),
         verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
-        Text(
-            text = stringResource(Res.string.compose_search_recent_searches),
-            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
-            color = MaterialTheme.colorScheme.onBackground,
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(Res.string.compose_search_recent_searches),
+                style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            IconButton(onClick = onClearSearches) {
+                Icon(
+                    imageVector = Icons.Rounded.Delete,
+                    contentDescription = stringResource(Res.string.compose_search_clear_recent_searches),
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
         Spacer(modifier = Modifier.height(4.dp))
         recentSearches.forEach { recentQuery ->
             SearchRecentRow(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContentDiscoverySettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContentDiscoverySettingsPage.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.icons.rounded.Extension
 import androidx.compose.material.icons.rounded.Home
 import androidx.compose.material.icons.rounded.Hub
 import androidx.compose.material.icons.rounded.Tune
+import com.nuvio.app.features.search.SearchHistoryRecentSearchLimit
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.compose_settings_page_addons
 import nuvio.composeapp.generated.resources.compose_settings_page_homescreen
@@ -19,11 +20,16 @@ import nuvio.composeapp.generated.resources.settings_content_discovery_homescree
 import nuvio.composeapp.generated.resources.settings_content_discovery_meta_screen_description
 import nuvio.composeapp.generated.resources.settings_content_discovery_plugins_description
 import nuvio.composeapp.generated.resources.settings_content_discovery_section_home
+import nuvio.composeapp.generated.resources.settings_content_discovery_section_search
 import nuvio.composeapp.generated.resources.settings_content_discovery_section_sources
+import nuvio.composeapp.generated.resources.settings_search_history_limit_description
+import nuvio.composeapp.generated.resources.settings_search_history_limit_title
 import org.jetbrains.compose.resources.stringResource
 
 internal fun LazyListScope.contentDiscoveryContent(
     isTablet: Boolean,
+    searchHistoryLimitOverride: Int?,
+    onSearchHistoryLimitSelected: (Int?) -> Unit,
     showPluginsEntry: Boolean,
     onAddonsClick: () -> Unit,
     onPluginsClick: () -> Unit,
@@ -53,6 +59,26 @@ internal fun LazyListScope.contentDiscoveryContent(
                         onClick = onPluginsClick,
                     )
                 }
+            }
+        }
+    }
+    item {
+        SettingsSection(
+            title = stringResource(Res.string.settings_content_discovery_section_search),
+            isTablet = isTablet,
+        ) {
+            SettingsGroup(isTablet = isTablet) {
+                SettingsSwitchRow(
+                    title = stringResource(Res.string.settings_search_history_limit_title),
+                    description = stringResource(Res.string.settings_search_history_limit_description),
+                    checked = searchHistoryLimitOverride == SearchHistoryRecentSearchLimit,
+                    isTablet = isTablet,
+                    onCheckedChange = { enabled ->
+                        onSearchHistoryLimitSelected(
+                            if (enabled) SearchHistoryRecentSearchLimit else null,
+                        )
+                    },
+                )
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
@@ -68,6 +68,7 @@ import com.nuvio.app.features.mdblist.MdbListSettingsRepository
 import com.nuvio.app.features.notifications.EpisodeReleaseNotificationsRepository
 import com.nuvio.app.features.notifications.EpisodeReleaseNotificationsUiState
 import com.nuvio.app.features.player.PlayerSettingsRepository
+import com.nuvio.app.features.search.SearchHistoryRepository
 import com.nuvio.app.features.trakt.TraktAuthUiState
 import com.nuvio.app.features.trakt.TraktAuthRepository
 import com.nuvio.app.features.trakt.TraktCommentsSettings
@@ -185,6 +186,10 @@ fun SettingsScreen(
             EpisodeReleaseNotificationsRepository.ensureLoaded()
             EpisodeReleaseNotificationsRepository.uiState
         }.collectAsStateWithLifecycle()
+        val searchHistorySettingsUiState by remember {
+            SearchHistoryRepository.ensureLoaded()
+            SearchHistoryRepository.settingsUiState
+        }.collectAsStateWithLifecycle()
 
         LaunchedEffect(homescreenCatalogRefreshKey) {
             if (homescreenCatalogRefreshKey.isEmpty()) return@LaunchedEffect
@@ -249,6 +254,7 @@ fun SettingsScreen(
                 metaScreenSettingsUiState = metaScreenSettingsUiState,
                 continueWatchingPreferencesUiState = continueWatchingPreferencesUiState,
                 posterCardStyleUiState = posterCardStyleUiState,
+                searchHistoryLimitOverride = searchHistorySettingsUiState.limitOverride,
                 onSwitchProfile = onSwitchProfile,
                 onDownloadsClick = onDownloadsClick,
                 onSupportersContributorsClick = onSupportersContributorsClick,
@@ -297,6 +303,7 @@ fun SettingsScreen(
                 metaScreenSettingsUiState = metaScreenSettingsUiState,
                 continueWatchingPreferencesUiState = continueWatchingPreferencesUiState,
                 posterCardStyleUiState = posterCardStyleUiState,
+                searchHistoryLimitOverride = searchHistorySettingsUiState.limitOverride,
                 onSwitchProfile = onSwitchProfile,
                 onHomescreenClick = onHomescreenClick,
                 onMetaScreenClick = onMetaScreenClick,
@@ -355,6 +362,7 @@ private fun MobileSettingsScreen(
     metaScreenSettingsUiState: MetaScreenSettingsUiState,
     continueWatchingPreferencesUiState: ContinueWatchingPreferencesUiState,
     posterCardStyleUiState: PosterCardStyleUiState,
+    searchHistoryLimitOverride: Int?,
     onSwitchProfile: (() -> Unit)? = null,
     onHomescreenClick: () -> Unit = {},
     onMetaScreenClick: () -> Unit = {},
@@ -529,6 +537,8 @@ private fun MobileSettingsScreen(
                 )
                 SettingsPage.ContentDiscovery -> contentDiscoveryContent(
                     isTablet = false,
+                    searchHistoryLimitOverride = searchHistoryLimitOverride,
+                    onSearchHistoryLimitSelected = SearchHistoryRepository::setLimitOverride,
                     showPluginsEntry = AppFeaturePolicy.pluginsEnabled,
                     onAddonsClick = onAddonsClick,
                     onPluginsClick = onPluginsClick,
@@ -662,6 +672,7 @@ private fun TabletSettingsScreen(
     metaScreenSettingsUiState: MetaScreenSettingsUiState,
     continueWatchingPreferencesUiState: ContinueWatchingPreferencesUiState,
     posterCardStyleUiState: PosterCardStyleUiState,
+    searchHistoryLimitOverride: Int?,
     onSwitchProfile: (() -> Unit)? = null,
     onDownloadsClick: () -> Unit = {},
     onSupportersContributorsClick: () -> Unit = {},
@@ -895,6 +906,8 @@ private fun TabletSettingsScreen(
                     )
                     SettingsPage.ContentDiscovery -> contentDiscoveryContent(
                         isTablet = true,
+                        searchHistoryLimitOverride = searchHistoryLimitOverride,
+                        onSearchHistoryLimitSelected = SearchHistoryRepository::setLimitOverride,
                         showPluginsEntry = AppFeaturePolicy.pluginsEnabled,
                         onAddonsClick = { openInlinePage(SettingsPage.Addons) },
                         onPluginsClick = { openInlinePage(SettingsPage.Plugins) },

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/search/SearchHistoryStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/search/SearchHistoryStorage.ios.kt
@@ -1,15 +1,32 @@
 package com.nuvio.app.features.search
 
 import com.nuvio.app.core.storage.ProfileScopedKey
+import platform.Foundation.NSNumber
 import platform.Foundation.NSUserDefaults
 
 actual object SearchHistoryStorage {
     private const val payloadKey = "search_history_payload"
+    private const val limitOverrideKey = "search_history_limit_override"
 
     actual fun loadPayload(): String? =
         NSUserDefaults.standardUserDefaults.stringForKey(ProfileScopedKey.of(payloadKey))
 
     actual fun savePayload(payload: String) {
         NSUserDefaults.standardUserDefaults.setObject(payload, forKey = ProfileScopedKey.of(payloadKey))
+    }
+
+    actual fun loadLimitOverride(): Int? {
+        val key = ProfileScopedKey.of(limitOverrideKey)
+        val stored = NSUserDefaults.standardUserDefaults.objectForKey(key) ?: return null
+        return (stored as? NSNumber)?.intValue
+    }
+
+    actual fun saveLimitOverride(limit: Int?) {
+        val key = ProfileScopedKey.of(limitOverrideKey)
+        if (limit == null) {
+            NSUserDefaults.standardUserDefaults.removeObjectForKey(key)
+        } else {
+            NSUserDefaults.standardUserDefaults.setInteger(limit.toLong(), forKey = key)
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds basic recent search history controls.

- Adds a clear-all button next to Recent Searches
- Keeps individual recent search removal unchanged
- Adds a Content & Discovery setting to show only the last 5 searches
- Leaves the existing app default behavior unchanged unless the setting is enabled

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Users can remove recent searches one by one, but there is no quick way to clear the whole recent search list. This also adds a small opt-in setting for users who prefer a shorter recent search history.

## Issue or approval

No linked issue: small focused search history usability improvement.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only updates recent search history controls. No search provider, catalog, discover, playback, account, or sync behavior was changed.

## Testing

Tested on Android debug build.

Commands run:

- `./gradlew.bat :composeApp:compilePlaystoreDebugKotlinAndroid`
- `./gradlew.bat :composeApp:assemblePlaystoreDebug`

Manual checks:

- Opened Search
- Confirmed individual recent search removal still works
- Confirmed the clear-all button removes all recent searches
- Opened Settings > Content & Discovery
- Confirmed the “Show only last 5 searches” switch is visible
- Confirmed enabling the switch limits recent searches to 5
- Confirmed disabling the switch returns to the app default behavior

## Screenshots / Video (UI changes only)

<img width="406" height="840" alt="image" src="https://github.com/user-attachments/assets/8ee678ef-2bb1-42da-ba9c-aaa86df29db3" />
<img width="418" height="849" alt="image" src="https://github.com/user-attachments/assets/a67ac2cf-2c4d-45c8-b082-80186d66f54f" />

## Breaking changes

None.

## Linked issues

No linked issue: small focused search history usability improvement.
