### PR TITLE
fix: plugin crashes when playing certain episodes on GrapheneOS

### DIFF
--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRuntime.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRuntime.kt
@@ -264,11 +264,6 @@ internal object PluginRuntime {
                     prevId
                 }
 
-                function("__capture_result") { args ->
-                    resultJson = args.getOrNull(0)?.toString() ?: "[]"
-                    null
-                }
-
                 val settingsJson = toJsonElement(scraperSettings).toString()
                 val polyfillCode = buildPolyfillCode(scraperId, settingsJson)
                 evaluate<Any?>(polyfillCode)
@@ -290,18 +285,21 @@ internal object PluginRuntime {
                             var getStreams = module.exports.getStreams || globalThis.getStreams;
                             if (!getStreams) {
                                 console.error("getStreams function not found on module.exports or globalThis");
-                                __capture_result(JSON.stringify([]));
+                                globalThis.__nuvio_plugin_result = JSON.stringify([]);
                                 return;
                             }
                             var result = await getStreams("$tmdbId", "$mediaType", $seasonArg, $episodeArg);
-                            __capture_result(JSON.stringify(result || []));
+                            globalThis.__nuvio_plugin_result = JSON.stringify(result || []);
                         } catch (e) {
                             console.error("getStreams error:", e && e.message ? e.message : e, e && e.stack ? e.stack : "");
-                            __capture_result(JSON.stringify([]));
+                            globalThis.__nuvio_plugin_result = JSON.stringify([]);
                         }
                     })();
                 """.trimIndent()
                 evaluate<Any?>(callCode)
+                resultJson = evaluate<String>(
+                    "typeof globalThis.__nuvio_plugin_result === 'string' ? globalThis.__nuvio_plugin_result : '[]'"
+                ) ?: "[]"
             }
 
             return parseJsonResults(resultJson)


### PR DESCRIPTION
## Summary

Fix use after free crash during async plugin execution.

Currently, async functions like `getStreams()` pass results to Kotlin via a JNI callback (`__capture_result`). This creates a race condition: QuickJS can garbage collect the string while `NewStringUTF` is still reading it. 

Stock Android often lets this slide, but MTE enabled devices (like GrapheneOS) catch it and immediately kill the app (`SIGSEGV`). This explains why only certain episodes crash, heavier async chains create more GC pressure, exposing the bug.

Instead of crossing the JNI boundary during async execution, we now stash the result in `globalThis.__nuvio_plugin_result`. Once all QuickJS jobs finish, Kotlin safely reads it back using a synchronous `evaluate<String>()`.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
So people using GrapheneOS can use Nuvio as intended.

## Issue or approval

Fixes #892

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
Just the minimal swap from JNI callback to JS global inside `PluginRuntime.kt`.

## Testing

I am not able to test.

## Screenshots / Video

None.

## Breaking changes

None.

## Linked issues

Fixes #892