### PR TITLE
Add account-synced stream link cache with Supabase RPC backend support

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/sync/SyncManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/sync/SyncManager.kt
@@ -11,6 +11,7 @@ import com.nuvio.app.features.library.LibraryRepository
 import com.nuvio.app.features.plugins.PluginRepository
 import com.nuvio.app.features.profiles.ProfileRepository
 import com.nuvio.app.features.trakt.TraktPlatformClock
+import com.nuvio.app.features.streams.StreamLinkCacheRepository
 import com.nuvio.app.features.watched.WatchedRepository
 import com.nuvio.app.features.watchprogress.WatchProgressRepository
 import kotlinx.coroutines.CoroutineScope
@@ -57,6 +58,10 @@ object SyncManager {
             launch {
                 runCatching { WatchProgressRepository.pullFromServer(profileId) }
                     .onFailure { log.e(it) { "WatchProgress pull failed" } }
+            }
+            launch {
+                runCatching { StreamLinkCacheRepository.pullFromServer(profileId) }
+                    .onFailure { log.e(it) { "StreamLinkCache pull failed" } }
             }
             launch {
                 runCatching { WatchedRepository.pullFromServer(profileId) }
@@ -109,6 +114,10 @@ object SyncManager {
                     .onFailure { log.e(it) { "Foreground library pull failed" } }
             }
 
+            launch {
+                runCatching { StreamLinkCacheRepository.pullFromServer(profileId) }
+                    .onFailure { log.e(it) { "Foreground StreamLinkCache pull failed" } }
+            }
             launch {
                 runCatching { WatchProgressRepository.pullFromServer(profileId) }
                     .onFailure { log.e(it) { "Foreground watch progress pull failed" } }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamLinkCacheRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamLinkCacheRepository.kt
@@ -1,5 +1,12 @@
 package com.nuvio.app.features.streams
 
+import com.nuvio.app.core.auth.AuthRepository
+import com.nuvio.app.core.auth.AuthState
+import com.nuvio.app.features.profiles.ProfileRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
@@ -21,6 +28,7 @@ internal expect fun epochMs(): Long
 
 object StreamLinkCacheRepository {
     private val json = Json { ignoreUnknownKeys = true }
+    private val syncScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     fun contentKey(
         type: String,
@@ -48,6 +56,7 @@ object StreamLinkCacheRepository {
         filename: String? = null,
         videoSize: Long? = null,
         bingeGroup: String? = null,
+        syncToRemote: Boolean = true,
     ) {
         val entry = CachedStreamLink(
             url = url,
@@ -63,10 +72,48 @@ object StreamLinkCacheRepository {
         )
         val payload = json.encodeToString(CachedStreamLink.serializer(), entry)
         StreamLinkCacheStorage.saveEntry(hashedKey(contentKey), payload)
+
+        if (!syncToRemote) return
+
+        val profileId = ProfileRepository.activeProfileId
+        syncScope.launch {
+            runCatching {
+                val authState = AuthRepository.state.value
+                if (authState !is AuthState.Authenticated || authState.isAnonymous) return@runCatching
+                StreamLinkCacheSyncService.push(
+                    profileId = profileId,
+                    entries = listOf(
+                        StreamLinkCacheSyncEntry(
+                            contentKey = contentKey,
+                            url = entry.url,
+                            streamName = entry.streamName,
+                            addonName = entry.addonName,
+                            addonId = entry.addonId,
+                            cachedAtMs = entry.cachedAtMs,
+                            requestHeaders = entry.requestHeaders,
+                            responseHeaders = entry.responseHeaders,
+                            filename = entry.filename,
+                            videoSize = entry.videoSize,
+                            bingeGroup = entry.bingeGroup,
+                        ),
+                    ),
+                )
+            }
+        }
     }
 
     fun remove(contentKey: String) {
         StreamLinkCacheStorage.removeEntry(hashedKey(contentKey))
+        syncScope.launch {
+            runCatching {
+                val authState = AuthRepository.state.value
+                if (authState !is AuthState.Authenticated || authState.isAnonymous) return@runCatching
+                StreamLinkCacheSyncService.delete(
+                    profileId = ProfileRepository.activeProfileId,
+                    contentKeys = listOf(contentKey),
+                )
+            }
+        }
     }
 
     fun getValid(contentKey: String, maxAgeMs: Long): CachedStreamLink? {
@@ -88,6 +135,39 @@ object StreamLinkCacheRepository {
             return null
         }
         return entry
+    }
+
+    suspend fun pullFromServer(profileId: Int) {
+        val remoteEntries = runCatching {
+            StreamLinkCacheSyncService.pull(profileId)
+        }.getOrNull().orEmpty()
+
+        for (remoteEntry in remoteEntries) {
+            if (remoteEntry.url.isBlank()) continue
+            val localEntry = load(contentKey = remoteEntry.contentKey)
+            if (localEntry == null || remoteEntry.cachedAtMs > localEntry.cachedAtMs) {
+                save(
+                    contentKey = remoteEntry.contentKey,
+                    url = remoteEntry.url,
+                    streamName = remoteEntry.streamName,
+                    addonName = remoteEntry.addonName,
+                    addonId = remoteEntry.addonId,
+                    requestHeaders = remoteEntry.requestHeaders,
+                    responseHeaders = remoteEntry.responseHeaders,
+                    filename = remoteEntry.filename,
+                    videoSize = remoteEntry.videoSize,
+                    bingeGroup = remoteEntry.bingeGroup,
+                    syncToRemote = false,
+                )
+            }
+        }
+    }
+
+    private fun load(contentKey: String): CachedStreamLink? {
+        val raw = StreamLinkCacheStorage.loadEntry(hashedKey(contentKey)) ?: return null
+        return runCatching {
+            json.decodeFromString(CachedStreamLink.serializer(), raw)
+        }.getOrNull()
     }
 
     private fun hashedKey(contentKey: String): String {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamLinkCacheSyncService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamLinkCacheSyncService.kt
@@ -1,0 +1,58 @@
+package com.nuvio.app.features.streams
+
+import com.nuvio.app.core.network.SupabaseProvider
+import io.github.jan.supabase.postgrest.postgrest
+import io.github.jan.supabase.postgrest.rpc
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.encodeToJsonElement
+
+object StreamLinkCacheSyncService {
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    suspend fun pull(profileId: Int): List<StreamLinkCacheSyncEntry> {
+        val params = buildJsonObject {
+            put("p_profile_id", profileId)
+        }
+        val result = SupabaseProvider.client.postgrest.rpc("sync_pull_stream_link_cache", params)
+        return result.decodeList<StreamLinkCacheSyncEntry>()
+    }
+
+    suspend fun push(profileId: Int, entries: Collection<StreamLinkCacheSyncEntry>) {
+        if (entries.isEmpty()) return
+        val params = buildJsonObject {
+            put("p_profile_id", profileId)
+            put("p_entries", json.encodeToJsonElement(entries))
+        }
+        SupabaseProvider.client.postgrest.rpc("sync_push_stream_link_cache", params)
+    }
+
+    suspend fun delete(profileId: Int, contentKeys: Collection<String>) {
+        if (contentKeys.isEmpty()) return
+        val params = buildJsonObject {
+            put("p_profile_id", profileId)
+            put("p_keys", json.encodeToJsonElement(contentKeys))
+        }
+        SupabaseProvider.client.postgrest.rpc("sync_delete_stream_link_cache", params)
+    }
+}
+
+@Serializable
+internal data class StreamLinkCacheSyncEntry(
+    @SerialName("content_key") val contentKey: String,
+    val url: String,
+    @SerialName("stream_name") val streamName: String,
+    @SerialName("addon_name") val addonName: String,
+    @SerialName("addon_id") val addonId: String,
+    @SerialName("cached_at_ms") val cachedAtMs: Long = 0,
+    @SerialName("request_headers") val requestHeaders: Map<String, String> = emptyMap(),
+    @SerialName("response_headers") val responseHeaders: Map<String, String> = emptyMap(),
+    val filename: String? = null,
+    @SerialName("video_size") val videoSize: Long? = null,
+    @SerialName("binge_group") val bingeGroup: String? = null,
+)

--- a/supabase_stream_link_cache_sync.sql
+++ b/supabase_stream_link_cache_sync.sql
@@ -1,0 +1,145 @@
+-- Supabase SQL for stream link cache sync
+--
+-- Run this against your Supabase database to add a table and RPC functions
+-- used by `StreamLinkCacheSyncService` in the mobile app.
+
+create table if not exists public.stream_link_cache (
+    profile_id integer not null,
+    content_key text not null,
+    url text not null,
+    stream_name text not null,
+    addon_name text not null,
+    addon_id text not null,
+    cached_at_ms bigint not null,
+    request_headers jsonb not null default '{}'::jsonb,
+    response_headers jsonb not null default '{}'::jsonb,
+    filename text,
+    video_size bigint,
+    binge_group text,
+    created_at timestamptz not null default now(),
+    updated_at timestamptz not null default now(),
+    primary key (profile_id, content_key)
+);
+
+create or replace function public.sync_pull_stream_link_cache(
+    p_profile_id integer
+)
+returns table (
+    content_key text,
+    url text,
+    stream_name text,
+    addon_name text,
+    addon_id text,
+    cached_at_ms bigint,
+    request_headers jsonb,
+    response_headers jsonb,
+    filename text,
+    video_size bigint,
+    binge_group text
+)
+language sql stable as $$
+    select
+        content_key,
+        url,
+        stream_name,
+        addon_name,
+        addon_id,
+        cached_at_ms,
+        request_headers,
+        response_headers,
+        filename,
+        video_size,
+        binge_group
+    from public.stream_link_cache
+    where profile_id = p_profile_id
+    order by cached_at_ms desc;
+$$;
+
+create or replace function public.sync_push_stream_link_cache(
+    p_profile_id integer,
+    p_entries jsonb
+)
+returns void
+language plpgsql as $$
+begin
+    if p_entries is null or jsonb_array_length(p_entries) = 0 then
+        return;
+    end if;
+
+    insert into public.stream_link_cache (
+        profile_id,
+        content_key,
+        url,
+        stream_name,
+        addon_name,
+        addon_id,
+        cached_at_ms,
+        request_headers,
+        response_headers,
+        filename,
+        video_size,
+        binge_group,
+        updated_at
+    )
+    select
+        p_profile_id,
+        entry.content_key,
+        entry.url,
+        entry.stream_name,
+        entry.addon_name,
+        entry.addon_id,
+        entry.cached_at_ms,
+        coalesce(entry.request_headers, '{}'::jsonb),
+        coalesce(entry.response_headers, '{}'::jsonb),
+        entry.filename,
+        entry.video_size,
+        entry.binge_group,
+        now()
+    from jsonb_to_recordset(p_entries) as entry(
+        content_key text,
+        url text,
+        stream_name text,
+        addon_name text,
+        addon_id text,
+        cached_at_ms bigint,
+        request_headers jsonb,
+        response_headers jsonb,
+        filename text,
+        video_size bigint,
+        binge_group text
+    )
+    on conflict (profile_id, content_key) do update
+    set
+        url = excluded.url,
+        stream_name = excluded.stream_name,
+        addon_name = excluded.addon_name,
+        addon_id = excluded.addon_id,
+        cached_at_ms = excluded.cached_at_ms,
+        request_headers = excluded.request_headers,
+        response_headers = excluded.response_headers,
+        filename = excluded.filename,
+        video_size = excluded.video_size,
+        binge_group = excluded.binge_group,
+        updated_at = now()
+    where excluded.cached_at_ms >= public.stream_link_cache.cached_at_ms;
+end;
+$$;
+
+create or replace function public.sync_delete_stream_link_cache(
+    p_profile_id integer,
+    p_keys jsonb
+)
+returns void
+language plpgsql as $$
+begin
+    if p_keys is null or jsonb_array_length(p_keys) = 0 then
+        return;
+    end if;
+
+    delete from public.stream_link_cache
+    where profile_id = p_profile_id
+      and content_key in (
+        select jsonb_array_elements_text(p_keys)
+      );
+end;
+$$;


### PR DESCRIPTION
## Summary

Adds account-synced stream link cache support so resolved playback URLs can be reused across devices for the same profile.

StreamLinkCacheRepository now pushes cached stream links to Supabase when authenticated
Added StreamLinkCacheSyncService with RPC calls:
`sync_pull_stream_link_cache`
`sync_push_stream_link_cache`
`sync_delete_stream_link_cache`
Updated `SyncManager` to pull stream link cache data during profile sync
Added `supabase_stream_link_cache_sync.sql`

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

<!-- Why this change is needed. Explain the user-visible bug, regression, maintenance need, docs error, or approved request. -->

The current stream reuse cache is device-local only. That means a stream resolved on one device cannot be reused on another device even for the same account/profile.

This change lets the app persist resolved stream links to the account backend and pull them down on other devices, improving playback continuity and reducing repeated stream resolution.

## Issue or approval

<!-- Required. Link the bug issue or approved feature request. For docs/translation/maintenance with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / Approved in #456 / No linked issue: typo-only docs fix. -->
Pending explicit maintainer approval for the feature request.
A feature request issue will be linked once approval is received.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

Note: this PR contains a behavior change and is pending explicit maintainer approval before review.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->
Intentionally does not change player UI
Intentionally does not modify local-only cache semantics
Intentionally does not add any new UI or playback controls
Only adds backend sync plumbing and pull/push/delete support for stream link cache

## Testing
- Manual verification of local cache save behavior in current branch
- Confirmed branch compiles in [composeApp] metadata compile step
- Confirmed branch push to fork and branch creation succeeded
- Further testing should include:
        - saving a stream link while authenticated
        - verifying remote push occurs
        - syncing on another device and verifying remote pull restores the cache
        - checking newer cached_at_ms entries win during merge

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is docs/translation-only. -->

## Screenshots / Video (UI changes only)

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->
Not a UI change

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None

## Linked issues

<!-- Required for bug fixes, UI glitch fixes, behavior fixes, and approved changes. For docs/translation/maintenance with no issue, write: No linked issue - reason. -->

No linked issue yet - feature request approval pending