### PR TITLE
Remove dropped Trakt series from continue watching

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktProgressRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktProgressRepository.kt
@@ -147,7 +147,13 @@ object TraktProgressRepository {
             coroutineScope {
                 val history = async { fetchHistoryEntries(headers) }
                 val watchedShowSeeds = async { fetchWatchedShowSeedEntries(headers) }
-                history.await() + watchedShowSeeds.await()
+                val hiddenShows = async { fetchHiddenProgressShowIds(headers) }
+                val hiddenIds = hiddenShows.await()
+                (history.await() + watchedShowSeeds.await())
+                    .filterNot { entry ->
+                        entry.parentMetaType == "series" &&
+                                hiddenIds.contains(entry.parentMetaId)
+                    }
             }
         }.onFailure { error ->
             if (error is CancellationException) throw error
@@ -388,6 +394,35 @@ object TraktProgressRepository {
 
         val merged = mergeNewestByVideoId(completedEpisodes + completedMovies)
         merged
+    }
+
+    private suspend fun fetchHiddenProgressShowIds(
+        headers: Map<String, String>,
+    ): Set<String> = withContext(Dispatchers.Default) {
+        val allIds = mutableSetOf<String>()
+        var page = 1
+        val limit = 1000
+        while (true) {
+            val payload = httpGetTextWithHeaders(
+                url = "$BASE_URL/users/hidden/dropped?type=show&page=$page&limit=$limit",
+                headers = headers,
+            )
+            val items = json.decodeFromString<List<TraktHiddenItem>>(payload)
+            if (items.isEmpty()) break
+            items.forEach { item ->
+                val ids = item.show?.ids ?: return@forEach
+                ids.imdb
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let(allIds::add)
+                ids.tmdb
+                    ?.let { allIds.add("tmdb:$it") }
+                ids.trakt
+                    ?.let { allIds.add("trakt:$it") }
+            }
+            if (items.size < limit) break
+            page++
+        }
+        allIds
     }
 
     private suspend fun fetchWatchedShowSeedEntries(
@@ -847,6 +882,13 @@ private data class TraktWatchedShowEpisodeSeed(
     val season: Int,
     val episode: Int,
     val watchedAt: Long,
+)
+
+@Serializable
+private data class TraktHiddenItem(
+    @SerialName("hidden_at") val hiddenAt: String? = null,
+    @SerialName("type") val type: String? = null,
+    @SerialName("show") val show: TraktMedia? = null,
 )
 
 @Serializable


### PR DESCRIPTION
## Summary

<!-- What changed in this PR? -->

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

<!-- Why this change is needed. Explain the user-visible bug, regression, maintenance need, docs error, or approved request. -->
Currently when retrieving continue watching data from Trakt we are fetching all started series regardless if they have been dropped or not, this is incorrectly returning lots of shows that should not be in continue watching. 

The Android TV app is already filtering these dropped shows from continue watching therefore creating a mismatch between the TV and mobile app. For example on ATV I correctly have 3 shows in continue watching (matching the CW on the Trakt app itself), however on the mobile app it is showing 15+ series, 12 of which I no longer want to continue so dropped on Trakt.

## Issue or approval

<!-- Required. Link the bug issue or approved feature request. For docs/translation/maintenance with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / Approved in #456 / No linked issue: typo-only docs fix. -->
Fixes [#1015](https://github.com/NuvioMedia/NuvioMobile/issues/1015)

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->
Continue watching bug fix only - no UI changes or other behaviour tweaks

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is docs/translation-only. -->
Tested on emulator using own Trakt login, confirmed the continue watching now matches Android TV and Trakt.
Also tested on android phone and same result.
If no dropped shows are found, will retrieve continue watching as before with no issues.
Uses same API call and logic as Android TV app to fetch and filter out dropped shows.

## Screenshots / Video (UI changes only)

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None.

## Linked issues

<!-- Required for bug fixes, UI glitch fixes, behavior fixes, and approved changes. For docs/translation/maintenance with no issue, write: No linked issue - reason. -->
[#1015](https://github.com/NuvioMedia/NuvioMobile/issues/1015)
