### PR TITLE
fix(player): preserve hls stream type

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -68,11 +68,32 @@ import java.net.URL
 
 private const val TAG = "NuvioPlayer"
 
+private fun buildPlaybackMediaItem(
+    url: String,
+    streamType: String?,
+): MediaItem {
+    val isHls = streamType.equals("hls", ignoreCase = true) || url.isExplicitHlsPlaylistUrl()
+    return MediaItem.Builder()
+        .setUri(url)
+        .apply {
+            if (isHls) {
+                setMimeType(MimeTypes.APPLICATION_M3U8)
+            }
+        }
+        .build()
+}
+
+private fun String.isExplicitHlsPlaylistUrl(): Boolean =
+    endsWith(".m3u8", ignoreCase = true) ||
+        contains(".m3u8?", ignoreCase = true) ||
+        contains(".m3u8#", ignoreCase = true)
+
 @androidx.annotation.OptIn(UnstableApi::class)
 @Composable
 actual fun PlatformPlayerSurface(
     sourceUrl: String,
     sourceAudioUrl: String?,
+    streamType: String?,
     sourceHeaders: Map<String, String>,
     sourceResponseHeaders: Map<String, String>,
     useYoutubeChunkedPlayback: Boolean,
@@ -108,6 +129,7 @@ actual fun PlatformPlayerSurface(
     val playerSourceKey = listOf(
         sourceUrl,
         sourceAudioUrl.orEmpty(),
+        streamType.orEmpty(),
         sanitizedSourceHeaders,
         sanitizedSourceResponseHeaders,
         useYoutubeChunkedPlayback,
@@ -143,7 +165,7 @@ actual fun PlatformPlayerSurface(
         if (!sourceAudioUrl.isNullOrBlank()) {
             val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory)
             val videoSource = mediaSourceFactory.createMediaSource(videoMediaItem)
-            val audioSource = mediaSourceFactory.createMediaSource(MediaItem.fromUri(sourceAudioUrl))
+            val audioSource = mediaSourceFactory.createMediaSource(buildPlaybackMediaItem(sourceAudioUrl, null))
             val mergedSource = MergingMediaSource(videoSource, audioSource)
             if (startPositionMs != null) {
                 setMediaSource(mergedSource, startPositionMs.coerceAtLeast(0L))
@@ -160,6 +182,7 @@ actual fun PlatformPlayerSurface(
     val exoPlayer = remember(
         sourceUrl,
         sourceAudioUrl,
+        streamType,
         sanitizedSourceHeaders,
         sanitizedSourceResponseHeaders,
         useYoutubeChunkedPlayback,
@@ -223,7 +246,7 @@ actual fun PlatformPlayerSurface(
 
         player.apply {
             setPlaybackMediaItem(
-                videoMediaItem = MediaItem.fromUri(sourceUrl),
+                videoMediaItem = buildPlaybackMediaItem(sourceUrl, streamType),
                 startPositionMs = fallbackStartPositionMs,
             )
             prepare()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -1952,6 +1952,7 @@ private fun MainAppContent(
                         val playerLaunch = PlayerLaunch(
                                 title = launch.title,
                                 sourceUrl = sourceUrl,
+                                streamType = stream.streamType,
                                 sourceHeaders = sanitizePlaybackHeaders(stream.behaviorHints.proxyHeaders?.request),
                                 sourceResponseHeaders = sanitizePlaybackResponseHeaders(stream.behaviorHints.proxyHeaders?.response),
                                 logo = launch.logo,
@@ -2076,6 +2077,7 @@ private fun MainAppContent(
                         val playerLaunch = PlayerLaunch(
                             title = launch.title,
                             sourceUrl = sourceUrl,
+                            streamType = stream.streamType,
                             sourceHeaders = sanitizePlaybackHeaders(stream.behaviorHints.proxyHeaders?.request),
                             sourceResponseHeaders = sanitizePlaybackResponseHeaders(stream.behaviorHints.proxyHeaders?.response),
                             logo = launch.logo,
@@ -2234,6 +2236,7 @@ private fun MainAppContent(
                         title = launch.title,
                         sourceUrl = launch.sourceUrl,
                         sourceAudioUrl = launch.sourceAudioUrl,
+                        streamType = launch.streamType,
                         sourceHeaders = launch.sourceHeaders,
                         sourceResponseHeaders = launch.sourceResponseHeaders,
                         logo = launch.logo,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
@@ -283,6 +283,7 @@ internal object MetaDetailsParser {
                 name = obj.string("name"),
                 description = obj.string("description") ?: obj.string("title"),
                 url = url,
+                streamType = obj.string("type"),
                 infoHash = infoHash,
                 fileIdx = obj.int("fileIdx"),
                 externalUrl = externalUrl,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
@@ -55,6 +55,7 @@ internal fun sanitizePlaybackResponseHeaders(headers: Map<String, String>?): Map
 expect fun PlatformPlayerSurface(
     sourceUrl: String,
     sourceAudioUrl: String? = null,
+    streamType: String? = null,
     sourceHeaders: Map<String, String> = emptyMap(),
     sourceResponseHeaders: Map<String, String> = emptyMap(),
     useYoutubeChunkedPlayback: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerModels.kt
@@ -23,6 +23,7 @@ data class PlayerLaunch(
     val title: String,
     val sourceUrl: String,
     val sourceAudioUrl: String? = null,
+    val streamType: String? = null,
     val sourceHeaders: Map<String, String> = emptyMap(),
     val sourceResponseHeaders: Map<String, String> = emptyMap(),
     val logo: String? = null,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreen.kt
@@ -153,6 +153,7 @@ fun PlayerScreen(
     title: String,
     sourceUrl: String,
     sourceAudioUrl: String? = null,
+    streamType: String? = null,
     sourceHeaders: Map<String, String> = emptyMap(),
     sourceResponseHeaders: Map<String, String> = emptyMap(),
     providerName: String,
@@ -239,6 +240,7 @@ fun PlayerScreen(
         // Active playback state (mutable to support source/episode switching)
         var activeSourceUrl by rememberSaveable { mutableStateOf(sourceUrl) }
         var activeSourceAudioUrl by rememberSaveable { mutableStateOf(sourceAudioUrl) }
+        var activeStreamType by rememberSaveable { mutableStateOf(streamType) }
         var activeSourceHeaders by remember(sourceUrl, sourceHeaders) {
             mutableStateOf(sanitizePlaybackHeaders(sourceHeaders))
         }
@@ -1257,6 +1259,7 @@ fun PlayerScreen(
             )
             activeSourceUrl = p2pSentinelUrl(infoHash, stream.fileIdx)
             activeSourceAudioUrl = null
+            activeStreamType = null
             activeSourceHeaders = emptyMap()
             activeSourceResponseHeaders = emptyMap()
             activeTorrentInfoHash = infoHash
@@ -1315,6 +1318,7 @@ fun PlayerScreen(
             )
             activeSourceUrl = p2pSentinelUrl(infoHash, stream.fileIdx)
             activeSourceAudioUrl = null
+            activeStreamType = null
             activeSourceHeaders = emptyMap()
             activeSourceResponseHeaders = emptyMap()
             activeTorrentInfoHash = infoHash
@@ -1363,7 +1367,10 @@ fun PlayerScreen(
                 return
             }
             val url = stream.playableDirectUrl ?: return
-            if (url == activeSourceUrl) return
+            if (url == activeSourceUrl) {
+                activeStreamType = stream.streamType
+                return
+            }
             val currentPositionMs = playbackSnapshot.positionMs.coerceAtLeast(0L)
             flushWatchProgress()
             stopActiveP2pStream()
@@ -1390,6 +1397,7 @@ fun PlayerScreen(
             }
             activeSourceUrl = url
             activeSourceAudioUrl = null
+            activeStreamType = stream.streamType
             activeSourceHeaders = sanitizePlaybackHeaders(stream.behaviorHints.proxyHeaders?.request)
             activeSourceResponseHeaders = sanitizePlaybackResponseHeaders(stream.behaviorHints.proxyHeaders?.response)
             activeStreamTitle = stream.streamLabel
@@ -1478,6 +1486,7 @@ fun PlayerScreen(
             }
             activeSourceUrl = url
             activeSourceAudioUrl = null
+            activeStreamType = stream.streamType
             activeSourceHeaders = sanitizePlaybackHeaders(stream.behaviorHints.proxyHeaders?.request)
             activeSourceResponseHeaders = sanitizePlaybackResponseHeaders(stream.behaviorHints.proxyHeaders?.response)
             activeStreamTitle = stream.streamLabel
@@ -1525,6 +1534,7 @@ fun PlayerScreen(
 
             activeSourceUrl = localFileUri
             activeSourceAudioUrl = null
+            activeStreamType = null
             activeSourceHeaders = emptyMap()
             activeSourceResponseHeaders = emptyMap()
             activeStreamTitle = downloadItem.streamTitle.ifBlank {
@@ -1904,7 +1914,7 @@ fun PlayerScreen(
             setSubtitleDelay(newDelayMs)
         }
 
-        LaunchedEffect(activeSourceUrl, activeSourceAudioUrl, activeSourceHeaders, activeSourceResponseHeaders) {
+        LaunchedEffect(activeSourceUrl, activeSourceAudioUrl, activeStreamType, activeSourceHeaders, activeSourceResponseHeaders) {
             errorMessage = null
             playerController = null
             playerControllerSourceUrl = null
@@ -2310,7 +2320,7 @@ fun PlayerScreen(
             }
         }
 
-        DisposableEffect(playbackSession.videoId, activeSourceUrl, activeSourceAudioUrl) {
+        DisposableEffect(playbackSession.videoId, activeSourceUrl, activeSourceAudioUrl, activeStreamType) {
             onDispose {
                 flushWatchProgress()
             }
@@ -2477,6 +2487,7 @@ fun PlayerScreen(
                 PlatformPlayerSurface(
                     sourceUrl = playerSurfaceSourceUrl,
                     sourceAudioUrl = activeSourceAudioUrl,
+                    streamType = activeStreamType,
                     sourceHeaders = activeSourceHeaders,
                     sourceResponseHeaders = activeSourceResponseHeaders,
                     modifier = Modifier.fillMaxSize(),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerStreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerStreamsRepository.kt
@@ -448,6 +448,7 @@ private fun PluginRuntimeResult.toStreamItem(scraper: PluginScraper): StreamItem
         name = name ?: title,
         description = subtitleParts.joinToString(" • ").ifBlank { null },
         url = url,
+        streamType = type,
         infoHash = infoHash,
         addonName = scraper.name,
         addonId = "plugin:${scraper.id}",

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamModels.kt
@@ -10,6 +10,7 @@ data class StreamItem(
     val title: String? = null,
     val description: String? = null,
     val url: String? = null,
+    val streamType: String? = null,
     val infoHash: String? = null,
     val fileIdx: Int? = null,
     val externalUrl: String? = null,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamParser.kt
@@ -40,6 +40,7 @@ object StreamParser {
                 title = obj.string("title"),
                 description = obj.string("description") ?: obj.string("title"),
                 url = url,
+                streamType = obj.string("type"),
                 infoHash = infoHash,
                 fileIdx = obj.int("fileIdx"),
                 externalUrl = externalUrl,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
@@ -910,6 +910,7 @@ private fun PluginRuntimeResult.toStreamItem(
         name = name ?: title,
         description = subtitleParts.joinToString(" • ").ifBlank { null },
         url = url,
+        streamType = type,
         infoHash = infoHash,
         sourceName = scraper.name,
         addonName = addonName,

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerEngine.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerEngine.ios.kt
@@ -27,6 +27,7 @@ private const val TAG = "NuvioiOSPlayer"
 actual fun PlatformPlayerSurface(
     sourceUrl: String,
     sourceAudioUrl: String?,
+    streamType: String?,
     sourceHeaders: Map<String, String>,
     sourceResponseHeaders: Map<String, String>,
     useYoutubeChunkedPlayback: Boolean,


### PR DESCRIPTION
## Summary

Preserves the addon-provided stream type through stream parsing, player launch, and the platform player surface.

On Android, streams declared as `type: "hls"` are now created with `MimeTypes.APPLICATION_M3U8`, so ExoPlayer can handle HLS streams even when the URL does not visibly end with `.m3u8`.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Some addons can return valid HLS streams with `type: "hls"` while using playlist URLs that do not expose a `.m3u8` suffix.

The Android player previously built the media item only from the URL, so ExoPlayer could fail to infer the HLS media type and playback would not start correctly.

This fix preserves the declared stream type and applies the HLS MIME type on Android when appropriate.

## Issue or approval

Fixes #1244

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This only preserves and uses the existing stream type metadata for playback.

It does not add new UI, new settings, new dependencies, caching changes, source-selection changes, or broad media-type heuristics. Non-HLS streams continue to use the existing MediaItem behavior unless the URL explicitly contains `.m3u8`.

## Testing

- Ran `git diff --check`.
- Ran `./gradlew :composeApp:compileCommonMainKotlinMetadata` successfully with JDK 17.
- Attempted Android Kotlin compilation with `:composeApp:compileFullDebugKotlinAndroid` and `:composeApp:compilePlaystoreDebugKotlinAndroid`, but this local machine does not have Android SDK configured, so Gradle stops before Android compilation with `SDK location not found`.

Manual validation needed on an Android device/build:
- Play an addon-declared HLS stream with `type: "hls"` and a URL without a visible `.m3u8` suffix.
- Play a normal non-HLS stream to verify existing behavior is unchanged.
- Switch between streams during playback to verify the active stream type does not leak between sources.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1244