### PR TITLE
fix(player): respect stream user agent headers

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerPlaybackNetworking.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerPlaybackNetworking.kt
@@ -63,7 +63,9 @@ internal object PlayerPlaybackNetworking {
         val mergedHeaders = DEFAULT_STREAM_HEADERS + defaultHeaders
         return OkHttpDataSource.Factory(playbackHttpClient).apply {
             setDefaultRequestProperties(mergedHeaders)
-            setUserAgent(DEFAULT_USER_AGENT)
+            if (defaultHeaders.none { it.key.equals("User-Agent", ignoreCase = true) }) {
+                setUserAgent(DEFAULT_USER_AGENT)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Respects stream-provided `User-Agent` headers during Android playback.

The Android player now only applies the default player user agent when the stream does not already provide its own `User-Agent` header.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Some streams require a specific `User-Agent` header to be accepted by the server.

The Android player previously set its default user agent even when the stream already provided a `User-Agent` header. This could cause playback requests to use the wrong user agent and fail.

This fix preserves stream-provided request headers by only applying the default user agent when no `User-Agent` is present.

## Issue or approval

Fixes #1246

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This only changes Android playback header handling for streams that already provide a `User-Agent`.

It does not add new headers, change UI, change stream selection, add settings, add dependencies, or alter request headers other than avoiding the default user agent override when a stream-specific `User-Agent` exists.

## Testing

- Ran `git diff --check`.
- Reviewed the Android playback data source setup to confirm the default user agent is still applied when no stream `User-Agent` is provided.
- Verified the change is limited to `PlayerPlaybackNetworking.kt`.

Manual validation needed on an Android device/build:
- Play a stream that provides a required custom `User-Agent` header.
- Play a normal stream without a custom `User-Agent` to confirm the default user agent is still used.
- Confirm playback requests are not rejected by hosts that require the stream-provided user agent.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1246