### PR TITLE
fix(ios): restore mpv muted bridge

### DIFF
--- a/iosApp/iosApp/Player/MPVPlayerBridge.swift
+++ b/iosApp/iosApp/Player/MPVPlayerBridge.swift
@@ -60,6 +60,7 @@ final class MPVPlayerBridgeImpl: NSObject, NuvioPlayerBridge {
         )
     }
     func setPlaybackSpeed(speed: Float) { playerVC?.setSpeed(speed) }
+    func setMuted(muted: Bool) { playerVC?.setMuted(muted) }
     func setResizeMode(mode: Int32) { playerVC?.setResize(Int(mode)) }
 
     // Audio tracks
@@ -515,6 +516,11 @@ final class MPVPlayerViewController: UIViewController {
         guard mpv != nil else { return }
         var s = Double(speed)
         mpv_set_property(mpv, "speed", MPV_FORMAT_DOUBLE, &s)
+    }
+
+    func setMuted(_ muted: Bool) {
+        guard mpv != nil else { return }
+        setStringProperty("mute", muted ? "yes" : "no")
     }
 
     func setResize(_ mode: Int) {


### PR DESCRIPTION
## Summary

Restore the missing iOS MPV mute bridge so the player can actually apply mute/unmute state again.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The iOS player bridge was missing the mute wiring, so mute/unmute state was not being propagated correctly to MPV.

This breaks a basic playback control and leaves the iOS player behavior inconsistent with the rest of the app.

## Issue or approval

Fixes #1260.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This PR only restores the iOS mute bridge in the MPV player.

It does not change:
- playback UI layout
- other player controls
- Android behavior
- source selection or stream logic

## Testing

- Built the iOS app successfully with Xcode.
- Installed and launched the app on the booted iOS simulator.
- Manually verified the project compiles with the mute bridge restored.
- Verified `git diff --check`.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

#1260