### PR TITLE
Auto-play next episode for external players

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/MainActivity.kt
@@ -27,6 +27,7 @@ import com.nuvio.app.features.notifications.EpisodeReleaseNotificationPlatform
 import com.nuvio.app.features.notifications.EpisodeReleaseNotificationsStorage
 import com.nuvio.app.features.player.PlayerSettingsStorage
 import com.nuvio.app.features.player.PlayerTrackPreferenceStorage
+import com.nuvio.app.features.player.PendingExternalPlaybackStorage
 import com.nuvio.app.features.player.ExternalPlayerPlatform
 import com.nuvio.app.features.player.PlayerPictureInPictureManager
 import com.nuvio.app.features.p2p.P2pSettingsStorage
@@ -97,6 +98,7 @@ class MainActivity : AppCompatActivity() {
         StreamLinkCacheStorage.initialize(applicationContext)
         StreamBadgeSettingsStorage.initialize(applicationContext)
         BingeGroupCacheStorage.initialize(applicationContext)
+        PendingExternalPlaybackStorage.initialize(applicationContext)
         PluginStorage.initialize(applicationContext)
         CollectionMobileSettingsStorage.initialize(applicationContext)
         CollectionStorage.initialize(applicationContext)

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PendingExternalPlaybackStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PendingExternalPlaybackStorage.android.kt
@@ -1,0 +1,25 @@
+package com.nuvio.app.features.player
+
+import android.content.Context
+import android.content.SharedPreferences
+
+actual object PendingExternalPlaybackStorage {
+    private const val preferencesName = "nuvio_pending_external_playback"
+    private const val key = "pending"
+
+    private var preferences: SharedPreferences? = null
+
+    fun initialize(context: Context) {
+        preferences = context.getSharedPreferences(preferencesName, Context.MODE_PRIVATE)
+    }
+
+    actual fun load(): String? = preferences?.getString(key, null)
+
+    actual fun save(value: String) {
+        preferences?.edit()?.putString(key, value)?.apply()
+    }
+
+    actual fun clear() {
+        preferences?.edit()?.remove(key)?.apply()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -3,8 +3,10 @@ package com.nuvio.app
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionLayout
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
+import coil3.compose.AsyncImage
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
 import androidx.compose.animation.togetherWith
@@ -124,6 +126,9 @@ import com.nuvio.app.features.details.MetaDetailsScreen
 import com.nuvio.app.features.details.MetaPerson
 import com.nuvio.app.features.details.PersonDetailScreen
 import com.nuvio.app.features.details.TmdbEntityBrowseScreen
+import com.nuvio.app.features.details.nextReleasedEpisodeAfter
+import com.nuvio.app.features.watchprogress.CurrentDateProvider
+import co.touchlab.kermit.Logger
 import com.nuvio.app.features.tmdb.TmdbEntityKind
 import com.nuvio.app.features.home.HomeCatalogSection
 import com.nuvio.app.features.home.HomeScreen
@@ -139,6 +144,9 @@ import com.nuvio.app.features.notifications.EpisodeReleaseNotificationsRepositor
 import com.nuvio.app.features.p2p.P2pConsentDialog
 import com.nuvio.app.features.p2p.P2pSettingsRepository
 import com.nuvio.app.features.player.PlayerLaunch
+import com.nuvio.app.features.player.PendingExternalPlayback
+import com.nuvio.app.features.player.PendingExternalPlaybackRepository
+import com.nuvio.app.features.player.toPendingExternalPlayback
 import com.nuvio.app.features.player.PlayerLaunchStore
 import com.nuvio.app.features.player.PlayerRoute
 import com.nuvio.app.features.player.PlayerScreen
@@ -799,6 +807,10 @@ private fun MainAppContent(
     var profileSwitchLoading by remember { mutableStateOf(false) }
     var resumePromptItem by remember { mutableStateOf<ContinueWatchingItem?>(null) }
     var lastExternalPlayerLaunch by remember { mutableStateOf<PlayerLaunch?>(null) }
+    // Set when an external episode finishes; the effect below resolves + launches the next one.
+    var pendingExternalAutoNext by remember { mutableStateOf<PendingExternalPlayback?>(null) }
+    // Drives the "Loading next episode" loader during the auto-next hand-off.
+    var externalAutoNextOverlay by remember { mutableStateOf<PendingExternalPlayback?>(null) }
     val launchExternalPlayer = rememberExternalPlayerLauncher { result ->
         if (result != null && result.positionMs > 0L) {
             coroutineScope.launch {
@@ -859,6 +871,28 @@ private fun MainAppContent(
                     )
                 }
             }
+            // Resolve the finished item from memory, or from disk if the player killed our
+            // process (its result is still redelivered). Flag completion (natural end or ~90%).
+            val finishedSnapshot = lastExternalPlayerLaunch?.toPendingExternalPlayback()
+                ?: PendingExternalPlaybackRepository.load()
+            if (finishedSnapshot?.seasonNumber != null && finishedSnapshot.episodeNumber != null) {
+                val resultDurationMs = result.durationMs
+                val completed = !result.endedByUser ||
+                    (
+                        resultDurationMs != null && resultDurationMs > 0L &&
+                            result.positionMs >= (resultDurationMs * 0.9).toLong()
+                        )
+                if (completed) {
+                    Logger.withTag("ExtAutoNext").i {
+                        "external episode finished S${finishedSnapshot.seasonNumber}E${finishedSnapshot.episodeNumber} " +
+                            "endedByUser=${result.endedByUser} recovered=${lastExternalPlayerLaunch == null}"
+                    }
+                    externalAutoNextOverlay = finishedSnapshot
+                    pendingExternalAutoNext = finishedSnapshot
+                }
+            }
+            // Consumed (or not a completion) — drop the persisted snapshot.
+            PendingExternalPlaybackRepository.clear()
         }
     }
     val continueWatchingPreferencesUiState by remember {
@@ -905,6 +939,10 @@ private fun MainAppContent(
 
         suspend fun openExternalPlayback(launch: PlayerLaunch): Boolean {
             lastExternalPlayerLaunch = launch
+            // A player is launching and will cover the screen — drop the hand-off loader.
+            externalAutoNextOverlay = null
+            // Persist so auto-next survives the player killing our process.
+            PendingExternalPlaybackRepository.save(launch)
 
             // Persist binge group for subsequent episode plays (same as internal player)
             val bingeGroup = launch.bingeGroup
@@ -1087,6 +1125,73 @@ private fun MainAppContent(
             navController.navigate(
                 StreamRoute(launchId = streamLaunchId),
             )
+        }
+
+        // Auto-play next episode after an external episode finishes: resolve the next
+        // episode and route it through the normal play path (reusing stream auto-play ->
+        // external relaunch). Gated by the same setting as the internal player.
+        LaunchedEffect(pendingExternalAutoNext) {
+            val finished = pendingExternalAutoNext ?: return@LaunchedEffect
+            pendingExternalAutoNext = null
+            val log = Logger.withTag("ExtAutoNext")
+            if (!playerSettingsUiState.streamAutoPlayNextEpisodeEnabled) {
+                log.i { "auto-play next episode OFF; skipping" }
+                externalAutoNextOverlay = null
+                return@LaunchedEffect
+            }
+            val metaType = finished.parentMetaType
+            val metaId = finished.parentMetaId
+            val seasonNumber = finished.seasonNumber
+            val episodeNumber = finished.episodeNumber
+            if (seasonNumber == null || episodeNumber == null || metaType.isBlank() || metaId.isBlank()) {
+                externalAutoNextOverlay = null
+                return@LaunchedEffect
+            }
+
+            val meta = MetaDetailsRepository.fetch(type = metaType, id = metaId)
+            if (meta == null) {
+                log.i { "could not load meta for $metaId; skipping" }
+                externalAutoNextOverlay = null
+                return@LaunchedEffect
+            }
+            val nextEpisode = meta.nextReleasedEpisodeAfter(
+                seasonNumber = seasonNumber,
+                episodeNumber = episodeNumber,
+                todayIsoDate = CurrentDateProvider.todayIsoDate(),
+            )
+            if (nextEpisode == null) {
+                log.i { "no next episode after S${seasonNumber}E$episodeNumber for $metaId" }
+                externalAutoNextOverlay = null
+                return@LaunchedEffect
+            }
+            log.i { "next episode resolved S${nextEpisode.season}E${nextEpisode.episode} videoId=${nextEpisode.id}; launching" }
+
+            launchPlaybackWithDownloadPreference(
+                type = finished.contentType ?: metaType,
+                videoId = nextEpisode.id,
+                parentMetaId = metaId,
+                parentMetaType = metaType,
+                title = finished.title,
+                logo = finished.logo,
+                poster = finished.poster,
+                background = finished.background,
+                seasonNumber = nextEpisode.season,
+                episodeNumber = nextEpisode.episode,
+                episodeTitle = nextEpisode.title,
+                episodeThumbnail = nextEpisode.thumbnail,
+                pauseDescription = finished.pauseDescription,
+                resumePositionMs = null,
+                resumeProgressFraction = null,
+                manualSelection = false,
+                startFromBeginning = true,
+            )
+
+            // Safety net: normally cleared when the next player launches, but Manual mode
+            // waits for the user, so don't leave the loader stuck.
+            kotlinx.coroutines.delay(20_000)
+            if (externalAutoNextOverlay === finished) {
+                externalAutoNextOverlay = null
+            }
         }
 
         val onPlay: (String, String, String, String, String, String?, String?, String?, Int?, Int?, String?, String?, String?, Long?) -> Unit =
@@ -2292,6 +2397,7 @@ private fun MainAppContent(
                                 initialPositionMs = request.resumePositionMs,
                             )
                             lastExternalPlayerLaunch = playerLaunch
+                            PendingExternalPlaybackRepository.save(playerLaunch)
                             val intentResult = ExternalPlayerPlatform.buildIntent(
                                 request = request,
                                 playerId = playerSettingsUiState.externalPlayerId,
@@ -2504,6 +2610,46 @@ private fun MainAppContent(
                         },
                     )
                 }
+                }
+            }
+
+            // Loader covering the auto-next hand-off (app cold-start + next-source resolution).
+            AnimatedVisibility(
+                visible = externalAutoNextOverlay != null,
+                enter = fadeIn(animationSpec = tween(250)),
+                exit = fadeOut(animationSpec = tween(200)),
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                val overlayLogo = externalAutoNextOverlay?.logo
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = 0.92f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                    ) {
+                        if (!overlayLogo.isNullOrBlank()) {
+                            AsyncImage(
+                                model = overlayLogo,
+                                contentDescription = null,
+                                modifier = Modifier.height(48.dp),
+                                contentScale = ContentScale.Fit,
+                            )
+                        }
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(32.dp),
+                            color = Color.White,
+                            strokeWidth = 2.5.dp,
+                        )
+                        Text(
+                            text = "Loading next episode…",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = Color.White.copy(alpha = 0.8f),
+                        )
+                    }
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PendingExternalPlayback.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PendingExternalPlayback.kt
@@ -1,0 +1,64 @@
+package com.nuvio.app.features.player
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Snapshot of an external playback launch, persisted so auto-play-next survives the
+ * player killing our process. Holds only what's needed to resolve + launch the next episode.
+ */
+@Serializable
+data class PendingExternalPlayback(
+    val parentMetaId: String,
+    val parentMetaType: String,
+    val contentType: String?,
+    val title: String,
+    val logo: String?,
+    val poster: String?,
+    val background: String?,
+    val seasonNumber: Int?,
+    val episodeNumber: Int?,
+    val pauseDescription: String?,
+)
+
+fun PlayerLaunch.toPendingExternalPlayback(): PendingExternalPlayback =
+    PendingExternalPlayback(
+        parentMetaId = parentMetaId,
+        parentMetaType = parentMetaType,
+        contentType = contentType,
+        title = title,
+        logo = logo,
+        poster = poster,
+        background = background,
+        seasonNumber = seasonNumber,
+        episodeNumber = episodeNumber,
+        pauseDescription = pauseDescription,
+    )
+
+/** Platform key-value persistence for the pending external playback snapshot. */
+internal expect object PendingExternalPlaybackStorage {
+    fun load(): String?
+    fun save(value: String)
+    fun clear()
+}
+
+object PendingExternalPlaybackRepository {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun save(launch: PlayerLaunch) {
+        runCatching {
+            PendingExternalPlaybackStorage.save(json.encodeToString(launch.toPendingExternalPlayback()))
+        }
+    }
+
+    fun load(): PendingExternalPlayback? {
+        val raw = PendingExternalPlaybackStorage.load() ?: return null
+        return runCatching { json.decodeFromString<PendingExternalPlayback>(raw) }.getOrNull()
+    }
+
+    fun clear() {
+        runCatching { PendingExternalPlaybackStorage.clear() }
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PendingExternalPlaybackStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PendingExternalPlaybackStorage.ios.kt
@@ -1,0 +1,11 @@
+package com.nuvio.app.features.player
+
+// External auto-play-next is Android-only (iOS external playback is fire-and-forget
+// with no activity result), so persistence is a no-op on iOS.
+actual object PendingExternalPlaybackStorage {
+    actual fun load(): String? = null
+
+    actual fun save(value: String) {}
+
+    actual fun clear() {}
+}


### PR DESCRIPTION
## Summary

Adds auto-play next episode support for **external players**. The internal player already advances to the next episode when one finishes, but external players (mpv, Vimu, MX Player, VLC, etc.) had no equivalent path, so auto-next was unavailable for anyone using one. Routes external playback through the same next-episode flow the internal player uses, gated by the existing "Auto-play next episode" setting (no new toggle).

## PR type

- [x] Approved larger or directional change

## Why

External playback (`App.kt`'s `rememberExternalPlayerLauncher` result handler) only saved progress and stopped, it never resolved a next episode or re-entered the play flow, so binge/auto-next did not work with an external player. This brings external playback to parity with the internal player. Maintainer-requested as the mobile counterpart to the same feature approved for NuvioTV.

## Issue or approval

Maintainer-requested mobile parity for the external auto-next feature approved for NuvioTV (NuvioMedia/NuvioTV#2190, implemented in NuvioMedia/NuvioTV#2198).

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change. <!-- approved directional change; only UI is a "Loading next episode" loader during the hand-off, video below -->
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Internal player behavior unchanged.
- No new user-facing settings, reuses the existing "Auto-play next episode" setting and Auto Stream Selection mode.
- Next-episode resolution reuses the existing `MetaDetails.nextReleasedEpisodeAfter`, no change to that logic.
- iOS: persistence is a no-op (external playback there is fire-and-forget with no result), so behavior is unchanged on iOS.

## Testing

- Device: NVIDIA Shield TV (2019), Android 11. Plus 3 variations of an Android Mobile Emulator. Debug `assembleFullDebug` APK, sideloaded.
- External player: an mpv fork.
- Verified S1E1 -> E2 -> E3 auto-advance; no advance on a manual stop (`end_by=user`).
- Completion detection via `end_by=playback_completion` and the 90% position fallback.
- Verified the external player kills the app process on the Shield and the result is redelivered to the recreated process; the persisted snapshot is recovered and auto-next still fires.
- Verified the "Loading next episode" loader covers the cold-start / source-resolution hand-off.

## Screenshots / Video (UI changes only)

The only UI is a full-screen "Loading next episode" loader shown during the hand-off. _Screen recording to be attached._

## Breaking changes

None.

## Linked issues

NuvioMedia/NuvioTV#2190 (approved feature).