### PR TITLE
fix(iOS): Use VideoToolbox for iOS MPV hardware decoding

### DIFF
--- a/iosApp/iosApp/Player/MPVPlayerBridge.swift
+++ b/iosApp/iosApp/Player/MPVPlayerBridge.swift
@@ -317,7 +317,7 @@ final class MPVPlayerViewController: UIViewController {
         checkError(mpv_set_option_string(mpv, "vo", "gpu-next"))
         checkError(mpv_set_option_string(mpv, "gpu-api", "vulkan"))
         checkError(mpv_set_option_string(mpv, "gpu-context", "moltenvk"))
-        checkError(mpv_set_option_string(mpv, "hwdec", "auto"))
+        checkError(mpv_set_option_string(mpv, "hwdec", "videotoolbox"))
         checkError(mpv_set_option_string(mpv, "audio-channels", "stereo"))
         checkError(mpv_set_option_string(mpv, "audio-fallback-to-null", "yes"))
         checkError(mpv_set_option_string(mpv, "vulkan-swap-mode", "fifo"))
@@ -498,7 +498,7 @@ final class MPVPlayerViewController: UIViewController {
         metalLayer.wantsExtendedDynamicRangeContent = extendedDynamicRange
         guard mpv != nil else { return }
 
-        setStringProperty("hwdec", hardwareDecoder)
+        setStringProperty("hwdec", "videotoolbox")
         setStringProperty("target-colorspace-hint", targetColorspaceHint ? "yes" : "no")
         setStringProperty("tone-mapping", toneMapping)
         setStringProperty("hdr-compute-peak", hdrComputePeak ? "yes" : "no")


### PR DESCRIPTION
## Summary

<!-- What changed in this PR? -->
This PR updates the iOS MPV hardware decoding configuration to use VideoToolbox instead of relying on MPV's automatic hardware decoder selection.

Previously, the bridge used:
```
checkError(mpv_set_option_string(mpv, "hwdec", "auto"))
```
and later applied the selected hardware decoder directly through:
```
setStringProperty("hwdec", hardwareDecoder)
```

On iOS, `hwdec=auto` can incorrectly fall back to a Vulkan hardware decoding path. This is not supported on Apple devices through MoltenVK, and the Xcode console shows errors such as:
```
[MPV][ffmpeg/video] error: hevc: Device does not support the VK_KHR_video_decode_queue extension!
```

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

<!-- Why this change is needed. Explain the user-visible bug, regression, maintenance need, docs error, or approved request. -->
VideoToolbox is Apple's native hardware decoding framework for iOS. It is the correct decoder path for H.264/HEVC playback on Apple platforms.

Vulkan/MoltenVK is still used for rendering output, but it should not be selected as the hardware video decoder. When MPV attempts Vulkan video decoding, playback may produce decode errors and fallback to CPU-based decoding which potentially leads to inefficient playback, excessive battery drain, and severe thermal throttling on iOS devices, especially when playing high-resolution HEVC or H.264 streams.

Using VideoToolbox ensures that iOS playback uses the platform-supported hardware decoder while continuing to render through the existing MPV/MoltenVK output pipeline.

## Issue or approval

<!-- Required. Link the bug issue or approved feature request. For docs/translation/maintenance with no issue, explain why no issue is needed. -->
Fixes #1272

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->
This PR only change `hwdec=videotoolbox` in `MPVPlayerBridge.swift`

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is docs/translation-only. -->
Tested on iOS by playing video through the in-app MPV player.
Before this change, the console showed:
```
[MPV][ffmpeg/video] error: hevc: Device does not support the VK_KHR_video_decode_queue extension!
```
After forcing VideoToolbox, MPV no longer attempts the unsupported Vulkan video decode path during playback

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->
Not a UI change

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None

## Linked issues

<!-- Required for bug fixes, UI glitch fixes, behavior fixes, and approved changes. For docs/translation/maintenance with no issue, write: No linked issue - reason. -->
Fix #1272