### PR TITLE
Modify gesture sensitivity and top edge exclusion

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreen.kt
@@ -104,7 +104,10 @@ private const val PlayerDoubleTapSeekResetDelayMs = 800L
 private const val PlayerLockedOverlayDurationMs = 2_000L
 private const val PlayerLeftGestureBoundary = 0.4f
 private const val PlayerRightGestureBoundary = 0.6f
-private const val PlayerVerticalGestureSensitivity = 1f
+private const val PlayerVerticalGestureSensitivity = 0.75f
+/** Fraction of screen height from the top where vertical brightness/volume gestures are suppressed
+ *  to let the system notification shade swipe through. */
+private const val PlayerTopEdgeExclusionFraction = 0.12f
 private const val PlayerSeekProgressSyncDebounceMs = 700L
 private const val P2pInitialPreloadTargetBytes = 5_242_880L
 /** Hard ceiling for next-episode stream search to prevent hanging forever. */
@@ -2368,7 +2371,9 @@ fun PlayerScreen(
                         val controller = gestureController
                         val width = size.width.toFloat().takeIf { it > 0f } ?: return@awaitEachGesture
                         val height = size.height.toFloat().takeIf { it > 0f } ?: return@awaitEachGesture
+                        val startedInTopEdge = down.position.y < height * PlayerTopEdgeExclusionFraction
                         val region = when {
+                            startedInTopEdge -> null // suppress brightness/volume in top edge so notification shade works
                             down.position.x < width * PlayerLeftGestureBoundary -> PlayerSideGesture.Brightness
                             down.position.x > width * PlayerRightGestureBoundary -> PlayerSideGesture.Volume
                             else -> null
@@ -2429,6 +2434,11 @@ fun PlayerScreen(
                                 }
 
                                 if (gestureMode == null) {
+                                    // If this is a downward swipe from the top edge, abandon
+                                    // gesture tracking so the system notification shade can work.
+                                    if (startedInTopEdge && verticalDominant && totalDy > 0f) {
+                                        break
+                                    }
                                     continue
                                 }
                             }


### PR DESCRIPTION
Adjust vertical gesture sensitivity and add top edge exclusion for brightness/volume gestures.

## Summary

When users swipe down from the top edge of the screen while in fullscreen/immersive player mode, the brightness/volume gesture handler was intercepting the touch before the system insets controller could show the notification shade. This fix does two things:

1. Reduces `PlayerVerticalGestureSensitivity` from `1f` to `0.75f` to require a more deliberate vertical drag before triggering brightness/volume adjustment.
2. Adds `PlayerTopEdgeExclusionFraction = 0.12f` — gestures that start in the top 12% of the screen height are no longer consumed by the brightness/volume handler, allowing the system notification shade swipe to pass through.

Closes: #1282

## PR type

- [x] Reproducible bug fix
- [x] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Swiping down from the top of the screen in fullscreen mode was triggering brightness (left side) or volume (right side) changes instead of revealing the notification shade. The `awaitEachGesture` block in `PlayerScreen.kt` was consuming every downward touch event once `abs(totalDy) > touchSlop`, including touches that originated from the status bar area. Reducing sensitivity and excluding the top edge zone fixes this without affecting normal mid-screen brightness/volume gesture behaviour.

## Issue or approval

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR only modifies constants and gesture detection logic in `PlayerScreen.kt`. It does not touch:
- Playback engine or media session logic
- Any iOS-specific code paths
- Settings UI or user-configurable gesture sensitivity
- Any other screen outside the fullscreen player

## Testing

- Opened fullscreen player on POCO F7 (Android 16)
- Swiped down from top-left edge → notification shade appeared (previously adjusted brightness)
- Swiped down from top-right edge → notification shade appeared (previously adjusted volume)
- Swiped down from mid-screen left → brightness still adjusts correctly
- Swiped down from mid-screen right → volume still adjusts correctly
- Verified no regression in normal brightness/volume gesture behaviour

## Screenshots / Video (UI changes only)

_No visual change — behaviour fix only._

## Breaking changes

None. Sensitivity change is a minor tweak. Top-edge exclusion only suppresses gestures in the system bar region where the notification shade swipe is expected by Android.

## Linked issues

Closes #1282