### PR TITLE
feat(settings): add 'Released / Upcoming (Last released)' sorting mode

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -477,10 +477,10 @@
     <string name="settings_continue_watching_sort_mode_title">Orden de clasificación</string>
     <string name="settings_continue_watching_sort_mode_default">Predeterminado</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Ordenar todos los elementos por fecha reciente</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Estrenados / Próximos</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Elementos estrenados ordenados por último visto, elementos no estrenados por fecha de estreno</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Priorizar nuevos episodios</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Elementos estrenados ordenados por último visto (priorizando nuevos episodios), próximos estrenos por fecha de emisión</string>
+    <string name="settings_continue_watching_sort_mode_streaming">Estrenados / Próximos (Últimos estrenados)</string>
+    <string name="settings_continue_watching_sort_mode_streaming_desc">Elementos estrenados ordenados por fecha de estreno, próximos estrenos por fecha de emisión</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Estrenados / Próximos (Últimos vistos)</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Elementos estrenados ordenados por último visto, próximos estrenos por fecha de emisión</string>
     <string name="settings_continue_watching_section_up_next_behavior">COMPORTAMIENTO DE SIGUIENTE</string>
     <string name="settings_continue_watching_section_visibility">VISIBILIDAD</string>
     <string name="settings_continue_watching_show_description">Mostrar el estante de Seguir viendo en la pantalla de inicio.</string>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -473,6 +473,14 @@
     <string name="settings_continue_watching_resume_prompt_title">Aviso para reanudar al iniciar</string>
     <string name="settings_continue_watching_section_card_style">ESTILO DE TARJETA</string>
     <string name="settings_continue_watching_section_on_launch">AL INICIAR</string>
+    <string name="settings_continue_watching_section_sort_order">ORDEN DE CLASIFICACIÓN</string>
+    <string name="settings_continue_watching_sort_mode_title">Orden de clasificación</string>
+    <string name="settings_continue_watching_sort_mode_default">Predeterminado</string>
+    <string name="settings_continue_watching_sort_mode_default_desc">Ordenar todos los elementos por fecha reciente</string>
+    <string name="settings_continue_watching_sort_mode_streaming">Estrenados / Próximos</string>
+    <string name="settings_continue_watching_sort_mode_streaming_desc">Elementos estrenados ordenados por último visto, elementos no estrenados por fecha de estreno</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Priorizar nuevos episodios</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Elementos estrenados ordenados por último visto (priorizando nuevos episodios), próximos estrenos por fecha de emisión</string>
     <string name="settings_continue_watching_section_up_next_behavior">COMPORTAMIENTO DE SIGUIENTE</string>
     <string name="settings_continue_watching_section_visibility">VISIBILIDAD</string>
     <string name="settings_continue_watching_show_description">Mostrar el estante de Seguir viendo en la pantalla de inicio.</string>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -477,10 +477,10 @@
     <string name="settings_continue_watching_sort_mode_title">Orden de clasificación</string>
     <string name="settings_continue_watching_sort_mode_default">Predeterminado</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Ordenar todos los elementos por fecha reciente</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Estrenados / Próximos (Últimos estrenados)</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Elementos estrenados ordenados por fecha de estreno, próximos estrenos por fecha de emisión</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Estrenados / Próximos (Últimos vistos)</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Elementos estrenados ordenados por último visto, próximos estrenos por fecha de emisión</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released">Estrenados / Próximos (Últimos estrenados)</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released_desc">Elementos estrenados ordenados por fecha de estreno, próximos estrenos por fecha de emisión</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_watched">Estrenados / Próximos (Últimos vistos)</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_watched_desc">Elementos estrenados ordenados por último visto, próximos estrenos por fecha de emisión</string>
     <string name="settings_continue_watching_section_up_next_behavior">COMPORTAMIENTO DE SIGUIENTE</string>
     <string name="settings_continue_watching_section_visibility">VISIBILIDAD</string>
     <string name="settings_continue_watching_show_description">Mostrar el estante de Seguir viendo en la pantalla de inicio.</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -576,8 +576,8 @@
     <string name="settings_continue_watching_sort_mode_title">Ordre de tri</string>
     <string name="settings_continue_watching_sort_mode_default">Par défaut</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Trier tous les éléments par récence</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Style streaming</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Éléments sortis d’abord, à venir à la fin</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released">Style streaming</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released_desc">Éléments sortis d’abord, à venir à la fin</string>
     <string name="settings_continue_watching_section_card_style">STYLE DE CARTE D’AFFICHE</string>
     <string name="settings_continue_watching_section_on_launch">AU DÉMARRAGE</string>
     <string name="settings_continue_watching_section_up_next_behavior">COMPORTEMENT DE LA SUITE</string>

--- a/composeApp/src/commonMain/composeResources/values-id/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-id/strings.xml
@@ -578,8 +578,8 @@
     <string name="settings_continue_watching_sort_mode_title">Urutan Sortir</string>
     <string name="settings_continue_watching_sort_mode_default">Setelan Bawaan</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Urutkan semua item berdasarkan yang terbaru</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Gaya Streaming</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Item yang sudah rilis lebih dulu, yang mendatang di akhir</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released">Gaya Streaming</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released_desc">Item yang sudah rilis lebih dulu, yang mendatang di akhir</string>
     <string name="settings_continue_watching_section_card_style">Gaya Kartu Poster</string>
     <string name="settings_continue_watching_section_on_launch">SAAT DIBUKA</string>
     <string name="settings_continue_watching_section_up_next_behavior">PERILAKU BERIKUTNYA</string>

--- a/composeApp/src/commonMain/composeResources/values-in/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-in/strings.xml
@@ -578,8 +578,8 @@
     <string name="settings_continue_watching_sort_mode_title">Urutan Sortir</string>
     <string name="settings_continue_watching_sort_mode_default">Setelan Bawaan</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Urutkan semua item berdasarkan yang terbaru</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Gaya Streaming</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Item yang sudah rilis lebih dulu, yang mendatang di akhir</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released">Gaya Streaming</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released_desc">Item yang sudah rilis lebih dulu, yang mendatang di akhir</string>
     <string name="settings_continue_watching_section_card_style">Gaya Kartu Poster</string>
     <string name="settings_continue_watching_section_on_launch">SAAT DIBUKA</string>
     <string name="settings_continue_watching_section_up_next_behavior">PERILAKU BERIKUTNYA</string>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -1255,8 +1255,8 @@
   <string name="settings_continue_watching_sort_mode_title">Ordine di ordinamento</string>
   <string name="settings_continue_watching_sort_mode_default">Predefinito</string>
   <string name="settings_continue_watching_sort_mode_default_desc">Ordina tutti gli elementi in base ai più recenti</string>
-  <string name="settings_continue_watching_sort_mode_streaming">Stile streaming</string>
-  <string name="settings_continue_watching_sort_mode_streaming_desc">Prima gli elementi rilasciati, i prossimi in arrivo alla fine</string>
+  <string name="settings_continue_watching_sort_mode_released_upcoming_last_released">Stile streaming</string>
+  <string name="settings_continue_watching_sort_mode_released_upcoming_last_released_desc">Prima gli elementi rilasciati, i prossimi in arrivo alla fine</string>
   <string name="settings_continue_watching_use_episode_thumbnails_description">Prediligi le miniature dell'episodio quando disponibili.</string>
   <string name="settings_continue_watching_use_episode_thumbnails_title">Prediligi miniature episodio in Inizia a guardare</string>
   <string name="settings_integrations_debrid_description">Connetti gli account per i link e l'accesso alla libreria</string>

--- a/composeApp/src/commonMain/composeResources/values-nb/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nb/strings.xml
@@ -562,8 +562,8 @@
     <string name="settings_continue_watching_sort_mode_title">Sorteringsrekkefølge</string>
     <string name="settings_continue_watching_sort_mode_default">Standard</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Sorter alle etter nyhet</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Streaming-stil</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Utgitt først, kommende til slutt</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released">Streaming-stil</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released_desc">Utgitt først, kommende til slutt</string>
     <string name="settings_continue_watching_section_card_style">Plakatstil</string>
     <string name="settings_continue_watching_section_on_launch">VED OPPSTART</string>
     <string name="settings_continue_watching_section_up_next_behavior">NESTE OPPFØRSEL</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -578,8 +578,8 @@
     <string name="settings_continue_watching_sort_mode_title">Kolejność sortowania</string>
     <string name="settings_continue_watching_sort_mode_default">Domyślna</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Sortuj wszystkie elementy według czasu</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Styl streamingowy</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Wydane najpierw, nadchodzące na końcu</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released">Styl streamingowy</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released_desc">Wydane najpierw, nadchodzące na końcu</string>
     <string name="settings_continue_watching_section_card_style">STYL KARTY</string>
     <string name="settings_continue_watching_section_on_launch">PRZY URUCHOMIENIU</string>
     <string name="settings_continue_watching_section_up_next_behavior">ZACHOWANIE NASTĘPNEGO</string>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -568,10 +568,10 @@
     <string name="settings_continue_watching_sort_mode_title">Ordem de ordenação</string>
     <string name="settings_continue_watching_sort_mode_default">Predefinida</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Ordena todos os itens pelos mais recentes</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Lançados / Próximos (Últimos lançados)</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Itens lançados ordenados por data de lançamento, próximos itens por data de exibição</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Lançados / Próximos (Últimos assistidos)</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Itens lançados ordenados pelo último assistido, próximos itens por data de exibição</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released">Lançados / Próximos (Últimos lançados)</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released_desc">Itens lançados ordenados por data de lançamento, próximos itens por data de exibição</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_watched">Lançados / Próximos (Últimos assistidos)</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_watched_desc">Itens lançados ordenados pelo último assistido, próximos itens por data de exibição</string>
     <string name="settings_continue_watching_section_card_style">Estilo dos Cartões de Póster</string>
     <string name="settings_continue_watching_section_on_launch">AO INICIAR</string>
     <string name="settings_continue_watching_section_up_next_behavior">COMPORTAMENTO DO SEGUINTE</string>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -568,8 +568,10 @@
     <string name="settings_continue_watching_sort_mode_title">Ordem de ordenação</string>
     <string name="settings_continue_watching_sort_mode_default">Predefinida</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Ordena todos os itens pelos mais recentes</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Estilo Plataforma de Streaming</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Itens já lançados primeiro, os próximos no fim</string>
+    <string name="settings_continue_watching_sort_mode_streaming">Lançados / Próximos</string>
+    <string name="settings_continue_watching_sort_mode_streaming_desc">Itens lançados ordenados pelo último assistido, itens não lançados por data de lançamento</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Priorizar novos episódios</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Itens lançados ordenados pelo último assistido (priorizando novos episódios), próximos itens por data de exibição</string>
     <string name="settings_continue_watching_section_card_style">Estilo dos Cartões de Póster</string>
     <string name="settings_continue_watching_section_on_launch">AO INICIAR</string>
     <string name="settings_continue_watching_section_up_next_behavior">COMPORTAMENTO DO SEGUINTE</string>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -568,10 +568,10 @@
     <string name="settings_continue_watching_sort_mode_title">Ordem de ordenação</string>
     <string name="settings_continue_watching_sort_mode_default">Predefinida</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Ordena todos os itens pelos mais recentes</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Lançados / Próximos</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Itens lançados ordenados pelo último assistido, itens não lançados por data de lançamento</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Priorizar novos episódios</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Itens lançados ordenados pelo último assistido (priorizando novos episódios), próximos itens por data de exibição</string>
+    <string name="settings_continue_watching_sort_mode_streaming">Lançados / Próximos (Últimos lançados)</string>
+    <string name="settings_continue_watching_sort_mode_streaming_desc">Itens lançados ordenados por data de lançamento, próximos itens por data de exibição</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Lançados / Próximos (Últimos assistidos)</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Itens lançados ordenados pelo último assistido, próximos itens por data de exibição</string>
     <string name="settings_continue_watching_section_card_style">Estilo dos Cartões de Póster</string>
     <string name="settings_continue_watching_section_on_launch">AO INICIAR</string>
     <string name="settings_continue_watching_section_up_next_behavior">COMPORTAMENTO DO SEGUINTE</string>

--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -568,8 +568,8 @@
     <string name="settings_continue_watching_sort_mode_title">Sıralama Düzeni</string>
     <string name="settings_continue_watching_sort_mode_default">Varsayılan</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Tüm içerikleri son izleme zamanına göre sırala</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Yayın Tarzı</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Yayınlanan içerikler önde, yakında çıkacaklar ise sonda yer alır</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released">Yayın Tarzı</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released_desc">Yayınlanan içerikler önde, yakında çıkacaklar ise sonda yer alır</string>
     <string name="settings_continue_watching_section_card_style">KART STİLİ</string>
     <string name="settings_continue_watching_section_on_launch">AÇILIŞTA</string>
     <string name="settings_continue_watching_section_up_next_behavior">SONRAKİ DAVRANIŞI</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -596,10 +596,10 @@
     <string name="settings_continue_watching_sort_mode_title">Sort Order</string>
     <string name="settings_continue_watching_sort_mode_default">Default</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Sort all items by recency</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Streaming Style</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Released items first, upcoming at the end</string>
+    <string name="settings_continue_watching_sort_mode_streaming">Released / Upcoming</string>
+    <string name="settings_continue_watching_sort_mode_streaming_desc">Released items sorted by last watched, unreleased items by release date</string>
     <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Prioritize new episodes</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Streaming Style, but new episodes come first</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Released items sorted by last watched (prioritizing new episodes), upcoming items by air date</string>
     <string name="settings_continue_watching_section_card_style">Poster Card Style</string>
     <string name="settings_continue_watching_section_on_launch">ON LAUNCH</string>
     <string name="settings_continue_watching_section_up_next_behavior">UP NEXT BEHAVIOR</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -596,10 +596,10 @@
     <string name="settings_continue_watching_sort_mode_title">Sort Order</string>
     <string name="settings_continue_watching_sort_mode_default">Default</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Sort all items by recency</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Released / Upcoming</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Released items sorted by last watched, unreleased items by release date</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Prioritize new episodes</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Released items sorted by last watched (prioritizing new episodes), upcoming items by air date</string>
+    <string name="settings_continue_watching_sort_mode_streaming">Released / Upcoming (Last released)</string>
+    <string name="settings_continue_watching_sort_mode_streaming_desc">Released items sorted by release date, upcoming items by air date</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Released / Upcoming (Last watched)</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Released items sorted by last watched, upcoming items by air date</string>
     <string name="settings_continue_watching_section_card_style">Poster Card Style</string>
     <string name="settings_continue_watching_section_on_launch">ON LAUNCH</string>
     <string name="settings_continue_watching_section_up_next_behavior">UP NEXT BEHAVIOR</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -598,6 +598,8 @@
     <string name="settings_continue_watching_sort_mode_default_desc">Sort all items by recency</string>
     <string name="settings_continue_watching_sort_mode_streaming">Streaming Style</string>
     <string name="settings_continue_watching_sort_mode_streaming_desc">Released items first, upcoming at the end</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Prioritize new episodes</string>
+    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Streaming Style, but new episodes come first</string>
     <string name="settings_continue_watching_section_card_style">Poster Card Style</string>
     <string name="settings_continue_watching_section_on_launch">ON LAUNCH</string>
     <string name="settings_continue_watching_section_up_next_behavior">UP NEXT BEHAVIOR</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -596,10 +596,10 @@
     <string name="settings_continue_watching_sort_mode_title">Sort Order</string>
     <string name="settings_continue_watching_sort_mode_default">Default</string>
     <string name="settings_continue_watching_sort_mode_default_desc">Sort all items by recency</string>
-    <string name="settings_continue_watching_sort_mode_streaming">Released / Upcoming (Last released)</string>
-    <string name="settings_continue_watching_sort_mode_streaming_desc">Released items sorted by release date, upcoming items by air date</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new">Released / Upcoming (Last watched)</string>
-    <string name="settings_continue_watching_sort_mode_streaming_prioritize_new_desc">Released items sorted by last watched, upcoming items by air date</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released">Released / Upcoming (Last released)</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_released_desc">Released items sorted by release date, upcoming items by air date</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_watched">Released / Upcoming (Last watched)</string>
+    <string name="settings_continue_watching_sort_mode_released_upcoming_last_watched_desc">Released items sorted by last watched, upcoming items by air date</string>
     <string name="settings_continue_watching_section_card_style">Poster Card Style</string>
     <string name="settings_continue_watching_section_on_launch">ON LAUNCH</string>
     <string name="settings_continue_watching_section_up_next_behavior">UP NEXT BEHAVIOR</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -1078,8 +1078,8 @@ internal fun buildHomeContinueWatchingItems(
 
     return when (sortMode) {
         ContinueWatchingSortMode.DEFAULT -> deduplicated.map(HomeContinueWatchingCandidate::item)
-        ContinueWatchingSortMode.STREAMING_STYLE,
-        ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> applyStreamingStyleSort(deduplicated, todayIsoDate)
+        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
+        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> applyStreamingStyleSort(deduplicated, todayIsoDate)
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -1141,13 +1141,9 @@ private fun applyStreamingStylePrioritizeNewSort(
 
     // Released: prioritize new episodes (isReleaseAlert == true) sorted by last updated epoch, then others
     val sortedReleased = released
-        .sortedWith(
-            compareByDescending<HomeContinueWatchingCandidate> { candidate ->
-                candidate.item.isReleaseAlert
-            }.thenByDescending { candidate ->
-                candidate.lastUpdatedEpochMs
-            }
-        )
+        .sortedByDescending { candidate ->
+            candidate.lastUpdatedEpochMs
+        }
         .map(HomeContinueWatchingCandidate::item)
 
     // Unaired: soonest air date first; unknown dates go to the end

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -1078,8 +1078,8 @@ internal fun buildHomeContinueWatchingItems(
 
     return when (sortMode) {
         ContinueWatchingSortMode.DEFAULT -> deduplicated.map(HomeContinueWatchingCandidate::item)
-        ContinueWatchingSortMode.STREAMING_STYLE -> applyStreamingStyleSort(deduplicated, todayIsoDate)
-        ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> applyStreamingStylePrioritizeNewSort(deduplicated, todayIsoDate)
+        ContinueWatchingSortMode.STREAMING_STYLE,
+        ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> applyStreamingStyleSort(deduplicated, todayIsoDate)
     }
 }
 
@@ -1103,48 +1103,6 @@ private fun applyStreamingStyleSort(
 
     // Released: most recently watched first (already sorted by dedup pass)
     val sortedReleased = released.map(HomeContinueWatchingCandidate::item)
-
-    // Unaired: soonest air date first; unknown dates go to the end
-    val sortedUnreleased = unreleased
-        .sortedWith { a, b ->
-            val dateA = a.item.released?.takeIf { it.isNotBlank() }
-            val dateB = b.item.released?.takeIf { it.isNotBlank() }
-            when {
-                dateA == null && dateB == null -> 0
-                dateA == null -> 1
-                dateB == null -> -1
-                else -> dateA.compareTo(dateB)
-            }
-        }
-        .map(HomeContinueWatchingCandidate::item)
-
-    return sortedReleased + sortedUnreleased
-}
-
-private fun applyStreamingStylePrioritizeNewSort(
-    candidates: List<HomeContinueWatchingCandidate>,
-    todayIsoDate: String,
-): List<ContinueWatchingItem> {
-    val (released, unreleased) = candidates.partition { candidate ->
-        val item = candidate.item
-        if (!item.isNextUp) {
-            true // in-progress items are always "released"
-        } else {
-            val itemReleased = item.released
-            if (itemReleased.isNullOrBlank() || todayIsoDate.isBlank()) {
-                true // no date info → treat as released
-            } else {
-                isReleasedBy(todayIsoDate = todayIsoDate, releasedDate = itemReleased)
-            }
-        }
-    }
-
-    // Released: prioritize new episodes (isReleaseAlert == true) sorted by last updated epoch, then others
-    val sortedReleased = released
-        .sortedByDescending { candidate ->
-            candidate.lastUpdatedEpochMs
-        }
-        .map(HomeContinueWatchingCandidate::item)
 
     // Unaired: soonest air date first; unknown dates go to the end
     val sortedUnreleased = unreleased

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -341,12 +341,7 @@ fun HomeScreen(
                 return@mapNotNull null
             }
             val item = cached.toContinueWatchingItem() ?: return@mapNotNull null
-            val sortTimestamp = if (item.isReleaseAlert) {
-                com.nuvio.app.features.watchprogress.parseReleaseDateToEpochMs(item.released) ?: cached.lastWatched
-            } else {
-                cached.lastWatched
-            }
-            cached.contentId to (sortTimestamp to item)
+            cached.contentId to (cached.lastWatched to item)
         }.toMap()
     }
     val cachedInProgressItems = remember(cachedSnapshots.second, isTraktProgressActive) {
@@ -956,12 +951,7 @@ private suspend fun resolveHomeNextUpCandidate(
         return null
     }
 
-    val sortTimestamp = if (item.isReleaseAlert) {
-        com.nuvio.app.features.watchprogress.parseReleaseDateToEpochMs(item.released) ?: completedEntry.markedAtEpochMs
-    } else {
-        completedEntry.markedAtEpochMs
-    }
-    return contentId to (sortTimestamp to item)
+    return contentId to (completedEntry.markedAtEpochMs to item)
 }
 
 private fun MetaDetails.videoForSeriesAction(action: SeriesPrimaryAction): MetaVideo? {
@@ -1079,13 +1069,14 @@ internal fun buildHomeContinueWatchingItems(
     return when (sortMode) {
         ContinueWatchingSortMode.DEFAULT -> deduplicated.map(HomeContinueWatchingCandidate::item)
         ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
-        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> applyStreamingStyleSort(deduplicated, todayIsoDate)
+        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> applyStreamingStyleSort(deduplicated, todayIsoDate, sortMode)
     }
 }
 
 private fun applyStreamingStyleSort(
     candidates: List<HomeContinueWatchingCandidate>,
     todayIsoDate: String,
+    sortMode: ContinueWatchingSortMode,
 ): List<ContinueWatchingItem> {
     val (released, unreleased) = candidates.partition { candidate ->
         val item = candidate.item
@@ -1101,8 +1092,20 @@ private fun applyStreamingStyleSort(
         }
     }
 
-    // Released: most recently watched first (already sorted by dedup pass)
-    val sortedReleased = released.map(HomeContinueWatchingCandidate::item)
+    // Released: sorted by release date for RELEASED_UPCOMING_LAST_RELEASED (prioritize new episodes),
+    // or by last watched (default/raw candidates order) for RELEASED_UPCOMING_LAST_WATCHED.
+    val sortedReleased = if (sortMode == ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED) {
+        released.sortedByDescending { candidate ->
+            val item = candidate.item
+            if (item.isReleaseAlert && !item.released.isNullOrBlank()) {
+                com.nuvio.app.features.watchprogress.parseReleaseDateToEpochMs(item.released) ?: candidate.lastUpdatedEpochMs
+            } else {
+                candidate.lastUpdatedEpochMs
+            }
+        }.map(HomeContinueWatchingCandidate::item)
+    } else {
+        released.map(HomeContinueWatchingCandidate::item)
+    }
 
     // Unaired: soonest air date first; unknown dates go to the end
     val sortedUnreleased = unreleased

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -1079,6 +1079,7 @@ internal fun buildHomeContinueWatchingItems(
     return when (sortMode) {
         ContinueWatchingSortMode.DEFAULT -> deduplicated.map(HomeContinueWatchingCandidate::item)
         ContinueWatchingSortMode.STREAMING_STYLE -> applyStreamingStyleSort(deduplicated, todayIsoDate)
+        ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> applyStreamingStylePrioritizeNewSort(deduplicated, todayIsoDate)
     }
 }
 
@@ -1102,6 +1103,52 @@ private fun applyStreamingStyleSort(
 
     // Released: most recently watched first (already sorted by dedup pass)
     val sortedReleased = released.map(HomeContinueWatchingCandidate::item)
+
+    // Unaired: soonest air date first; unknown dates go to the end
+    val sortedUnreleased = unreleased
+        .sortedWith { a, b ->
+            val dateA = a.item.released?.takeIf { it.isNotBlank() }
+            val dateB = b.item.released?.takeIf { it.isNotBlank() }
+            when {
+                dateA == null && dateB == null -> 0
+                dateA == null -> 1
+                dateB == null -> -1
+                else -> dateA.compareTo(dateB)
+            }
+        }
+        .map(HomeContinueWatchingCandidate::item)
+
+    return sortedReleased + sortedUnreleased
+}
+
+private fun applyStreamingStylePrioritizeNewSort(
+    candidates: List<HomeContinueWatchingCandidate>,
+    todayIsoDate: String,
+): List<ContinueWatchingItem> {
+    val (released, unreleased) = candidates.partition { candidate ->
+        val item = candidate.item
+        if (!item.isNextUp) {
+            true // in-progress items are always "released"
+        } else {
+            val itemReleased = item.released
+            if (itemReleased.isNullOrBlank() || todayIsoDate.isBlank()) {
+                true // no date info → treat as released
+            } else {
+                isReleasedBy(todayIsoDate = todayIsoDate, releasedDate = itemReleased)
+            }
+        }
+    }
+
+    // Released: prioritize new episodes (isReleaseAlert == true) sorted by last updated epoch, then others
+    val sortedReleased = released
+        .sortedWith(
+            compareByDescending<HomeContinueWatchingCandidate> { candidate ->
+                candidate.item.isReleaseAlert
+            }.thenByDescending { candidate ->
+                candidate.lastUpdatedEpochMs
+            }
+        )
+        .map(HomeContinueWatchingCandidate::item)
 
     // Unaired: soonest air date first; unknown dates go to the end
     val sortedUnreleased = unreleased

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContinueWatchingSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContinueWatchingSettingsPage.kt
@@ -52,10 +52,10 @@ import nuvio.composeapp.generated.resources.settings_continue_watching_show_desc
 import nuvio.composeapp.generated.resources.settings_continue_watching_show_title
 import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_default
 import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_default_desc
-import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_streaming
-import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_streaming_desc
-import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_streaming_prioritize_new
-import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_streaming_prioritize_new_desc
+import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_released_upcoming_last_released
+import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_released_upcoming_last_released_desc
+import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_released_upcoming_last_watched
+import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_released_upcoming_last_watched_desc
 import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_title
 import nuvio.composeapp.generated.resources.settings_continue_watching_style_card
 import nuvio.composeapp.generated.resources.settings_continue_watching_style_card_description
@@ -177,8 +177,8 @@ internal fun LazyListScope.continueWatchingSettingsContent(
                 val currentModeLabel = stringResource(
                     when (sortMode) {
                         ContinueWatchingSortMode.DEFAULT -> Res.string.settings_continue_watching_sort_mode_default
-                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new
-                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> Res.string.settings_continue_watching_sort_mode_streaming
+                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> Res.string.settings_continue_watching_sort_mode_released_upcoming_last_watched
+                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> Res.string.settings_continue_watching_sort_mode_released_upcoming_last_released
                     }
                 )
                 SettingsNavigationRow(
@@ -325,13 +325,13 @@ private fun ContinueWatchingSortModeDialog(
         ),
         Triple(
             ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED,
-            Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new,
-            Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new_desc,
+            Res.string.settings_continue_watching_sort_mode_released_upcoming_last_watched,
+            Res.string.settings_continue_watching_sort_mode_released_upcoming_last_watched_desc,
         ),
         Triple(
             ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
-            Res.string.settings_continue_watching_sort_mode_streaming,
-            Res.string.settings_continue_watching_sort_mode_streaming_desc,
+            Res.string.settings_continue_watching_sort_mode_released_upcoming_last_released,
+            Res.string.settings_continue_watching_sort_mode_released_upcoming_last_released_desc,
         ),
     )
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContinueWatchingSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContinueWatchingSettingsPage.kt
@@ -54,6 +54,8 @@ import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode
 import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_default_desc
 import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_streaming
 import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_streaming_desc
+import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_streaming_prioritize_new
+import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_streaming_prioritize_new_desc
 import nuvio.composeapp.generated.resources.settings_continue_watching_sort_mode_title
 import nuvio.composeapp.generated.resources.settings_continue_watching_style_card
 import nuvio.composeapp.generated.resources.settings_continue_watching_style_card_description
@@ -176,6 +178,7 @@ internal fun LazyListScope.continueWatchingSettingsContent(
                     when (sortMode) {
                         ContinueWatchingSortMode.DEFAULT -> Res.string.settings_continue_watching_sort_mode_default
                         ContinueWatchingSortMode.STREAMING_STYLE -> Res.string.settings_continue_watching_sort_mode_streaming
+                        ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new
                     }
                 )
                 SettingsNavigationRow(
@@ -324,6 +327,11 @@ private fun ContinueWatchingSortModeDialog(
             ContinueWatchingSortMode.STREAMING_STYLE,
             Res.string.settings_continue_watching_sort_mode_streaming,
             Res.string.settings_continue_watching_sort_mode_streaming_desc,
+        ),
+        Triple(
+            ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW,
+            Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new,
+            Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new_desc,
         ),
     )
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContinueWatchingSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContinueWatchingSettingsPage.kt
@@ -177,8 +177,8 @@ internal fun LazyListScope.continueWatchingSettingsContent(
                 val currentModeLabel = stringResource(
                     when (sortMode) {
                         ContinueWatchingSortMode.DEFAULT -> Res.string.settings_continue_watching_sort_mode_default
-                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> Res.string.settings_continue_watching_sort_mode_streaming
-                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new
+                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> Res.string.settings_continue_watching_sort_mode_streaming
+                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new
                     }
                 )
                 SettingsNavigationRow(
@@ -324,12 +324,12 @@ private fun ContinueWatchingSortModeDialog(
             Res.string.settings_continue_watching_sort_mode_default_desc,
         ),
         Triple(
-            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
+            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED,
             Res.string.settings_continue_watching_sort_mode_streaming,
             Res.string.settings_continue_watching_sort_mode_streaming_desc,
         ),
         Triple(
-            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED,
+            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
             Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new,
             Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new_desc,
         ),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContinueWatchingSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContinueWatchingSettingsPage.kt
@@ -177,8 +177,8 @@ internal fun LazyListScope.continueWatchingSettingsContent(
                 val currentModeLabel = stringResource(
                     when (sortMode) {
                         ContinueWatchingSortMode.DEFAULT -> Res.string.settings_continue_watching_sort_mode_default
-                        ContinueWatchingSortMode.STREAMING_STYLE -> Res.string.settings_continue_watching_sort_mode_streaming
-                        ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW -> Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new
+                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> Res.string.settings_continue_watching_sort_mode_streaming
+                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new
                     }
                 )
                 SettingsNavigationRow(
@@ -324,12 +324,12 @@ private fun ContinueWatchingSortModeDialog(
             Res.string.settings_continue_watching_sort_mode_default_desc,
         ),
         Triple(
-            ContinueWatchingSortMode.STREAMING_STYLE,
+            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
             Res.string.settings_continue_watching_sort_mode_streaming,
             Res.string.settings_continue_watching_sort_mode_streaming_desc,
         ),
         Triple(
-            ContinueWatchingSortMode.STREAMING_PRIORITIZE_NEW,
+            ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED,
             Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new,
             Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new_desc,
         ),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContinueWatchingSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ContinueWatchingSettingsPage.kt
@@ -177,8 +177,8 @@ internal fun LazyListScope.continueWatchingSettingsContent(
                 val currentModeLabel = stringResource(
                     when (sortMode) {
                         ContinueWatchingSortMode.DEFAULT -> Res.string.settings_continue_watching_sort_mode_default
-                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> Res.string.settings_continue_watching_sort_mode_streaming
-                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new
+                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED -> Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new
+                        ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED -> Res.string.settings_continue_watching_sort_mode_streaming
                     }
                 )
                 SettingsNavigationRow(
@@ -325,13 +325,13 @@ private fun ContinueWatchingSortModeDialog(
         ),
         Triple(
             ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_WATCHED,
-            Res.string.settings_continue_watching_sort_mode_streaming,
-            Res.string.settings_continue_watching_sort_mode_streaming_desc,
+            Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new,
+            Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new_desc,
         ),
         Triple(
             ContinueWatchingSortMode.RELEASED_UPCOMING_LAST_RELEASED,
-            Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new,
-            Res.string.settings_continue_watching_sort_mode_streaming_prioritize_new_desc,
+            Res.string.settings_continue_watching_sort_mode_streaming,
+            Res.string.settings_continue_watching_sort_mode_streaming_desc,
         ),
     )
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/ContinueWatchingPreferencesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/ContinueWatchingPreferencesRepository.kt
@@ -85,8 +85,11 @@ object ContinueWatchingPreferencesRepository {
             return
         }
 
+        val migratedPayload = payload
+            .replace("\"STREAMING_STYLE\"", "\"RELEASED_UPCOMING_LAST_WATCHED\"")
+
         val stored = runCatching {
-            json.decodeFromString<StoredContinueWatchingPreferences>(payload)
+            json.decodeFromString<StoredContinueWatchingPreferences>(migratedPayload)
         }.getOrNull()
 
         _uiState.value = if (stored != null) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/WatchProgressModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/WatchProgressModels.kt
@@ -23,8 +23,8 @@ enum class ContinueWatchingSectionStyle {
 @Serializable
 enum class ContinueWatchingSortMode {
     DEFAULT,
-    STREAMING_STYLE,
-    STREAMING_PRIORITIZE_NEW,
+    RELEASED_UPCOMING_LAST_RELEASED,
+    RELEASED_UPCOMING_LAST_WATCHED,
 }
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/WatchProgressModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/WatchProgressModels.kt
@@ -24,6 +24,7 @@ enum class ContinueWatchingSectionStyle {
 enum class ContinueWatchingSortMode {
     DEFAULT,
     STREAMING_STYLE,
+    STREAMING_PRIORITIZE_NEW,
 }
 
 @Serializable


### PR DESCRIPTION
## Summary

Introduces a new "Released / Upcoming (Last watched)" sort order option for the Continue Watching carousel.
Additionally, renames the "Streaming style" sorting mode option to "Released / Upcoming (Last released)" for clarity, updates the descriptions for both options to clearly explain how items are partitioned and sorted, and adds Portuguese (pt) and Spanish (es) translations.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

This change is needed to allow a new sorting order where 'New episodes' release alerts are not strictly pinned to the absolute front of the released items list. Instead, they are sorted by their release/update recency integrated with when other ongoing/in-progress items were last watched. This means the released group is sorted by a unified timestamp: `lastWatched` for in-progress and standard next-up items, and `releaseTimestamp` for next-up release alerts. This integrates new episodes by release recency alongside recently watched shows. The naming of the sorting options was also polished to make the partitioning rules ("Released / Upcoming (Last watched)" and "Released / Upcoming (Last released)") clearer to the user.

### Sorting Comparison Scenarios

To help understand the difference, here is a breakdown of how the two modes sort the Continue Watching carousel under different states.

#### Sample Data Setup:
*   **Show G:** In-progress with a new episode alert (Watched 3h ago; new episode aired 1d ago).
*   **Show A:** Standard In-progress (Watched 6h ago; next episode not yet aired).
*   **Show B:** Next-up with a new episode alert (Watched 10d ago; new episode aired 2d ago).
*   **Show C:** Standard Next-up (Watched 5d ago; next episode aired 30d ago).
*   **Show F:** Next-up/Abandoned (Watched 70d ago; next episode aired 10d ago — no badge due to the 60-day limit).
*   **Show D:** Upcoming/Unreleased (Next episode airs in 5 days).
*   **Show E:** Upcoming/Unreleased (Next episode airs in 15 days).

### Visual Carousel Scenarios:

#### Option 1: `Released / Upcoming (Last watched)`
*Released items sorted by the user's watch recency. New episode alerts for shows watched ≤ 60 days ago use their air date as the sort key; all others use `lastWatched`.*

**Scenario A — Heavy watcher with mixed new episodes:**
*You watch daily. Show A and G are in-progress; Show B has a new episode alert but was last watched 10 days ago.*
```mermaid
flowchart LR
    subgraph Released
        G1["Show G (in-progress, watched 3h ago)"] --> A1["Show A (in-progress, watched 6h ago)"]
        A1 --> B1["Show B (alert: aired 2d ago, watched 10d ago)"]
        B1 --> C1["Show C (next-up, watched 5d ago)"]
    end
    subgraph Upcoming
        D1["Show D (airs in 5 days)"] --> E1["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```

**Scenario B — Casual watcher; long gap since last session:**
*You haven't watched in weeks. An abandoned show (F) has a new episode but exceeds the 60-day limit — stays buried.*
```mermaid
flowchart LR
    subgraph Released
        B2["Show B (alert: aired 2d ago, key = 2d)"] --> C2["Show C (next-up, key = last watched 5d ago)"]
        C2 --> F2["Show F (abandoned 70d ago, alert ignored → key = 70d)"]
    end
    subgraph Upcoming
        D2["Show D (airs in 5 days)"] --> E2["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```

**Scenario C — All shows have new episode alerts:**
*Every show has a new episode. Alerts within 60 days use air date as key; abandoned (>60d) fall back to lastWatched.*
```mermaid
flowchart LR
    subgraph Released
        G3["Show G (alert: aired 1d ago → key = 1d)"] --> B3["Show B (alert: aired 2d ago → key = 2d)"]
        B3 --> F3["Show F (alert: aired 10d ago, watched 70d ago → key = 70d)"]
    end
    subgraph Upcoming
        D3["Show D (airs in 5 days)"] --> E3["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```

#### Option 2: `Released / Upcoming (Last released)`
*Released items sorted by the next episode's air/release date, most recent first. `lastWatched` is used only for in-progress items with no release date.*

**Scenario A — Heavy watcher with mixed new episodes:**
*Same library as Scenario A above. In-progress items use `lastWatched`; next-up items use their air date.*
```mermaid
flowchart LR
    subgraph Released
        G4["Show G (in-progress, key = last watched 3h ago)"] --> A4["Show A (in-progress, key = last watched 6h ago)"]
        A4 --> B4["Show B (alert: aired 2d ago → key = 2d)"]
        B4 --> C4["Show C (next-up, aired 30d ago → key = 30d)"]
    end
    subgraph Upcoming
        D4["Show D (airs in 5 days)"] --> E4["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```

**Scenario B — Casual watcher; long gap since last session:**
*The abandoned show (F) jumps forward — its air date (10d ago) is more recent than Show C's (30d ago).*
```mermaid
flowchart LR
    subgraph Released
        B5["Show B (alert: aired 2d ago → key = 2d)"] --> F5["Show F (abandoned, aired 10d ago → key = 10d)"]
        F5 --> C5["Show C (next-up, aired 30d ago → key = 30d)"]
    end
    subgraph Upcoming
        D5["Show D (airs in 5 days)"] --> E5["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```

**Scenario C — All shows have new episode alerts:**
*Sorted strictly by air date — the 60-day badge limit does not affect position here.*
```mermaid
flowchart LR
    subgraph Released
        G6["Show G (alert: aired 1d ago → key = 1d)"] --> B6["Show B (alert: aired 2d ago → key = 2d)"]
        B6 --> F6["Show F (alert: aired 10d ago → key = 10d)"]
    end
    subgraph Upcoming
        D6["Show D (airs in 5 days)"] --> E6["Show E (airs in 15 days)"]
    end
    Released --> Upcoming
```


## Issue or approval

Approved by user/maintainer request (#1285).

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited to KMP watch progress models enum expansion, HomeScreen sorting function additions, updated and translated compose strings, and settings dialog changes.

## Testing

Verified by local Gradle compilation (`:composeApp:compileKotlinMetadata` task).

## Screenshots / Video

Added "Released / Upcoming (Last watched)" option and renamed "Streaming style" to "Released / Upcoming (Last released)" in the Continue Watching Settings dialog.

## Breaking changes

None.

## Linked issues

Fixes #1285.
