### PR TITLE
fix(collections): preserve catalog genre filter on View All

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -1191,6 +1191,7 @@ private fun MainAppContent(
                     type = section.type,
                     catalogId = section.catalogId,
                     supportsPagination = section.supportsPagination,
+                    genre = section.genre,
                 ),
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/collection/FolderDetailRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/collection/FolderDetailRepository.kt
@@ -421,6 +421,7 @@ object FolderDetailRepository {
                 items = tab.items,
                 availableItemCount = tab.items.size,
                 supportsPagination = tab.supportsPagination,
+                genre = tab.genre,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeModels.kt
@@ -39,6 +39,7 @@ data class HomeCatalogSection(
     val items: List<MetaPreview>,
     val availableItemCount: Int = items.size,
     val supportsPagination: Boolean = false,
+    val genre: String? = null,
 )
 
 fun HomeCatalogSection.canOpenCatalog(previewLimit: Int): Boolean =


### PR DESCRIPTION
## Summary

When a collection folder catalog has a genre filter applied (for example, a "Movies" catalog filtered to **Romance**), tapping **View All** dropped the genre and loaded the entire unfiltered catalog. This PR carries the active genre through the View All navigation so the full-catalog screen stays filtered to the same genre that was shown in the folder row.

## Why

The folder row sections are built from `FolderTab`s, which already hold the selected `genre`. However:

- `FolderDetailRepository.getCatalogSectionsForRows()` mapped each `FolderTab` to a `HomeCatalogSection`, but `HomeCatalogSection` had no `genre` field, so the genre was silently dropped at that point.
- `onCatalogClick` (in `App.kt`) built a `CatalogRoute` from the section without setting `genre`, even though `CatalogRoute`/`CatalogScreen` already support a `genre` parameter that is forwarded all the way to `CatalogRepository.fetchCatalogPage(genre = ...)`.

Because the genre never reached `CatalogRoute`, `CatalogScreen` was opened with `genre = null` and requested the catalog unfiltered.

The fix preserves the existing genre value through that single broken link in the chain. No filtering logic is added or changed — it already existed end-to-end; it was just being lost during the folder → View All transition.

## Issue or approval

Fixes #1264

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood CONTRIBUTING.md.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Scope boundaries

Three files changed, one line each, no formatting or unrelated edits:

- `composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeModels.kt` — add `val genre: String? = null` to `HomeCatalogSection` (defaulted, so all existing construction sites are unaffected).
- `composeApp/src/commonMain/kotlin/com/nuvio/app/features/collection/FolderDetailRepository.kt` — pass `genre = tab.genre` when mapping a `FolderTab` to a `HomeCatalogSection` in `getCatalogSectionsForRows()`.
- `composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt` — forward `genre = section.genre` into `CatalogRoute` inside `onCatalogClick`.

## Testing

**Build**

```
./gradlew :composeApp:assembleDebug
BUILD SUCCESSFUL in 7m 20s
```

**Unit tests**

```
./gradlew :composeApp:testFullDebugUnitTest
218 tests completed, 4 failed
```

The 4 failing tests are **pre-existing and unrelated to this change**. They fail identically on a clean `cmp-rewrite` checkout (verified by stashing this change and re-running the same tasks):

- `LibraryRepositoryTest` (×2) — `Method getSystem in android.content.res.Resources not mocked` (JVM unit-test environment limitation).
- `StreamAutoPlaySelectorTest` (×2) — timeout/debrid candidate timing assertions.

None of them touch the catalog, collection, or navigation code paths modified here.

**Static analysis** (the affected path runs through Compose navigation + singleton repository state, so it is not cleanly unit-testable without an unrelated refactor):

- **Before fix:** `FolderTab.genre` → dropped at `getCatalogSectionsForRows()` → `CatalogRoute.genre = null` → `CatalogScreen(genre = null)` → `fetchCatalogPage(genre = null)` → unfiltered catalog.
- **After fix:** `FolderTab.genre` → `HomeCatalogSection.genre` → `CatalogRoute.genre` → `CatalogScreen(genre = <selected>)` → `fetchCatalogPage(genre = <selected>)` → catalog stays filtered to the selected genre.
- **Edge cases:** folders/catalogs without a genre filter keep `genre = null`, identical to current behavior. Home and search sections never set a genre, so they remain unfiltered exactly as before.
- **Regression risk:** the new field is defaulted to `null`, so no existing `HomeCatalogSection` construction site (home, search) changes behavior; only the folder View All path, which is the bug, is affected.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1264
