### PR TITLE
fix(android): stop home hero carousel reshuffling while loading

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeRepository.kt
@@ -197,14 +197,14 @@ object HomeRepository {
             }
 
         val catalogHeroItems = if (snapshot.heroEnabled) {
-            val heroRandom = Random((requestKey?.hashCode() ?: 0).absoluteValue + 1)
+            val heroOrderSeed = requestKey?.hashCode() ?: 0
             currentDefinitions
                 .filter { definition -> preferences[definition.key]?.heroSourceEnabled != false }
                 .mapNotNull { definition -> cachedSections[definition.key] }
                 .map { section -> section.withReleaseFilter() }
                 .flatMap { section -> section.items }
                 .distinctBy { item -> "${item.type}:${item.id}" }
-                .shuffled(heroRandom)
+                .orderedForHero(heroOrderSeed) { item -> "${item.type}:${item.id}" }
                 .take(HOME_HERO_ITEM_LIMIT)
         } else {
             emptyList()
@@ -432,6 +432,26 @@ private const val HOME_COLLECTION_HERO_SOURCE_ITEM_LIMIT = 8
 private const val HOME_CATALOG_FETCH_BATCH_SIZE = 4
 private const val HOME_CATALOG_PREVIEW_FETCH_LIMIT = 18
 private const val HOME_CATALOG_PUBLISH_INTERVAL = 2
+
+internal fun <T> List<T>.orderedForHero(seed: Int, keySelector: (T) -> String): List<T> =
+    sortedWith(
+        compareBy(
+            { item -> stableHeroOrderRank(seed, keySelector(item)) },
+            { item -> keySelector(item) },
+        ),
+    )
+
+internal fun stableHeroOrderRank(seed: Int, itemKey: String): Int {
+    var hash = seed
+    for (index in itemKey.indices) {
+        hash = hash * 31 + itemKey[index].code
+    }
+    // Avalanche mix so items from the same catalog (similar ids) don't cluster together.
+    hash = hash xor (hash ushr 16)
+    hash *= 0x7feb352d
+    hash = hash xor (hash ushr 15)
+    return hash
+}
 
 private fun prioritizeDefinitions(
     definitions: List<HomeCatalogDefinition>,

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/home/HomeHeroOrderingTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/home/HomeHeroOrderingTest.kt
@@ -1,0 +1,54 @@
+package com.nuvio.app.features.home
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HomeHeroOrderingTest {
+
+    @Test
+    fun `ordering is deterministic for a given seed`() {
+        val items = listOf("series:a", "movie:b", "series:c", "movie:d", "series:e")
+
+        assertEquals(
+            items.orderedForHero(seed = 42) { it },
+            items.orderedForHero(seed = 42) { it },
+        )
+    }
+
+    @Test
+    fun `ordering does not depend on the input order`() {
+        val seed = 7
+        val ascending = listOf("a", "b", "c", "d", "e").orderedForHero(seed) { it }
+        val descending = listOf("e", "d", "c", "b", "a").orderedForHero(seed) { it }
+
+        assertEquals(ascending, descending)
+    }
+
+    @Test
+    fun `adding more items keeps the relative order of already-loaded items`() {
+        // Regression guard for the hero carousel reshuffle bug: the hero pool is rebuilt as more
+        // catalog batches load, so the ordering must keep already-shown items in place instead of
+        // re-permuting the whole carousel. The previous Random.shuffled() implementation failed
+        // this because shuffling lists of different sizes produces unrelated orders.
+        val seed = 123
+        val firstBatch = listOf("s1", "s2", "s3", "s4")
+        val grownPool = firstBatch + listOf("s5", "s6", "s7", "s8", "s9")
+
+        val firstBatchOrder = firstBatch.orderedForHero(seed) { it }
+        val grownOrderFilteredToFirstBatch = grownPool
+            .orderedForHero(seed) { it }
+            .filter { it in firstBatch }
+
+        assertEquals(firstBatchOrder, grownOrderFilteredToFirstBatch)
+    }
+
+    @Test
+    fun `ordering is shuffled rather than sorted alphabetically`() {
+        val items = (1..20).map { "series:tt$it" }
+        val ordered = items.orderedForHero(seed = 99) { it }
+
+        assertTrue(ordered != items.sortedBy { it }, "hero order should not be a plain sort")
+        assertEquals(items.toSet(), ordered.toSet(), "ordering must not drop or add items")
+    }
+}


### PR DESCRIPTION
## Summary

On app open the home hero carousel visibly reshuffles and reorders itself several times before settling. This PR makes the hero ordering stable so the carousel settles as items load instead of re-permuting on every intermediate update.

## Why

The home screen loads catalogs in batches and republishes the UI state after each batch. The hero carousel items are recomputed on every publish from the pool of items belonging to hero-enabled catalogs, and that pool is then shuffled with a one-shot `Random` seeded on the request key:

```kotlin
val heroRandom = Random((requestKey?.hashCode() ?: 0).absoluteValue + 1)
... .distinctBy { ... }
    .shuffled(heroRandom)
    .take(HOME_HERO_ITEM_LIMIT)
```

Because the candidate pool grows as more hero-source catalogs finish loading, `shuffled()` produces a completely different permutation each time it runs over the larger list. The result is the carousel re-ordering itself multiple times during the load before it finally stabilizes.

The fix orders the candidates by a stable per-item hash (`stableHeroOrderRank`, with the item id as a deterministic tie-breaker) instead of shuffling. Sorting by a fixed per-item key means the relative order of already-loaded items never changes as new items arrive — later items simply slot into their position — so the carousel settles instead of reshuffling. The seed is still mixed in, so the order remains varied per catalog set and deterministic/stable across app opens (it was already seeded by the request key before).

This only changes the playback/networking-independent ordering logic; the data flow, item selection source, and rendering are untouched.

## Issue or approval

Fixes #1133

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

No layout, spacing, color, typography, or animation change — only the ordering of the existing hero items is made stable.

## Policy check

- [x] I have read and understood CONTRIBUTING.md.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Scope boundaries

Two files changed:

- `composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeRepository.kt` — in `publishCurrentState`, replace the `Random(...).shuffled(...)` of the catalog hero pool with `.orderedForHero(seed) { ... }`. Add two small pure helpers next to the existing home constants: `orderedForHero` (sort by stable rank, id as tie-breaker) and `stableHeroOrderRank` (deterministic hash). The collection-hero fallback path is intentionally left unchanged (it is computed once per request, not on every publish).
- `composeApp/src/commonTest/kotlin/com/nuvio/app/features/home/HomeHeroOrderingTest.kt` — new unit tests covering the fix.

## Testing

- Build: `./gradlew :composeApp:assembleFullDebug` — ✅ BUILD SUCCESSFUL
- Targeted unit tests: `./gradlew :composeApp:testFullDebugUnitTest --tests "*.HomeHeroOrderingTest"` — ✅ 4 tests passed
- Full unit suite: `./gradlew :composeApp:testFullDebugUnitTest` — my 4 new tests pass. The suite reports 4 unrelated failures (`LibraryRepositoryTest`, `StreamAutoPlaySelectorTest`); I verified these fail identically on the clean `cmp-rewrite` baseline without my change, so they are pre-existing and unrelated to this PR.

New tests added (the third is the direct regression guard for this bug):

- `ordering is deterministic for a given seed`
- `ordering does not depend on the input order`
- `adding more items keeps the relative order of already-loaded items` — fails with the old `Random.shuffled()` (different-sized lists shuffle to unrelated orders) and passes with the stable ordering.
- `ordering is shuffled rather than sorted alphabetically` — guards that variety is preserved and no items are dropped/added.

## Screenshots / Video

The bug is a runtime ordering-stability issue (the carousel re-permutes over the ~2-3s progressive catalog load), which a static screenshot cannot capture. The behavior is instead verified by the deterministic unit tests above. Before: hero items reorder on each catalog batch that loads. After: hero order is fixed as items load in.

## Breaking changes

None.

## Linked issues

Fixes #1133
