### PR TITLE
fix(android): keep app language out of per-profile settings sync

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.android.kt
@@ -24,7 +24,6 @@ actual object ThemeSettingsStorage {
         amoledEnabledKey,
         liquidGlassNativeTabBarEnabledKey,
     )
-    private val globalSyncKeys = listOf(selectedAppLanguageKey)
 
     private var preferences: SharedPreferences? = null
 
@@ -94,19 +93,16 @@ actual object ThemeSettingsStorage {
         loadSelectedTheme()?.let { put(selectedThemeKey, encodeSyncString(it)) }
         loadAmoledEnabled()?.let { put(amoledEnabledKey, encodeSyncBoolean(it)) }
         loadLiquidGlassNativeTabBarEnabled()?.let { put(liquidGlassNativeTabBarEnabledKey, encodeSyncBoolean(it)) }
-        loadSelectedAppLanguage()?.let { put(selectedAppLanguageKey, encodeSyncString(it)) }
     }
 
     actual fun replaceFromSyncPayload(payload: JsonObject) {
         preferences?.edit()?.apply {
             profileScopedSyncKeys.forEach { remove(ProfileScopedKey.of(it)) }
-            globalSyncKeys.forEach { remove(it) }
         }?.apply()
 
         payload.decodeSyncString(selectedThemeKey)?.let(::saveSelectedTheme)
         payload.decodeSyncBoolean(amoledEnabledKey)?.let(::saveAmoledEnabled)
         payload.decodeSyncBoolean(liquidGlassNativeTabBarEnabledKey)?.let(::saveLiquidGlassNativeTabBarEnabled)
-        payload.decodeSyncString(selectedAppLanguageKey)?.let(::saveSelectedAppLanguage)
         applySelectedAppLanguage(loadSelectedAppLanguage() ?: AppLanguage.ENGLISH.code)
     }
 }

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.ios.kt
@@ -20,7 +20,6 @@ actual object ThemeSettingsStorage {
         amoledEnabledKey,
         liquidGlassNativeTabBarEnabledKey,
     )
-    private val globalSyncKeys = listOf(selectedAppLanguageKey)
 
     actual fun loadSelectedTheme(): String? =
         NSUserDefaults.standardUserDefaults.stringForKey(ProfileScopedKey.of(selectedThemeKey))
@@ -88,21 +87,16 @@ actual object ThemeSettingsStorage {
         loadSelectedTheme()?.let { put(selectedThemeKey, encodeSyncString(it)) }
         loadAmoledEnabled()?.let { put(amoledEnabledKey, encodeSyncBoolean(it)) }
         loadLiquidGlassNativeTabBarEnabled()?.let { put(liquidGlassNativeTabBarEnabledKey, encodeSyncBoolean(it)) }
-        loadSelectedAppLanguage()?.let { put(selectedAppLanguageKey, encodeSyncString(it)) }
     }
 
     actual fun replaceFromSyncPayload(payload: JsonObject) {
         profileScopedSyncKeys.forEach { key ->
             NSUserDefaults.standardUserDefaults.removeObjectForKey(ProfileScopedKey.of(key))
         }
-        globalSyncKeys.forEach { key ->
-            NSUserDefaults.standardUserDefaults.removeObjectForKey(key)
-        }
 
         payload.decodeSyncString(selectedThemeKey)?.let(::saveSelectedTheme)
         payload.decodeSyncBoolean(amoledEnabledKey)?.let(::saveAmoledEnabled)
         payload.decodeSyncBoolean(liquidGlassNativeTabBarEnabledKey)?.let(::saveLiquidGlassNativeTabBarEnabled)
-        payload.decodeSyncString(selectedAppLanguageKey)?.let(::saveSelectedAppLanguage)
         applySelectedAppLanguage(loadSelectedAppLanguage() ?: AppLanguage.ENGLISH.code)
     }
 }


### PR DESCRIPTION
## Summary

The app language is a device-global setting, but it was bundled into the per-profile cloud-sync payload. When a profile's settings were applied on profile switch / app relaunch, the sync code wiped the global language key and only restored it if the per-profile remote blob happened to contain a language — which it usually did not. The result was that the chosen language (e.g. Italian) reset back to English after relaunching the app. This PR removes the app language from per-profile settings sync so the global language is no longer erased or overwritten by it.

## Why

`ThemeSettingsStorage` stores the selected app language under a **global** key (`selected_app_language`), not a profile-scoped one. This was an intentional design decision (commits `e15a398f` "make app language key global, not profile-scoped" and `17cb75a4` "migrate language from legacy profile-scoped key to global key").

However, the language was still part of the per-profile settings-sync contract:

- `exportToSyncPayload()` wrote the language into the profile blob's `theme_settings`.
- `replaceFromSyncPayload()` unconditionally **removed** the global language key (it was listed in `globalSyncKeys`) and then only re-saved it if the incoming per-profile payload contained a language.

The language is also deliberately excluded from the sync change-tracking flows (`observeLocalChangesAndPush` / `currentObservedStateSignature` in `ProfileSettingsSync`), so changing the language never triggers a push. As a consequence the remote per-profile blob almost never carries the user's current language. On profile switch (which happens on every relaunch through the profile selector), `ProfileSettingsSync.applyRemoteBlob()` calls `replaceFromSyncPayload()`, which erased the locally-stored global language and fell back to `AppLanguage.ENGLISH`.

This exactly matches the report: the locale is correct on the profile-selection screen (applied by `ThemeSettingsStorage.initialize()`), then resets to English once a profile is selected and the remote blob is applied.

The fix makes per-profile sync leave the device-global language untouched: it is no longer exported into the profile blob, no longer removed in `replaceFromSyncPayload`, and no longer restored from the (per-profile) payload. The already-persisted global value is still re-applied at the end of `replaceFromSyncPayload`, so the user's language stays in effect across profile switches and relaunches.

## Issue or approval

Fixes #1253

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood CONTRIBUTING.md.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Scope boundaries

Two files changed, both implementations of the same `ThemeSettingsStorage` sync contract (the cloud-sync blob is shared across platforms, so the fix is applied symmetrically to avoid a cross-device inconsistency where one platform keeps writing/erasing a language the other ignores):

- `composeApp/src/androidMain/.../settings/ThemeSettingsStorage.android.kt`
- `composeApp/src/iosMain/.../settings/ThemeSettingsStorage.ios.kt`

In each file:
- Removed `selected_app_language` from `globalSyncKeys` (the field is now unused and removed), so `replaceFromSyncPayload` no longer deletes the global language key.
- Removed the language entry from `exportToSyncPayload()`.
- Removed the language restore line from `replaceFromSyncPayload()`.

The trailing `applySelectedAppLanguage(loadSelectedAppLanguage() ?: AppLanguage.ENGLISH.code)` is kept, so the persisted global language is re-applied after a profile sync. No other code reads the language from the profile blob.

## Testing

- Build: `./gradlew :composeApp:assembleFullDebug` — ✅ BUILD SUCCESSFUL
- Unit tests: `./gradlew :composeApp:testFullDebugUnitTest` — 218 tests, 4 failing. The 4 failures are pre-existing on a clean `cmp-rewrite` checkout and unrelated to this change (`LibraryRepositoryTest` — `android.content.res.Resources` not mocked under plain JVM unit tests; `StreamAutoPlaySelectorTest` — auto-play timing assertions). No test references the changed `ThemeSettingsStorage` code, so this change introduces no new failures.

The affected code path depends on Android `SharedPreferences` / `AppCompatDelegate` (and `NSUserDefaults` on iOS), so it is verified by static analysis rather than an isolated unit test:

STATIC ANALYSIS:
- Before fix: on profile switch, `ProfileSettingsSync.applyRemoteBlob()` → `ThemeSettingsStorage.replaceFromSyncPayload(remoteThemeSettings)` removed the global `selected_app_language` key, then restored it only if the per-profile payload contained one. Because the language is global and is not tracked for push, the per-profile payload typically lacked it, so `loadSelectedAppLanguage()` returned null and the locale fell back to `AppLanguage.ENGLISH`.
- After fix: `replaceFromSyncPayload()` no longer touches the global language key; the persisted value survives the sync and is re-applied via `applySelectedAppLanguage(loadSelectedAppLanguage() ?: AppLanguage.ENGLISH.code)`.
- Edge cases considered: first launch with no stored language still falls back to English (unchanged); legacy profile-scoped language values are still migrated to the global key by `loadSelectedAppLanguage()` (unchanged); theme/amoled/liquid-glass settings remain per-profile synced (unchanged).
- Regression risk: minimal. The only behavioral change is that per-profile sync no longer reads or writes the device-global language, which is exactly the intended design after the language was made global. Theme and other profile-scoped settings are untouched.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1253
