### PR TITLE
fix(trakt): restore recently-added order for Trakt watchlist

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktLibraryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktLibraryRepository.kt
@@ -538,10 +538,7 @@ object TraktLibraryRepository {
         }
         return (movieItems + showItems)
             .mapNotNull(::mapToLibraryItem)
-            .sortedWith(
-                compareBy<LibraryItem> { it.traktRank ?: Int.MAX_VALUE }
-                    .thenByDescending { it.savedAtEpochMs },
-            )
+            .sortedByDescending { it.savedAtEpochMs }
     }
 
     private suspend fun fetchPersonalListItems(


### PR DESCRIPTION
## Summary

This PR restores the "recently added first" ordering of the Trakt **Watchlist** in the library. Watchlist items were being ordered by Trakt rank (ascending), which is effectively the order in which they were added (oldest first), so the most recently added titles appeared at the bottom instead of the top.

## Why

The watchlist is fetched from Trakt's `…/watchlist/{type}/rank` endpoint and then sorted locally. Previously the items were sorted by `savedAtEpochMs` descending (Trakt's `listed_at`, i.e. when the item was added to the watchlist), so the newest additions came first.

Commit `ded51ed` ("feat(library): pagination and trakt mapping improvements") replaced that with:

```kotlin
.sortedWith(
    compareBy<LibraryItem> { it.traktRank ?: Int.MAX_VALUE }
        .thenByDescending { it.savedAtEpochMs },
)
```

For the watchlist, `traktRank` comes from the item's Trakt `rank`, which for `/watchlist/{type}/rank` increases in the order items were added (rank 1 = first/oldest). Sorting by rank ascending therefore shows the oldest additions first and pushes newly added titles to the end — the opposite of what users expect from a watchlist.

The fix restores the original `sortedByDescending { it.savedAtEpochMs }` for the watchlist, which is also the ordering already used elsewhere in the same repository for the aggregated library view.

## Issue or approval

Fixes #1207

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood CONTRIBUTING.md.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Scope boundaries

This PR changes a single file, `composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktLibraryRepository.kt` — specifically the sort in `fetchWatchlistItems()`. The rank-based `sortedWith(...)` is replaced with `sortedByDescending { it.savedAtEpochMs }`, restoring recently-added-first order for the watchlist.

Personal Trakt lists (`fetchPersonalListItems()`) are intentionally left unchanged, since those carry their own per-list Trakt sort configuration and are a separate concern from the watchlist's recently-added ordering.

## Testing

- Build: `./gradlew :composeApp:assembleFullDebug` — ✅ BUILD SUCCESSFUL
- Unit tests: `./gradlew :composeApp:testFullDebugUnitTest` — 214/218 passing. The 4 failures (`LibraryRepositoryTest` × 2, `StreamAutoPlaySelectorTest` × 2) are pre-existing and unrelated to this change: I confirmed they fail identically on the unmodified `cmp-rewrite` baseline (`git stash` → run → same 4 failures). Two are `android.content.res.Resources` mocking errors; two are stream auto-play debrid assertions in code this PR does not touch.

STATIC ANALYSIS:
- Before fix: `fetchWatchlistItems()` sorted by `compareBy { traktRank ?: Int.MAX_VALUE }.thenByDescending { savedAtEpochMs }`. With the `/watchlist/{type}/rank` endpoint, rank increases with add-order, so ascending rank → oldest-added first; recently added items sink to the bottom.
- After fix: items are sorted by `savedAtEpochMs` (Trakt `listed_at`) descending → most recently added first, matching the pre-`ded51ed` behavior and the issue's expected behavior.
- Edge cases: `savedAtEpochMs` falls back to "now" only when `listed_at` is missing/blank, so items without a parseable add-date stay at the top — acceptable and identical to the prior behavior. Movies and shows are fetched separately and concatenated, so a single combined sort is required; `sortedByDescending` provides a stable total order over the merged list.
- Regression risk: the change is confined to the watchlist's local ordering and does not alter fetching, pagination, mapping, or any other list. No existing test asserts the rank-based ordering.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1207
