### PR TITLE
fix: prevent autoplay from skipping post-credits scenes

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
@@ -111,10 +111,6 @@ object PlayerNextEpisodeRules {
     }
 
     val OUTRO_SEGMENT_TYPES = setOf("outro", "ed", "mixed-ed")
-
-    const val POST_OUTRO_AUTOPLAY_GAP_MS = 5_000L
-
-    const val END_OF_VIDEO_EPSILON_MS = 1_000L
 }
 
 internal expect fun currentDateComponents(): DateComponents

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
@@ -32,21 +32,33 @@ object PlayerNextEpisodeRules {
         thresholdPercent: Float,
         thresholdMinutesBeforeEnd: Float,
     ): Boolean {
-        val outroInterval = skipIntervals.firstOrNull { it.type == "outro" }
-        return if (outroInterval != null) {
-            positionMs / 1000.0 >= outroInterval.startTime
-        } else {
+        val outroSegments = skipIntervals.filter { it.type in OUTRO_SEGMENT_TYPES }
+
+        if (outroSegments.isNotEmpty()) {
             if (durationMs <= 0L) return false
-            when (thresholdMode) {
-                NextEpisodeThresholdMode.PERCENTAGE -> {
-                    val clampedPercent = thresholdPercent.coerceIn(97f, 100f)
-                    (positionMs.toDouble() / durationMs.toDouble()) >= (clampedPercent / 100.0)
-                }
-                NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
-                    val clampedMinutes = thresholdMinutesBeforeEnd.coerceIn(0f, 3.5f)
-                    val remainingMs = durationMs - positionMs
-                    remainingMs <= (clampedMinutes * 60_000f).toLong()
-                }
+            val latestOutroEndMs = (outroSegments.maxOf { it.endTime } * 1_000.0).toLong()
+            val postOutroGapMs = durationMs - latestOutroEndMs
+
+            return if (postOutroGapMs > POST_OUTRO_AUTOPLAY_GAP_MS) {
+                // Post-credits scene: hold prompt until video truly ends.
+                positionMs >= durationMs - END_OF_VIDEO_EPSILON_MS
+            } else {
+                // No post-credits scene: fire as soon as the earliest outro starts.
+                positionMs / 1_000.0 >= outroSegments.minOf { it.startTime }
+            }
+        }
+
+        // Fallback to the settings threshold when no outro data exists.
+        if (durationMs <= 0L) return false
+        return when (thresholdMode) {
+            NextEpisodeThresholdMode.PERCENTAGE -> {
+                val clampedPercent = thresholdPercent.coerceIn(97f, 100f)
+                (positionMs.toDouble() / durationMs.toDouble()) >= (clampedPercent / 100.0)
+            }
+            NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
+                val clampedMinutes = thresholdMinutesBeforeEnd.coerceIn(0f, 3.5f)
+                val remainingMs = durationMs - positionMs
+                remainingMs <= (clampedMinutes * 60_000f).toLong()
             }
         }
     }
@@ -76,6 +88,12 @@ object PlayerNextEpisodeRules {
         if (m1 != m2) return m1.compareTo(m2)
         return d1.compareTo(d2)
     }
+
+    val OUTRO_SEGMENT_TYPES = setOf("outro", "ed", "mixed-ed")
+
+    const val POST_OUTRO_AUTOPLAY_GAP_MS = 5_000L
+
+    const val END_OF_VIDEO_EPSILON_MS = 1_000L
 }
 
 internal expect fun currentDateComponents(): DateComponents

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
@@ -39,11 +39,32 @@ object PlayerNextEpisodeRules {
             val latestOutroEndMs = (outroSegments.maxOf { it.endTime } * 1_000.0).toLong()
             val postOutroGapMs = durationMs - latestOutroEndMs
 
-            return if (postOutroGapMs > POST_OUTRO_AUTOPLAY_GAP_MS) {
-                // Post-credits scene: hold prompt until video truly ends.
-                positionMs >= durationMs - END_OF_VIDEO_EPSILON_MS
+            // Calculate the user's configured threshold as milliseconds from end.
+            val userThresholdMs = when (thresholdMode) {
+                NextEpisodeThresholdMode.PERCENTAGE -> {
+                    val clampedPercent = thresholdPercent.coerceIn(97f, 100f)
+                    ((1.0 - clampedPercent / 100.0) * durationMs).toLong()
+                }
+                NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
+                    val clampedMinutes = thresholdMinutesBeforeEnd.coerceIn(0f, 3.5f)
+                    (clampedMinutes * 60_000f).toLong()
+                }
+            }
+
+            return if (postOutroGapMs > userThresholdMs) {
+                when (thresholdMode) {
+                    NextEpisodeThresholdMode.PERCENTAGE -> {
+                        val clampedPercent = thresholdPercent.coerceIn(97f, 100f)
+                        (positionMs.toDouble() / durationMs.toDouble()) >= (clampedPercent / 100.0)
+                    }
+                    NextEpisodeThresholdMode.MINUTES_BEFORE_END -> {
+                        val clampedMinutes = thresholdMinutesBeforeEnd.coerceIn(0f, 3.5f)
+                        val remainingMs = durationMs - positionMs
+                        remainingMs <= (clampedMinutes * 60_000f).toLong()
+                    }
+                }
             } else {
-                // No post-credits scene: fire as soon as the earliest outro starts.
+                // Outro ends close to the file end — fire at earliest outro start.
                 positionMs / 1_000.0 >= outroSegments.minOf { it.startTime }
             }
         }


### PR DESCRIPTION
## Summary

Fixes the next episode card skipping post credits scenes when outro timecodes are
available. It used to appear the moment the outro started, jumping past anything after
it. Now, when the gap after the outro is larger than the next episode threshold, the
card waits and appears at the configured threshold. Threshold logic ported from the TV
app (NuvioMedia/NuvioTV#2272).

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

With outro timecodes, the next episode card appeared right when the outro began,
skipping any post credits scene. Now, if the gap after the outro is larger than the
threshold, the card holds off and appears at the configured threshold so the scene
isn't missed.

## Issue or approval

Fixes https://github.com/NuvioMedia/NuvioMobile/issues/1305

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only affects when the next episode card appears; no other autoplay or playback behavior changes
- Does not change behavior when the outro ends near the file end (gap below threshold); still fires at the outro start
- Does not affect playback with no outro timecodes; still uses the configured threshold
- Covers outro, ed, and mixed-ed segment types, not just outro

## Testing

- Outro 19:00 to 20:00, file end 22:00, threshold 0.5min: card appears at 21:30 (gap above threshold)
- Outro 21:00 to 21:50, file end 22:00, threshold 0.5min: card appears at outro start 21:00 (gap below threshold, normal behavior)
- No outro timecodes: card falls back to the configured threshold
- Tested on iOS emulator via Xcode

## Screenshots / Video (UI changes only)

Not a UI change

## Breaking changes

None

## Linked issues

Fixes https://github.com/NuvioMedia/NuvioMobile/issues/1305