### PR TITLE
fix(android): keep addon IMDb rating over TMDB vote average

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -647,7 +647,7 @@ object TmdbMetadataService {
             updated = updated.copy(
                 name = enrichment.localizedTitle ?: updated.name,
                 description = enrichment.description ?: updated.description,
-                imdbRating = enrichment.rating?.formatRating() ?: updated.imdbRating,
+                imdbRating = updated.imdbRating ?: enrichment.rating?.formatRating(),
                 genres = enrichment.genres.ifEmpty { updated.genres },
             )
         }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt
@@ -116,6 +116,96 @@ class TmdbMetadataServiceTest {
     }
 
     @Test
+    fun `applyEnrichment keeps addon imdb rating instead of tmdb vote average`() {
+        val base = MetaDetails(
+            id = "tt0468569",
+            type = "movie",
+            name = "The Dark Knight",
+            imdbRating = "9.1",
+            videos = listOf(
+                MetaVideo(
+                    id = "movie",
+                    title = "The Dark Knight",
+                ),
+            ),
+        )
+        val enrichment = TmdbEnrichment(
+            localizedTitle = "The Dark Knight",
+            description = "TMDB description",
+            genres = listOf("Action"),
+            backdrop = "backdrop",
+            logo = "logo",
+            poster = "poster",
+            people = emptyList(),
+            director = emptyList(),
+            writer = emptyList(),
+            releaseInfo = "2008-07-18",
+            rating = 8.531,
+            runtimeMinutes = 152,
+            ageRating = "PG-13",
+            status = "Released",
+            countries = listOf("US"),
+            language = "en",
+            productionCompanies = emptyList(),
+            networks = emptyList(),
+        )
+
+        val result = TmdbMetadataService.applyEnrichment(
+            meta = base,
+            enrichment = enrichment,
+            episodeMap = emptyMap(),
+            settings = TmdbSettings(enabled = true),
+        )
+
+        assertEquals("9.1", result.imdbRating)
+    }
+
+    @Test
+    fun `applyEnrichment falls back to tmdb rating when addon has none`() {
+        val base = MetaDetails(
+            id = "tt0468569",
+            type = "movie",
+            name = "The Dark Knight",
+            imdbRating = null,
+            videos = listOf(
+                MetaVideo(
+                    id = "movie",
+                    title = "The Dark Knight",
+                ),
+            ),
+        )
+        val enrichment = TmdbEnrichment(
+            localizedTitle = "The Dark Knight",
+            description = "TMDB description",
+            genres = listOf("Action"),
+            backdrop = "backdrop",
+            logo = "logo",
+            poster = "poster",
+            people = emptyList(),
+            director = emptyList(),
+            writer = emptyList(),
+            releaseInfo = "2008-07-18",
+            rating = 8.531,
+            runtimeMinutes = 152,
+            ageRating = "PG-13",
+            status = "Released",
+            countries = listOf("US"),
+            language = "en",
+            productionCompanies = emptyList(),
+            networks = emptyList(),
+        )
+
+        val result = TmdbMetadataService.applyEnrichment(
+            meta = base,
+            enrichment = enrichment,
+            episodeMap = emptyMap(),
+            settings = TmdbSettings(enabled = true),
+        )
+
+        assertEquals("8.5", result.imdbRating)
+    }
+
+    @Test
     fun `applyEnrichment preserves disabled groups`() {
         val base = MetaDetails(
             id = "tt7654321",


### PR DESCRIPTION
## Summary

The IMDb rating shown on the details screen was being replaced with TMDB's `vote_average` during metadata enrichment. The value rendered under the IMDb logo/label was therefore TMDB's rating, not the IMDb rating. This change keeps the addon-provided IMDb rating and only falls back to TMDB when the addon supplies none.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

In `TmdbMetadataService.applyEnrichment`, the `useBasicInfo` branch assigned:

```kotlin
imdbRating = enrichment.rating?.formatRating() ?: updated.imdbRating
```

`enrichment.rating` is sourced from TMDB's `details.voteAverage`. Because TMDB's value took priority via `?:`, whenever TMDB enrichment was enabled (the default when a TMDB API key is configured) the real IMDb rating parsed from the meta addon (e.g. Cinemeta's `imdbRating`) was overwritten with TMDB's `vote_average`. The details screen (`DetailMetaInfo`) renders `meta.imdbRating` under the IMDb logo and yellow IMDb styling, so users saw a TMDB rating mislabeled as IMDb.

Empirical check (TMDB v3 API vs Cinemeta) for *The Dark Knight*: Cinemeta `imdbRating` = `9.1`, TMDB `vote_average` = `8.531` → formatted `8.5`. The app displayed `8.5` under the IMDb label instead of `9.1`. TMDB's `vote_average` diverges from the IMDb rating for the majority of titles, matching the report's "Often (more than 50%)".

## Issue or approval

Fixes #1271

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

Old behavior: IMDb-labeled rating showed TMDB's `vote_average` whenever TMDB enrichment was enabled.
Broken behavior: the displayed IMDb rating was wrong for most titles.
New behavior: the addon-provided IMDb rating is shown; TMDB's rating is used only as a fallback when the addon provides no IMDb rating (e.g. the standalone TMDB-only path is unchanged). No layout, color, or label changes.

## Policy check

- [x] I have read and understood CONTRIBUTING.md.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- `composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt` — in `applyEnrichment`, the `useBasicInfo` branch now prefers `updated.imdbRating` (addon value) and falls back to `enrichment.rating?.formatRating()` (TMDB value) instead of the reverse. One line changed.
- `composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt` — two added unit tests.

No other files touched. No formatting/rename changes.

## Testing

- `./gradlew :composeApp:assembleFullDebug` → BUILD SUCCESSFUL.
- `./gradlew :composeApp:testFullDebugUnitTest --tests "com.nuvio.app.features.tmdb.TmdbMetadataServiceTest"` → BUILD SUCCESSFUL (all pass), including the two new tests:
  - `applyEnrichment keeps addon imdb rating instead of tmdb vote average` — base `imdbRating = "9.1"`, `enrichment.rating = 8.531`; asserts result is `"9.1"` (fails before this change, which produced `"8.5"`).
  - `applyEnrichment falls back to tmdb rating when addon has none` — base `imdbRating = null`, `enrichment.rating = 8.531`; asserts result is `"8.5"` (fallback path preserved).
- Full suite: 4 unrelated tests fail (`LibraryRepositoryTest`, `StreamAutoPlaySelectorTest`); these fail identically on a clean `cmp-rewrite` checkout without this change and are pre-existing.
- Blast radius (`applyEnrichment`): used only by `enrichMeta` → `MetaDetailsRepository.tryFetchMeta`. The standalone TMDB-only path (`buildStandaloneMeta`) is intentionally left unchanged, so titles without an addon meta are unaffected.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1271
