### PR TITLE
fix: dismiss resume prompt when launching from continue watching

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -1215,6 +1215,7 @@ private fun MainAppContent(
         }
 
         val openContinueWatching: (ContinueWatchingItem, Boolean, Boolean) -> Unit = { item, manualSelection, startFromBeginning ->
+            resumePromptItem = null
             if (item.isCloudLibraryContinueWatchingItem()) {
                 coroutineScope.launch {
                     when (


### PR DESCRIPTION
## Summary

Dismiss the "Continue where you left off" floating resume prompt when playback is started from the Continue Watching row. Previously nothing on that path cleared the prompt, so the banner stayed overlaid on the stream-loading screen and the player (until a 15 s auto-dismiss timer fired).

## PR type

- [x] Behavior bug/regression fix

## Why

The launch resume prompt (`NuvioFloatingPrompt`) is rendered in the root `Box` of `App.kt` with `zIndex(15f)`, so it floats above every navigation destination. Its backing state, `resumePromptItem`, is only cleared by the prompt's own Resume/dismiss actions or the 15-second auto-dismiss. All Continue Watching playback launches funnel through the `openContinueWatching` lambda in `App.kt`, which never cleared `resumePromptItem` — so tapping a Continue Watching item while the banner was visible left it floating over the stream-loading UI and the player, exactly as reported in #1273. The prompt's own `onAction` handler already sets `resumePromptItem = null` before launching the same playback path; this change applies the identical dismissal to the Continue Watching row path.

## Issue or approval

Fixes #1273

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

`composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt` — one line added at the top of the `openContinueWatching` lambda: `resumePromptItem = null`. No layout, styling, navigation, or playback logic touched; no other files changed.

## Testing

Build: `./gradlew :composeApp:compileCommonMainKotlinMetadata` — BUILD SUCCESSFUL, zero compiler errors (the change is in the `commonMain` source set; the Android SDK is unavailable in this CI environment, so the platform variants were not assembled).

A unit test is not feasible: the affected state is a Compose `remember` variable inside the root `App` composable with no framework-free seam.

STATIC ANALYSIS:
- before fix: app launch shows the resume prompt (root-level overlay). User taps an item in the Continue Watching row → `openContinueWatching` → `launchPlaybackWithDownloadPreference` (or cloud-library launch). `resumePromptItem` is never written on this path, so the banner remains rendered above the stream-loading screen and the player until the 15 s auto-dismiss fires or the user swipes it away.
- after fix: `openContinueWatching` clears `resumePromptItem` first, so the overlay disappears the moment any Continue Watching launch begins — matching the prompt's own Resume button, which already clears the state before invoking the same lambda.
- edge cases: (1) Launch via the prompt's Resume button — `onAction` already nulls the state, so the added write is a no-op. (2) Cloud-library failure branches (not connected / not found) — the prompt is dismissed before the toast; the user actively chose an item, so the launch-time prompt is stale either way. (3) Re-population — the `LaunchedEffect` that sets the prompt only runs when `resumePromptItem == null` and `consumeResumePrompt()` returns an item; storage is consumed on first read, so the prompt cannot reappear after being cleared.
- regression risk: a single assignment to UI state that already has identical writes in the prompt's `onAction` and `onDismiss` handlers. No data, navigation, or playback logic changed.

## Screenshots / Video

Not a UI change (no layout or styling modified; the fix only clears stale overlay state per the documented bug — the "before" state is shown in the screenshot attached to #1273).

## Breaking changes

None.

## Linked issues

Fixes #1273
