### PR TITLE
Fix Trakt scrobble for non-standard IDs

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktIdUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktIdUtils.kt
@@ -54,3 +54,49 @@ internal fun extractTraktYear(value: String?): Int? {
 
 internal fun TraktExternalIds.hasAnyId(): Boolean =
     trakt != null || !imdb.isNullOrBlank() || tmdb != null || !slug.isNullOrBlank()
+
+/**
+ * Returns true if the given contentId uses a Trakt-compatible prefix
+ * (IMDB, TMDB, or Trakt numeric). IDs from other sources (kitsu:, mal:,
+ * anilist:, anidb:, tvdb:, etc.) are NOT Trakt-resolvable and should be
+ * preserved locally rather than being discarded when absent from Trakt
+ * remote responses.
+ */
+internal fun isTraktCompatibleId(contentId: String?): Boolean {
+    if (contentId.isNullOrBlank()) return false
+    val raw = contentId.trim()
+    if (raw.startsWith("tt")) return true
+    if (raw.startsWith("tmdb:", ignoreCase = true)) return true
+    if (raw.startsWith("trakt:", ignoreCase = true)) return true
+    // Pure numeric IDs are treated as Trakt IDs
+    val beforeColon = raw.substringBefore(':')
+    if (beforeColon.toIntOrNull() != null) return true
+    return false
+}
+
+/**
+ * If [contentId] is not Trakt-resolvable but [videoId] contains a valid
+ * IMDB or TMDB prefix, extract and return the resolved ID from videoId.
+ * This handles addons that wrap real IDs in non-standard content IDs
+ * (e.g. contentId = "tun_tt7821582", videoId = "tt7821582:3:7").
+ *
+ * Returns the original [contentId] if it's already valid or if no
+ * better ID can be extracted from [videoId].
+ */
+internal fun resolveEffectiveContentId(contentId: String, videoId: String?): String {
+    val parsedContent = parseTraktContentIds(contentId)
+    if (parsedContent.hasAnyId()) return contentId
+
+    if (videoId.isNullOrBlank() || videoId == contentId) return contentId
+
+    val parsedVideo = parseTraktContentIds(videoId)
+    if (!parsedVideo.hasAnyId()) return contentId
+
+    // Rebuild a canonical content ID from the resolved video IDs
+    return when {
+        !parsedVideo.imdb.isNullOrBlank() -> parsedVideo.imdb
+        parsedVideo.tmdb != null -> "tmdb:${parsedVideo.tmdb}"
+        parsedVideo.trakt != null -> parsedVideo.trakt.toString()
+        else -> contentId
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktScrobbleRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktScrobbleRepository.kt
@@ -81,7 +81,19 @@ internal object TraktScrobbleRepository {
         releaseInfo: String? = null,
     ): TraktScrobbleItem? {
         val normalizedType = contentType.trim().lowercase()
-        val ids = parseTraktContentIds(parentMetaId)
+        var ids = parseTraktContentIds(parentMetaId)
+
+        // Fallback: if parentMetaId doesn't resolve to valid Trakt IDs, try videoId.
+        // Some addons use non-standard contentId (e.g. "tun_tt7821582") but set a
+        // valid IMDB/TMDB videoId (e.g. "tt7821582:3:7").
+        if (!ids.hasAnyId() && !videoId.isNullOrBlank() && videoId != parentMetaId) {
+            ids = parseTraktContentIds(videoId)
+        }
+
+        // Don't send scrobble if we still have no valid Trakt IDs — would cause
+        // title-based fuzzy match on Trakt API resulting in wrong show matched.
+        if (!ids.hasAnyId()) return null
+
         val parsedYear = extractTraktYear(releaseInfo)
 
         return if (

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/WatchProgressRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watchprogress/WatchProgressRepository.kt
@@ -14,6 +14,8 @@ import com.nuvio.app.features.profiles.ProfileRepository
 import com.nuvio.app.features.trakt.TraktAuthRepository
 import com.nuvio.app.features.trakt.TraktProgressRepository
 import com.nuvio.app.features.trakt.TraktSettingsRepository
+import com.nuvio.app.features.trakt.isTraktCompatibleId
+import com.nuvio.app.features.trakt.resolveEffectiveContentId
 import com.nuvio.app.features.trakt.shouldUseTraktProgress as shouldUseTraktProgressSource
 import com.nuvio.app.features.watching.application.WatchingActions
 import com.nuvio.app.features.watching.sync.ProgressDeltaEvent
@@ -806,9 +808,20 @@ object WatchProgressRepository {
             return
         }
 
+        val useTraktProgress = shouldUseTraktProgress()
+
+        // If Trakt is the active CW source and parentMetaId is not Trakt-resolvable
+        // but videoId contains a valid IMDB/TMDB, use the resolved ID to avoid
+        // duplicate CW entries (one local with garbage ID, one from Trakt with real ID).
+        val effectiveParentMetaId = if (useTraktProgress) {
+            resolveEffectiveContentId(session.parentMetaId, session.videoId)
+        } else {
+            session.parentMetaId
+        }
+
         val entry = WatchProgressEntry(
             contentType = session.contentType,
-            parentMetaId = session.parentMetaId,
+            parentMetaId = effectiveParentMetaId,
             parentMetaType = session.parentMetaType,
             videoId = session.videoId,
             title = session.title,
@@ -834,8 +847,6 @@ object WatchProgressRepository {
         if (entry.parentMetaType.equals("series", ignoreCase = true)) {
             ContinueWatchingPreferencesRepository.removeDismissedNextUpKeysForContent(entry.parentMetaId)
         }
-
-        val useTraktProgress = shouldUseTraktProgress()
 
         entriesByVideoId[session.videoId] = entry
         if (useTraktProgress) {
@@ -925,7 +936,25 @@ object WatchProgressRepository {
 
     private fun currentEntries(): List<WatchProgressEntry> {
         return if (shouldUseTraktProgress()) {
-            TraktProgressRepository.uiState.value.entries
+            // Merge Trakt remote progress with local-only entries that use
+            // non-Trakt-compatible IDs (kitsu:, mal:, anilist:, etc.).
+            // Trakt will never return these IDs, so they must come from local storage.
+            val traktItems = TraktProgressRepository.uiState.value.entries
+            val localNonTraktItems = entriesByVideoId.values.filter {
+                !isTraktCompatibleId(it.parentMetaId)
+            }
+            if (localNonTraktItems.isEmpty()) {
+                traktItems
+            } else {
+                val traktKeys = traktItems.map { it.videoId }.toSet()
+                val merged = traktItems.toMutableList()
+                localNonTraktItems.forEach { localItem ->
+                    if (localItem.videoId !in traktKeys) {
+                        merged.add(localItem)
+                    }
+                }
+                merged
+            }
         } else {
             entriesByVideoId.values.toList()
         }


### PR DESCRIPTION
## Summary

Port Trakt scrobble and Continue Watching fixes from NuvioTV (PRs #2202, #2220, #2238). Alignment with functionality already shipping in the TV version.

1. Don't send Trakt scrobble when contentId resolves to no valid IDs (prevents wrong title-based fuzzy match)
2. Fallback to videoId when contentId is not Trakt-resolvable (handles addons with non-standard IDs like `tun_tt7821582`)
3. Preserve non-Trakt-compatible CW entries (kitsu:, mal:, anilist:) when Trakt is the active progress source

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

When using anime addons that provide non-standard content IDs (kitsu:, mal:, anilist:, or prefixed like `tun_tt7821582`):
- Trakt scrobble was sent with just a title, causing wrong show to be matched (e.g. One Piece anime matched to live-action)
- Continue Watching lost non-Trakt entries when Trakt was the active CW source, since Trakt API never returns those IDs
- Addons providing valid IMDB in videoId but garbage in contentId had no scrobble or duplicate CW entries

All three bugs are already fixed in NuvioTV. This PR brings parity to mobile.

## Issue or approval

No linked issue - feature parity port from NuvioTV PRs #2202, #2220, #2238.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not add Kitsu->IMDB resolution (separate concern)
- Does not change Nuvio Sync merge logic (already handles non-Trakt IDs correctly)
- Does not modify UI, stream selection, or badge logic
- NuvioTV also fixed "stop playback on episode switch" in #2202 — intentionally omitted here as NuvioMobile handles episode transitions differently

## Testing

- Built successfully with `compileFullDebugKotlinAndroid`
- Verified `buildItem()` returns null for kitsu:12 contentId with no videoId fallback (no scrobble sent)
- Verified `buildItem()` returns valid item for contentId `tun_tt7821582` with videoId `tt7821582:3:7` (IMDB extracted from videoId)
- Verified `currentEntries()` merges local non-Trakt items alongside Trakt remote items when Trakt is active CW source
- Verified `resolveEffectiveContentId` returns original ID when already valid, falls back to videoId when not

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - feature parity port from NuvioTV PRs #2202, #2220, #2238.
