### PR TITLE
Add optional addon logo display on stream cards

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/streams/StreamBadgeSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/streams/StreamBadgeSettingsStorage.android.kt
@@ -16,6 +16,7 @@ actual object StreamBadgeSettingsStorage {
     private const val legacyDebridPreferencesName = "nuvio_debrid_settings"
     private const val streamBadgeRulesKey = "stream_badge_rules"
     private const val showFileSizeBadgesKey = "show_file_size_badges"
+    private const val showAddonLogoKey = "show_addon_logo"
     private const val streamBadgePlacementKey = "stream_badge_placement"
     private const val legacyDebridStreamBadgeRulesKey = "debrid_stream_badge_rules"
 
@@ -39,6 +40,12 @@ actual object StreamBadgeSettingsStorage {
 
     actual fun saveShowFileSizeBadges(enabled: Boolean) {
         saveBoolean(showFileSizeBadgesKey, enabled)
+    }
+
+    actual fun loadShowAddonLogo(): Boolean? = loadBoolean(showAddonLogoKey)
+
+    actual fun saveShowAddonLogo(enabled: Boolean) {
+        saveBoolean(showAddonLogoKey, enabled)
     }
 
     actual fun loadStreamBadgePlacement(): String? = loadString(streamBadgePlacementKey)

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -1456,4 +1456,7 @@
     <string name="cloud_library_type_torrents">Torrenty</string>
     <string name="cloud_library_type_usenet">Usenet</string>
     <string name="cloud_library_type_web">Web</string>
+    <string name="settings_stream_addon_logo_title">Logo dodatku</string>
+    <string name="settings_stream_addon_logo_description">Pokazuj logo i nazwę dodatku obok źródeł.</string>
+    <string name="settings_stream_display_section">Wyświetlanie</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -681,6 +681,9 @@
     <string name="settings_stream_badges_section">Fusion Style</string>
     <string name="settings_stream_size_badges_title">Size badges</string>
     <string name="settings_stream_size_badges_description">Show file size badges in stream results and player source panels.</string>
+    <string name="settings_stream_addon_logo_title">Addon logo</string>
+    <string name="settings_stream_addon_logo_description">Show addon logo and name next to stream sources.</string>
+    <string name="settings_stream_display_section">Display</string>
     <string name="settings_stream_badge_position_title">Badge position</string>
     <string name="settings_stream_badge_position_description">Choose whether Fusion and size badges appear above or below stream cards.</string>
     <string name="settings_stream_badge_position_dialog_title">Badge position</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsSearch.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsSearch.kt
@@ -465,6 +465,15 @@ internal fun settingsSearchEntries(
     val playbackNextEpisode = stringResource(Res.string.settings_playback_section_next_episode)
     addRow(
         page = SettingsPage.Streams,
+        key = "stream-addon-logo",
+        title = stringResource(Res.string.settings_stream_addon_logo_title),
+        description = stringResource(Res.string.settings_stream_addon_logo_description),
+        pageLabel = streamsPage,
+        section = stringResource(Res.string.settings_stream_display_section),
+        icon = Icons.Rounded.Style,
+    )
+    addRow(
+        page = SettingsPage.Streams,
         key = "stream-size-badges",
         title = stringResource(Res.string.settings_stream_size_badges_title),
         description = stringResource(Res.string.settings_stream_size_badges_description),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/StreamsSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/StreamsSettingsPage.kt
@@ -87,6 +87,9 @@ import nuvio.composeapp.generated.resources.settings_stream_badge_urls_title
 import nuvio.composeapp.generated.resources.settings_stream_badges_section
 import nuvio.composeapp.generated.resources.settings_stream_size_badges_description
 import nuvio.composeapp.generated.resources.settings_stream_size_badges_title
+import nuvio.composeapp.generated.resources.settings_stream_addon_logo_title
+import nuvio.composeapp.generated.resources.settings_stream_addon_logo_description
+import nuvio.composeapp.generated.resources.settings_stream_display_section
 import org.jetbrains.compose.resources.stringResource
 
 internal fun LazyListScope.streamsSettingsContent(isTablet: Boolean) {
@@ -125,6 +128,21 @@ internal fun LazyListScope.streamsSettingsContent(isTablet: Boolean) {
                     icon = Icons.Rounded.Style,
                     isTablet = isTablet,
                     onClick = { showBadgeImportDialog = true },
+                )
+            }
+        }
+
+        SettingsSection(
+            title = stringResource(Res.string.settings_stream_display_section),
+            isTablet = isTablet,
+        ) {
+            SettingsGroup(isTablet = isTablet) {
+                SettingsSwitchRow(
+                    title = stringResource(Res.string.settings_stream_addon_logo_title),
+                    description = stringResource(Res.string.settings_stream_addon_logo_description),
+                    checked = currentSettings.showAddonLogo,
+                    isTablet = isTablet,
+                    onCheckedChange = StreamBadgeSettingsRepository::setShowAddonLogo,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamBadgeSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamBadgeSettingsRepository.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.Json
 data class StreamBadgeSettingsUiState(
     val rules: StreamBadgeRules = StreamBadgeRules(),
     val showFileSizeBadges: Boolean = true,
+    val showAddonLogo: Boolean = false,
     val badgePlacement: StreamBadgePlacement = StreamBadgePlacement.BOTTOM,
 )
 
@@ -36,6 +37,7 @@ object StreamBadgeSettingsRepository {
     private var hasLoaded = false
     private var streamBadgeRules = StreamBadgeRules()
     private var showFileSizeBadges = true
+    private var showAddonLogo = false
     private var badgePlacement = StreamBadgePlacement.BOTTOM
 
     fun ensureLoaded() {
@@ -51,6 +53,7 @@ object StreamBadgeSettingsRepository {
         hasLoaded = false
         streamBadgeRules = StreamBadgeRules()
         showFileSizeBadges = true
+        showAddonLogo = false
         badgePlacement = StreamBadgePlacement.BOTTOM
         _uiState.value = StreamBadgeSettingsUiState()
     }
@@ -133,6 +136,14 @@ object StreamBadgeSettingsRepository {
         StreamBadgeSettingsStorage.saveShowFileSizeBadges(enabled)
     }
 
+    fun setShowAddonLogo(enabled: Boolean) {
+        ensureLoaded()
+        if (showAddonLogo == enabled) return
+        showAddonLogo = enabled
+        publish()
+        StreamBadgeSettingsStorage.saveShowAddonLogo(enabled)
+    }
+
     fun setBadgePlacement(placement: StreamBadgePlacement) {
         ensureLoaded()
         if (badgePlacement == placement) return
@@ -151,6 +162,7 @@ object StreamBadgeSettingsRepository {
         }
         streamBadgeRules = storedRules ?: legacyRules ?: StreamBadgeRules()
         showFileSizeBadges = StreamBadgeSettingsStorage.loadShowFileSizeBadges() ?: true
+        showAddonLogo = StreamBadgeSettingsStorage.loadShowAddonLogo() ?: false
         badgePlacement = StreamBadgeSettingsStorage.loadStreamBadgePlacement()
             ?.let { storedPlacement ->
                 StreamBadgePlacement.entries.firstOrNull { placement ->
@@ -169,6 +181,7 @@ object StreamBadgeSettingsRepository {
         _uiState.value = StreamBadgeSettingsUiState(
             rules = streamBadgeRules,
             showFileSizeBadges = showFileSizeBadges,
+            showAddonLogo = showAddonLogo,
             badgePlacement = badgePlacement,
         )
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamBadgeSettingsStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamBadgeSettingsStorage.kt
@@ -7,6 +7,8 @@ internal expect object StreamBadgeSettingsStorage {
     fun saveStreamBadgeRules(rules: String)
     fun loadShowFileSizeBadges(): Boolean?
     fun saveShowFileSizeBadges(enabled: Boolean)
+    fun loadShowAddonLogo(): Boolean?
+    fun saveShowAddonLogo(enabled: Boolean)
     fun loadStreamBadgePlacement(): String?
     fun saveStreamBadgePlacement(placement: String)
     fun loadLegacyDebridStreamBadgeRules(): String?

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamModels.kt
@@ -17,6 +17,7 @@ data class StreamItem(
     val sourceName: String? = null,
     val addonName: String,
     val addonId: String,
+    val addonLogo: String? = null,
     val behaviorHints: StreamBehaviorHints = StreamBehaviorHints(),
     val clientResolve: StreamClientResolve? = null,
     val debridCacheStatus: StreamDebridCacheStatus? = null,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamParser.kt
@@ -18,6 +18,7 @@ object StreamParser {
         payload: String,
         addonName: String,
         addonId: String,
+        addonLogo: String? = null,
     ): List<StreamItem> {
         val root = json.parseToJsonElement(payload).jsonObject
         val streamsArray = root["streams"] as? JsonArray ?: return emptyList()
@@ -46,6 +47,7 @@ object StreamParser {
                 sources = obj.stringList("sources"),
                 addonName = addonName,
                 addonId = addonId,
+                addonLogo = addonLogo,
                 clientResolve = clientResolve,
                 behaviorHints = StreamBehaviorHints(
                     bingeGroup = hintsObj?.string("bingeGroup"),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
@@ -456,6 +456,7 @@ object StreamsRepository {
                             payload = payload,
                             addonName = displayName,
                             addonId = addon.addonId,
+                            addonLogo = addon.manifest.logoUrl,
                         )
                     }.fold(
                         onSuccess = { streams ->

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsScreen.kt
@@ -833,6 +833,7 @@ internal fun StreamList(
                         debridEnabled = debridEnabled,
                         appendInstantServiceToDefaultName = appendInstantServiceToDefaultName,
                         showFileSizeBadges = streamBadgeSettings.showFileSizeBadges,
+                        showAddonLogo = streamBadgeSettings.showAddonLogo,
                         badgePlacement = streamBadgeSettings.badgePlacement,
                         onStreamSelected = onStreamSelected,
                         onStreamLongPress = onStreamLongPress,
@@ -860,6 +861,7 @@ private fun LazyListScope.streamSection(
     debridEnabled: Boolean,
     appendInstantServiceToDefaultName: Boolean,
     showFileSizeBadges: Boolean,
+    showAddonLogo: Boolean,
     badgePlacement: StreamBadgePlacement,
     onStreamSelected: (stream: StreamItem, resumePositionMs: Long?, resumeProgressFraction: Float?) -> Unit,
     onStreamLongPress: (StreamItem) -> Unit,
@@ -907,6 +909,7 @@ private fun LazyListScope.streamSection(
                 enabled = stream.isSelectableForPlayback(debridEnabled),
                 appendInstantServiceToDefaultName = appendInstantServiceToDefaultName,
                 showFileSizeBadges = showFileSizeBadges,
+                showAddonLogo = showAddonLogo,
                 badgePlacement = badgePlacement,
                 onClick = {
                     if (stream.isSelectableForPlayback(debridEnabled)) {
@@ -1014,6 +1017,7 @@ private fun StreamCard(
     enabled: Boolean,
     appendInstantServiceToDefaultName: Boolean,
     showFileSizeBadges: Boolean,
+    showAddonLogo: Boolean,
     badgePlacement: StreamBadgePlacement,
     onClick: () -> Unit,
     onLongClick: (() -> Unit)? = null,
@@ -1040,7 +1044,7 @@ private fun StreamCard(
                 onLongClick = onLongClick,
             )
             .padding(14.dp),
-        verticalAlignment = Alignment.Top,
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(modifier = Modifier.weight(1f)) {
             if (hasBadges && badgePlacement == StreamBadgePlacement.TOP) {
@@ -1076,6 +1080,31 @@ private fun StreamCard(
                     badgeImages = badgeImages,
                     stream = stream,
                     showFileSizeBadges = showFileSizeBadges,
+                )
+            }
+        }
+
+        if (showAddonLogo) {
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                if (!stream.addonLogo.isNullOrBlank()) {
+                    AsyncImage(
+                        model = stream.addonLogo,
+                        contentDescription = stream.addonName,
+                        modifier = Modifier
+                            .size(28.dp)
+                            .clip(RoundedCornerShape(6.dp)),
+                        contentScale = ContentScale.Fit,
+                    )
+                }
+                Spacer(modifier = Modifier.height(2.dp))
+                Text(
+                    text = stream.addonName,
+                    style = MaterialTheme.typography.labelSmall.copy(fontSize = 10.sp),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 1,
                 )
             }
         }

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/streams/StreamBadgeSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/streams/StreamBadgeSettingsStorage.ios.kt
@@ -13,6 +13,7 @@ import platform.Foundation.NSUserDefaults
 actual object StreamBadgeSettingsStorage {
     private const val streamBadgeRulesKey = "stream_badge_rules"
     private const val showFileSizeBadgesKey = "show_file_size_badges"
+    private const val showAddonLogoKey = "show_addon_logo"
     private const val streamBadgePlacementKey = "stream_badge_placement"
     private const val legacyDebridStreamBadgeRulesKey = "debrid_stream_badge_rules"
     private val syncKeys = listOf(streamBadgeRulesKey, showFileSizeBadgesKey, streamBadgePlacementKey)
@@ -27,6 +28,12 @@ actual object StreamBadgeSettingsStorage {
 
     actual fun saveShowFileSizeBadges(enabled: Boolean) {
         saveBoolean(showFileSizeBadgesKey, enabled)
+    }
+
+    actual fun loadShowAddonLogo(): Boolean? = loadBoolean(showAddonLogoKey)
+
+    actual fun saveShowAddonLogo(enabled: Boolean) {
+        saveBoolean(showAddonLogoKey, enabled)
     }
 
     actual fun loadStreamBadgePlacement(): String? = loadString(streamBadgePlacementKey)


### PR DESCRIPTION
## Summary

Add a "Display" settings section in Streams settings with a toggle to show addon logo and name next to stream sources. When enabled, each stream card displays the addon icon and name in a column on the right side. Disabled by default on mobile.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

Provides visual context for which addon each stream comes from, especially useful when multiple addons return results. Already implemented in the TV version (enabled by default there). On mobile it's opt-in to keep the compact card layout clean by default.

## Issue or approval

https://github.com/NuvioMedia/NuvioTV/pull/2258

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Setting defaults to OFF on mobile (TV defaults to ON)
- Only affects stream cards on the streams screen, not player source panels
- Addon logo URL comes from the addon manifest (`logoUrl`) - no new network requests
- No changes to stream fetching, parsing logic, or badge system

## Testing

- Built successfully with `compileFullDebugKotlinAndroid` + `assembleFullDebug`
- Toggle ON: addon logo (28dp, rounded) + name displayed on right side of stream card
- Toggle OFF: stream card renders as before, no logo column
- Addons without logo URL: only name shown (no broken image)
- Setting persists across app restarts (SharedPreferences on Android, NSUserDefaults on iOS)
- Searchable in Settings search under "Display" section
- Polish translation included

## Screenshots / Video (UI changes only)

<img width="1264" height="2780" alt="Screenshot_2026-06-10-14-44-37-68_f1c980342b0e858ddfa283cbd93d4e69" src="https://github.com/user-attachments/assets/f184940e-301f-45fa-8f57-11ac4ae62c6c" />
<img width="1264" height="2780" alt="Screenshot_2026-06-10-14-47-57-51_f1c980342b0e858ddfa283cbd93d4e69" src="https://github.com/user-attachments/assets/cc4cb4fb-8f23-4c12-9bf2-2da41a9b4566" />


## Breaking changes

None.

## Linked issues

https://github.com/NuvioMedia/NuvioTV/pull/2258
