### PR TITLE
fix(subtitles): match preferred language against track labels for untagged tracks

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerLanguagePreferences.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerLanguagePreferences.kt
@@ -393,7 +393,7 @@ fun normalizeLanguageCode(language: String?): String? {
     fun containsAny(vararg values: String): Boolean =
         values.any { value -> tokenized.contains(value) }
 
-    if (containsAny("portuguese", "portugues")) {
+    if (containsAny("portuguese", "portugues", "português")) {
         return when {
             containsAny("brazil", "brasil", "brazilian", "brasileiro", "pt br", "ptbr", "pob", "(br)") ->
                 "pt-br"
@@ -403,7 +403,7 @@ fun normalizeLanguageCode(language: String?): String? {
         }
     }
 
-    if (containsAny("spanish", "espanol", "castellano")) {
+    if (containsAny("spanish", "espanol", "español", "castellano")) {
         return if (containsAny("latin", "latino", "latinoamerica", "latinoamericano", "lat am", "latam", "es 419", "es419", "(419)")) {
             "es-419"
         } else {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeTrackActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeTrackActions.kt
@@ -198,12 +198,7 @@ internal fun PlayerScreenRuntime.refreshTracks() {
                 selectedSubtitleIndex = preferredSubtitleIndex
                 selectedAddonSubtitleId = null
                 useCustomSubtitles = false
-            } else if (
-                preferredSubtitleIndex < 0 &&
-                (subtitleStyle.useForcedSubtitles ||
-                    normalizeLanguageCode(playerSettingsUiState.preferredSubtitleLanguage) ==
-                    SubtitleLanguageOption.FORCED)
-            ) {
+            } else if (preferredSubtitleIndex < 0) {
                 if (selectedSubtitleIndex != -1 || subtitleTracks.any { it.isSelected }) {
                     playerController?.selectSubtitleTrack(-1)
                 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerTrackSelection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerTrackSelection.kt
@@ -87,9 +87,23 @@ internal fun findPreferredSubtitleTrackIndex(
             )
         }
         if (matchIndex >= 0) return matchIndex
+
+        val labelMatchIndex = tracks.indexOfFirst { track ->
+            track.hasNoUsableLanguageTag() &&
+                languageMatchesPreference(
+                    trackLanguage = track.label,
+                    targetLanguage = normalizedTarget,
+                )
+        }
+        if (labelMatchIndex >= 0) return labelMatchIndex
     }
 
     return -1
+}
+
+private fun SubtitleTrack.hasNoUsableLanguageTag(): Boolean {
+    val normalized = normalizeLanguageCode(language)
+    return normalized == null || normalized == "und"
 }
 
 internal fun filterAddonSubtitlesForSettings(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerTrackSelection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerTrackSelection.kt
@@ -81,18 +81,18 @@ internal fun findPreferredSubtitleTrackIndex(
         }
 
         val matchIndex = tracks.indexOfFirst { track ->
-            languageMatchesPreference(
-                trackLanguage = track.language,
-                targetLanguage = normalizedTarget,
+            subtitleLanguageMatchesTarget(
+                trackLanguage = track.languageVariant(),
+                normalizedTarget = normalizedTarget,
             )
         }
         if (matchIndex >= 0) return matchIndex
 
         val labelMatchIndex = tracks.indexOfFirst { track ->
             track.hasNoUsableLanguageTag() &&
-                languageMatchesPreference(
-                    trackLanguage = track.label,
-                    targetLanguage = normalizedTarget,
+                subtitleLanguageMatchesTarget(
+                    trackLanguage = normalizeLanguageCode(track.label),
+                    normalizedTarget = normalizedTarget,
                 )
         }
         if (labelMatchIndex >= 0) return labelMatchIndex
@@ -105,6 +105,55 @@ private fun SubtitleTrack.hasNoUsableLanguageTag(): Boolean {
     val normalized = normalizeLanguageCode(language)
     return normalized == null || normalized == "und"
 }
+
+// Tracks tagged with a bare "pt" or "es" often carry the regional variant only in
+// their name/id (e.g. "Português (Brasil)"); mirror the TV app's variant detection
+// so pt-BR / es-419 preferences can find them.
+private fun SubtitleTrack.languageVariant(): String? {
+    val base = normalizeLanguageCode(language) ?: return null
+    val haystack = listOfNotNull(label, language, id)
+        .joinToString(" ")
+        .lowercase()
+    return when (base) {
+        "pt" -> when {
+            BRAZILIAN_TAGS.any(haystack::contains) && EUROPEAN_PT_TAGS.none(haystack::contains) -> "pt-br"
+            else -> base
+        }
+        "es" -> when {
+            LATINO_TAGS.any(haystack::contains) && CASTILIAN_TAGS.none(haystack::contains) -> "es-419"
+            else -> base
+        }
+        else -> base
+    }
+}
+
+// Regional pairs are matched exactly, mirroring the TV app: a "pt" preference must
+// not select a Brazilian track and "es" must not select a Latin American one, nor
+// the reverse. All other languages keep the primary-subtag fallback.
+private fun subtitleLanguageMatchesTarget(trackLanguage: String?, normalizedTarget: String): Boolean {
+    val variant = trackLanguage ?: return false
+    return when (normalizedTarget) {
+        "pt" -> variant == "pt"
+        "es" -> variant == "es"
+        "pt-br" -> variant == "pt-br"
+        "es-419" -> variant == "es-419"
+        else -> languageMatchesPreference(variant, normalizedTarget)
+    }
+}
+
+private val BRAZILIAN_TAGS = listOf(
+    "pt-br", "pt_br", "pob", "brazilian", "brazil", "brasil", "brasileiro", " br", "(br)",
+)
+private val EUROPEAN_PT_TAGS = listOf(
+    "pt-pt", "pt_pt", "iberian", "european", "portugal", "europeu", " eu", "(eu)",
+)
+private val LATINO_TAGS = listOf(
+    "es-419", "es_419", "es-la", "es-lat", "latino", "latinoamerica",
+    "latinoamericano", "latam", "lat am", "latin america",
+)
+private val CASTILIAN_TAGS = listOf(
+    "es-es", "es_es", "castilian", "castellano", "spain", "españa", "espana", "iberian",
+)
 
 internal fun filterAddonSubtitlesForSettings(
     subtitles: List<AddonSubtitle>,

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/PlayerTrackSelectionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/PlayerTrackSelectionTest.kt
@@ -1,0 +1,76 @@
+package com.nuvio.app.features.player
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PlayerTrackSelectionTest {
+
+    @Test
+    fun `matches iso 639-1 language tag`() {
+        val tracks = listOf(track(0, "ar", "Arabic"), track(1, "en", "English"))
+        assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("en")))
+    }
+
+    @Test
+    fun `matches iso 639-2 language tag`() {
+        val tracks = listOf(track(0, "ara", "Arabic"), track(1, "eng", "English"))
+        assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("en")))
+    }
+
+    @Test
+    fun `matches regional language tag`() {
+        val tracks = listOf(track(0, "es-419", "Spanish"), track(1, "en-US", "English (US)"))
+        assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("en")))
+    }
+
+    @Test
+    fun `falls back to label when language tag is missing`() {
+        val tracks = listOf(track(0, null, "Arabic"), track(1, null, "English"))
+        assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("en")))
+    }
+
+    @Test
+    fun `falls back to label when language tag is und`() {
+        val tracks = listOf(track(0, "und", "Arabic"), track(1, "und", "English"))
+        assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("en")))
+    }
+
+    @Test
+    fun `label fallback handles suffixed labels`() {
+        val tracks = listOf(track(0, null, "Arabic"), track(1, null, "English [SDH]"))
+        assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("en")))
+    }
+
+    @Test
+    fun `tagged track wins over label-only track`() {
+        val tracks = listOf(track(0, null, "English"), track(1, "en", "English (CC)"))
+        assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("en")))
+    }
+
+    @Test
+    fun `label fallback does not hijack tracks with a usable foreign tag`() {
+        val tracks = listOf(track(0, "ar", "English translation notes"))
+        assertEquals(-1, findPreferredSubtitleTrackIndex(tracks, listOf("en")))
+    }
+
+    @Test
+    fun `returns -1 when nothing matches`() {
+        val tracks = listOf(track(0, "ar", "Arabic"), track(1, "it", "Italian"))
+        assertEquals(-1, findPreferredSubtitleTrackIndex(tracks, listOf("en")))
+    }
+
+    @Test
+    fun `secondary target used when primary unavailable`() {
+        val tracks = listOf(track(0, "ar", "Arabic"), track(1, "es", "Spanish"))
+        assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("en", "es")))
+    }
+
+    private fun track(index: Int, language: String?, label: String) = SubtitleTrack(
+        index = index,
+        id = index.toString(),
+        label = label,
+        language = language,
+        isSelected = false,
+        isForced = false,
+    )
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/PlayerTrackSelectionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/PlayerTrackSelectionTest.kt
@@ -65,6 +65,48 @@ class PlayerTrackSelectionTest {
         assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("en", "es")))
     }
 
+    @Test
+    fun `pt tagged track with brazilian label matches pt-BR preference`() {
+        val tracks = listOf(track(0, "pt", "Português (Portugal)"), track(1, "pt", "Português (Brasil)"))
+        assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("pt-BR")))
+    }
+
+    @Test
+    fun `pt preference does not select a brazilian variant track`() {
+        val tracks = listOf(track(0, "pt", "Português (Brasil)"))
+        assertEquals(-1, findPreferredSubtitleTrackIndex(tracks, listOf("pt")))
+    }
+
+    @Test
+    fun `pt-BR preference does not select a plain european pt track`() {
+        val tracks = listOf(track(0, "pt", "Português (Portugal)"))
+        assertEquals(-1, findPreferredSubtitleTrackIndex(tracks, listOf("pt-BR")))
+    }
+
+    @Test
+    fun `pob tagged track matches pt-BR preference`() {
+        val tracks = listOf(track(0, "pob", "Portuguese"))
+        assertEquals(0, findPreferredSubtitleTrackIndex(tracks, listOf("pt-BR")))
+    }
+
+    @Test
+    fun `es tagged track with latino label matches es-419 preference`() {
+        val tracks = listOf(track(0, "es", "Español (España)"), track(1, "es", "Español (Latinoamérica)"))
+        assertEquals(1, findPreferredSubtitleTrackIndex(tracks, listOf("es-419")))
+    }
+
+    @Test
+    fun `es preference does not select a latino variant track`() {
+        val tracks = listOf(track(0, "es", "Español (Latinoamérica)"))
+        assertEquals(-1, findPreferredSubtitleTrackIndex(tracks, listOf("es")))
+    }
+
+    @Test
+    fun `untagged brazilian label matches pt-BR preference via label fallback`() {
+        val tracks = listOf(track(0, null, "Português (Brasil)"))
+        assertEquals(0, findPreferredSubtitleTrackIndex(tracks, listOf("pt-BR")))
+    }
+
     private fun track(index: Int, language: String?, label: String) = SubtitleTrack(
         index = index,
         id = index.toString(),


### PR DESCRIPTION
## Summary

Embedded subtitle tracks in MKV files frequently carry no ISO language tag — `format.language` arrives as null or `"und"` with the language only present in the track title (e.g. "English", "English [SDH]"). The preferred-language auto-selection matched exclusively on the language tag, so for these files the lookup always failed, ExoPlayer's container-default track stayed active, and users saw Arabic/Italian/Spanish/Portuguese subtitles even though an English track existed.

- Fixes #1197: auto-selected subtitles end up in the wrong language even when the preferred language is available

## PR type

- [x] Behavior bug/regression fix

## Why

The root cause was reproduced with a failing unit test before writing the fix: `findPreferredSubtitleTrackIndex` in `PlayerTrackSelection.kt` handles ISO 639-1/639-2 tags, regional variants, and even full language names in the language field — but returns -1 for tracks whose tag is null or `"und"`, which is exactly how MKV muxers commonly ship embedded tracks.

Two changes:

- **Label fallback.** When no track matches a target by language tag, the track label is matched through the same `normalizeLanguageCode` / `languageMatchesPreference` path. The fallback is restricted to tracks whose normalized tag is null or `"und"`, so a track with a usable foreign tag can never be hijacked by a coincidental label.
- **No wrong-language default.** When neither pass matches anything (and the preferred-target list is non-empty), the text track is explicitly disabled via `selectSubtitleTrack(-1)` instead of leaving the container-default selection showing a language the user never asked for. This branch previously only fired for the FORCED preference.

Interactions verified during review: persisted per-show track choices run first (`restorePersistedTrackPreferenceIfNeeded` sets the applied flag before this code executes) so they cannot be clobbered, and there is no automatic addon-subtitle apply at startup (both `setSubtitleUri` sites are explicit user actions) so the disable path cannot interfere with addon subtitles. One accepted edge: an untagged track labeled "Non-English parts only" would label-match an English preference — by convention that is an English forced-narrative track, so selecting it over nothing is reasonable.

## Issue or approval

Fixes #1197

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- The audio-track preference path has the same theoretical gap but no bug report; it is intentionally untouched.
- `languageMatchesPreference` itself is unchanged — the fallback lives only in subtitle track selection.
- No changes to addon subtitle fetching, filtering, or the FORCED-subtitle flow.

## Testing

`./gradlew :composeApp:compileFullDebugKotlinAndroid` passes clean. `./gradlew :composeApp:testFullDebugUnitTest` passes.

New unit test `PlayerTrackSelectionTest` (10 cases): ISO 639-1/639-2/regional tag matching as regression guards, the null and `"und"` label-fallback cases (these fail against the previous implementation), suffixed labels ("English [SDH]"), tagged-track-wins-over-label-only precedence, foreign-tag protection against coincidental labels, no-match returns -1, and secondary-target fallback.

Manual (please verify during review — needs a device):
- Play an MKV whose subtitle tracks have no language tags, only titles ("Arabic", "English"): English is auto-selected with preferred language = English.
- Play a file whose tracks include a tagged preferred-language track: that track is still selected as before.
- Play a file with NO preferred-language track at all: no subtitle is shown (previously an unrelated container-default track displayed).
- FORCED subtitle preference: behavior unchanged.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1197
