### PR TITLE
fix(player): hold next-episode prompt until playback ends when post-credits content exists

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
@@ -38,9 +38,9 @@ object PlayerNextEpisodeRules {
             val outroEndMs = (outroInterval.endTime * 1000.0).toLong()
             val hasPostCreditsTail = durationMs > 0L &&
                 outroEndMs > outroStartMs &&
-                (durationMs - outroEndMs) >= POST_CREDITS_THRESHOLD_MS
+                (durationMs - outroEndMs) >= POST_CREDITS_TAIL_MIN_MS
             if (hasPostCreditsTail) {
-                false
+                positionMs >= durationMs - POST_CREDITS_END_WINDOW_MS
             } else {
                 positionMs >= outroStartMs
             }
@@ -60,7 +60,14 @@ object PlayerNextEpisodeRules {
         }
     }
 
-    private const val POST_CREDITS_THRESHOLD_MS = 30_000L
+    // Content after the outro end counts as a post-credits scene only when it is at
+    // least this long; shorter tails are treated as trailing logos/silence and keep
+    // the fire-at-outro-start behavior.
+    private const val POST_CREDITS_TAIL_MIN_MS = 30_000L
+
+    // When a post-credits scene exists, the card is held until playback reaches the
+    // final stretch of the episode instead of firing at the outro.
+    private const val POST_CREDITS_END_WINDOW_MS = 5_000L
 
     fun hasEpisodeAired(raw: String?): Boolean {
         val value = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return true

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
@@ -34,7 +34,16 @@ object PlayerNextEpisodeRules {
     ): Boolean {
         val outroInterval = skipIntervals.firstOrNull { it.type == "outro" }
         return if (outroInterval != null) {
-            positionMs / 1000.0 >= outroInterval.startTime
+            val outroStartMs = (outroInterval.startTime * 1000.0).toLong()
+            val outroEndMs = (outroInterval.endTime * 1000.0).toLong()
+            val hasPostCreditsTail = durationMs > 0L &&
+                outroEndMs > outroStartMs &&
+                (durationMs - outroEndMs) >= POST_CREDITS_THRESHOLD_MS
+            if (hasPostCreditsTail) {
+                false
+            } else {
+                positionMs >= outroStartMs
+            }
         } else {
             if (durationMs <= 0L) return false
             when (thresholdMode) {
@@ -50,6 +59,8 @@ object PlayerNextEpisodeRules {
             }
         }
     }
+
+    private const val POST_CREDITS_THRESHOLD_MS = 30_000L
 
     fun hasEpisodeAired(raw: String?): Boolean {
         val value = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return true

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRulesTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRulesTest.kt
@@ -1,0 +1,116 @@
+package com.nuvio.app.features.player.skip
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PlayerNextEpisodeRulesTest {
+
+    @Test
+    fun `outro without post-credits fires at outro start`() {
+        val intervals = listOf(outro(startSec = 1200.0, endSec = 1260.0))
+        val durationMs = 1280_000L
+
+        assertFalse(
+            PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
+                positionMs = 1199_999L,
+                durationMs = durationMs,
+                skipIntervals = intervals,
+                thresholdMode = NextEpisodeThresholdMode.PERCENTAGE,
+                thresholdPercent = 100f,
+                thresholdMinutesBeforeEnd = 0f,
+            ),
+        )
+        assertTrue(
+            PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
+                positionMs = 1200_000L,
+                durationMs = durationMs,
+                skipIntervals = intervals,
+                thresholdMode = NextEpisodeThresholdMode.PERCENTAGE,
+                thresholdPercent = 100f,
+                thresholdMinutesBeforeEnd = 0f,
+            ),
+        )
+    }
+
+    @Test
+    fun `outro with post-credits scene holds the card until playback truly ends`() {
+        val intervals = listOf(outro(startSec = 1200.0, endSec = 1260.0))
+        val durationMs = 1330_000L
+
+        // During the outro itself
+        assertFalse(
+            PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
+                positionMs = 1200_000L,
+                durationMs = durationMs,
+                skipIntervals = intervals,
+                thresholdMode = NextEpisodeThresholdMode.PERCENTAGE,
+                thresholdPercent = 100f,
+                thresholdMinutesBeforeEnd = 0f,
+            ),
+        )
+        // At outro end, where the post-credits scene starts playing
+        assertFalse(
+            PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
+                positionMs = 1260_000L,
+                durationMs = durationMs,
+                skipIntervals = intervals,
+                thresholdMode = NextEpisodeThresholdMode.PERCENTAGE,
+                thresholdPercent = 100f,
+                thresholdMinutesBeforeEnd = 0f,
+            ),
+        )
+        // Mid post-credits scene
+        assertFalse(
+            PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
+                positionMs = 1320_000L,
+                durationMs = durationMs,
+                skipIntervals = intervals,
+                thresholdMode = NextEpisodeThresholdMode.PERCENTAGE,
+                thresholdPercent = 100f,
+                thresholdMinutesBeforeEnd = 0f,
+            ),
+        )
+    }
+
+    @Test
+    fun `outro with trailing tail just under post-credits threshold fires at outro start`() {
+        val intervals = listOf(outro(startSec = 1200.0, endSec = 1260.0))
+        val durationMs = 1289_000L
+
+        assertTrue(
+            PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
+                positionMs = 1200_000L,
+                durationMs = durationMs,
+                skipIntervals = intervals,
+                thresholdMode = NextEpisodeThresholdMode.PERCENTAGE,
+                thresholdPercent = 100f,
+                thresholdMinutesBeforeEnd = 0f,
+            ),
+        )
+    }
+
+    @Test
+    fun `unknown duration falls back to outro start trigger`() {
+        val intervals = listOf(outro(startSec = 1200.0, endSec = 1260.0))
+
+        assertTrue(
+            PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
+                positionMs = 1200_000L,
+                durationMs = 0L,
+                skipIntervals = intervals,
+                thresholdMode = NextEpisodeThresholdMode.PERCENTAGE,
+                thresholdPercent = 100f,
+                thresholdMinutesBeforeEnd = 0f,
+            ),
+        )
+    }
+
+    private fun outro(startSec: Double, endSec: Double): SkipInterval =
+        SkipInterval(
+            startTime = startSec,
+            endTime = endSec,
+            type = "outro",
+            provider = "test",
+        )
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRulesTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRulesTest.kt
@@ -60,10 +60,21 @@ class PlayerNextEpisodeRulesTest {
                 thresholdMinutesBeforeEnd = 0f,
             ),
         )
-        // Mid post-credits scene
+        // Mid post-credits scene, outside the end window
         assertFalse(
             PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
                 positionMs = 1320_000L,
+                durationMs = durationMs,
+                skipIntervals = intervals,
+                thresholdMode = NextEpisodeThresholdMode.PERCENTAGE,
+                thresholdPercent = 100f,
+                thresholdMinutesBeforeEnd = 0f,
+            ),
+        )
+        // Final stretch of the episode
+        assertTrue(
+            PlayerNextEpisodeRules.shouldShowNextEpisodeCard(
+                positionMs = 1326_000L,
                 durationMs = durationMs,
                 skipIntervals = intervals,
                 thresholdMode = NextEpisodeThresholdMode.PERCENTAGE,


### PR DESCRIPTION
## Summary

When an outro skip interval exists for the current episode, the next-episode card fired as soon as playback reached `outroInterval.startTime`. With auto-play next episode enabled this advances to the next episode during the credits, skipping any post-credits scene that lives between the outro end and the episode's actual end.

- Fixes #1305: autoplay skips post-credits scenes

## PR type

- [x] Behavior bug/regression fix

## Why

`PlayerNextEpisodeRules.shouldShowNextEpisodeCard` hard-coded the trigger at outro start whenever an outro interval exists. A naive fix of deferring the trigger to the outro end is not enough — the post-credits scene starts at the outro end, so a card firing there still cuts the scene off after the 3-second auto-play countdown.

Instead, when the gap between the outro end and the episode duration is at least 30 seconds (a post-credits tail rather than trailing logos/silence), the outro-based trigger is suppressed entirely and the existing playback-ended handler in `PlayerScreenRuntimeEffects` shows the card at the true end of the episode — matching the issue's expectation that the prompt holds until the episode truly ends. Episodes whose outro runs to (or nearly to) the end keep the fire-at-outro-start behavior unchanged, as do episodes with no outro data (threshold modes untouched) and episodes with unknown duration.

The 30-second tail threshold is a judgment call — happy to tune it or make the post-credits hold a setting if preferred.

## Issue or approval

Fixes #1305

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- The skip-outro button and intro/recap skip behavior are untouched — only the next-episode card trigger changes.
- The percentage / minutes-before-end threshold modes (used when no outro data exists) are unchanged.
- #1301 (autoplay ignoring binge group) is intentionally NOT bundled — it was already addressed by the StreamsRepository rewrite that threads persistedBingeGroup and bingeGroupOnly through every selector call site.

## Testing

`./gradlew :composeApp:compileFullDebugKotlinAndroid` passes clean. `./gradlew :composeApp:testFullDebugUnitTest` passes.

New unit test `PlayerNextEpisodeRulesTest`:
- asserts an outro with no post-credits content still fires at outro start
- asserts a 70-second post-credits tail suppresses the card during the outro, at outro end, and mid post-credits scene
- asserts a tail just under the 30-second threshold keeps the outro-start behavior (no regression for episodes with brief trailing logos)
- asserts unknown duration falls back to the outro-start trigger

Manual (please verify during review — needs a device):
- Play an episode with outro timecodes and a post-credits scene, autoplay enabled: the next-episode prompt should not appear during credits or the post-credits scene; it fires when playback actually ends.
- Play an episode whose outro runs to the end: the prompt appears at outro start as before.
- Play an episode with no outro data: the configured threshold behavior is unchanged.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1305