### PR TITLE
fix(streams): classify torrent:// and magnet URLs as torrent streams, never playable

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -1815,7 +1815,7 @@ private fun MainAppContent(
                         replaceStreamRoute: Boolean,
                     ) {
                         val infoHash = stream.p2pInfoHash ?: return
-                        val sentinelUrl = p2pSentinelUrl(infoHash, stream.fileIdx)
+                        val sentinelUrl = p2pSentinelUrl(infoHash, stream.p2pFileIdx)
                         if (playerSettings.streamReuseLastLinkEnabled) {
                             val cacheKey = StreamLinkCacheRepository.contentKey(
                                 type = launch.type,
@@ -1835,7 +1835,7 @@ private fun MainAppContent(
                                 filename = stream.behaviorHints.filename,
                                 videoSize = stream.behaviorHints.videoSize,
                                 infoHash = infoHash,
-                                fileIdx = stream.fileIdx,
+                                fileIdx = stream.p2pFileIdx,
                                 sources = stream.sources,
                                 bingeGroup = stream.behaviorHints.bingeGroup,
                             )
@@ -1863,7 +1863,7 @@ private fun MainAppContent(
                             parentMetaId = launch.parentMetaId ?: effectiveVideoId,
                             parentMetaType = launch.parentMetaType ?: launch.type,
                             torrentInfoHash = infoHash,
-                            torrentFileIdx = stream.fileIdx,
+                            torrentFileIdx = stream.p2pFileIdx,
                             torrentFilename = stream.behaviorHints.filename,
                             torrentTrackers = stream.p2pTrackers,
                             initialPositionMs = resolvedResumePositionMs ?: 0L,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/debrid/DebridMagnetBuilder.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/debrid/DebridMagnetBuilder.kt
@@ -5,7 +5,7 @@ import com.nuvio.app.features.streams.StreamItem
 internal object DebridMagnetBuilder {
     fun fromStream(stream: StreamItem): String? {
         stream.torrentMagnetUri?.takeIf { it.isNotBlank() }?.let { return it }
-        val hash = stream.infoHash?.trim()?.takeIf { it.isNotBlank() } ?: return null
+        val hash = stream.p2pInfoHash ?: return null
         return buildString {
             append("magnet:?xt=urn:btih:")
             append(hash)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
@@ -51,7 +51,7 @@ internal fun PlayerScreenRuntime.isP2pStream(stream: StreamItem): Boolean =
 
 internal fun StreamItem.playerSourceIdentityKey(): String? {
     p2pInfoHash?.trim()?.lowercase()?.takeIf { it.isNotBlank() }?.let { hash ->
-        return "torrent:$hash:${fileIdx ?: -1}"
+        return "torrent:$hash:${p2pFileIdx ?: -1}"
     }
 
     clientResolve?.let { resolve ->
@@ -138,7 +138,7 @@ internal fun PlayerScreenRuntime.saveP2pStreamForReuse(
         filename = stream.behaviorHints.filename,
         videoSize = stream.behaviorHints.videoSize,
         infoHash = infoHash,
-        fileIdx = stream.fileIdx,
+        fileIdx = stream.p2pFileIdx,
         sources = stream.sources,
         bingeGroup = stream.behaviorHints.bingeGroup,
     )
@@ -160,12 +160,12 @@ internal fun PlayerScreenRuntime.switchToP2pSourceStream(stream: StreamItem) {
         season = activeSeasonNumber,
         episode = activeEpisodeNumber,
     )
-    activeSourceUrl = p2pSentinelUrl(infoHash, stream.fileIdx)
+    activeSourceUrl = p2pSentinelUrl(infoHash, stream.p2pFileIdx)
     activeSourceAudioUrl = null
     activeSourceHeaders = emptyMap()
     activeSourceResponseHeaders = emptyMap()
     activeTorrentInfoHash = infoHash
-    activeTorrentFileIdx = stream.fileIdx
+    activeTorrentFileIdx = stream.p2pFileIdx
     activeTorrentFilename = stream.behaviorHints.filename
     activeTorrentTrackers = stream.p2pTrackers
     activeSourceIdentityKey = stream.playerSourceIdentityKey()
@@ -202,12 +202,12 @@ internal fun PlayerScreenRuntime.switchToP2pEpisodeStream(
         season = episode.season,
         episode = episode.episode,
     )
-    activeSourceUrl = p2pSentinelUrl(infoHash, stream.fileIdx)
+    activeSourceUrl = p2pSentinelUrl(infoHash, stream.p2pFileIdx)
     activeSourceAudioUrl = null
     activeSourceHeaders = emptyMap()
     activeSourceResponseHeaders = emptyMap()
     activeTorrentInfoHash = infoHash
-    activeTorrentFileIdx = stream.fileIdx
+    activeTorrentFileIdx = stream.p2pFileIdx
     activeTorrentFilename = stream.behaviorHints.filename
     activeTorrentTrackers = stream.p2pTrackers
     applyEpisodeStreamMetadata(stream, episode, resume)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamModels.kt
@@ -32,13 +32,22 @@ data class StreamItem(
     val directPlaybackUrl: String?
         get() = url ?: externalUrl
 
+    /**
+     * First URL that can be handed directly to a player or HTTP consumer.
+     * `magnet:` and `torrent://` URLs are filtered out, falling back to
+     * [externalUrl] when [url] carries one of those schemes.
+     */
     val playableDirectUrl: String?
         get() = listOfNotNull(url, externalUrl)
-            .firstOrNull { !it.isMagnetLink() }
+            .firstOrNull { !it.isMagnetLink() && !it.isTorrentSchemeUrl() }
 
     val torrentMagnetUri: String?
         get() = listOfNotNull(url, externalUrl)
             .firstOrNull { it.isMagnetLink() }
+
+    val torrentSchemeUri: String?
+        get() = listOfNotNull(url, externalUrl)
+            .firstOrNull { it.isTorrentSchemeUrl() }
 
     val isDirectDebridStream: Boolean
         get() = clientResolve?.isDirectDebridCandidate == true
@@ -50,7 +59,9 @@ data class StreamItem(
         get() = !isDirectDebridStream && (
             !infoHash.isNullOrBlank() ||
             url.isMagnetLink() ||
-            externalUrl.isMagnetLink()
+            externalUrl.isMagnetLink() ||
+            url.isTorrentSchemeUrl() ||
+            externalUrl.isTorrentSchemeUrl()
         )
 
     val isCachedDebridTorrentStream: Boolean
@@ -63,6 +74,10 @@ data class StreamItem(
         get() = infoHash.normalizedInfoHash()
             ?: clientResolve?.infoHash.normalizedInfoHash()
             ?: torrentMagnetUri.extractBtihInfoHash()
+            ?: torrentSchemeUri.extractTorrentSchemeInfoHash()
+
+    val p2pFileIdx: Int?
+        get() = fileIdx ?: torrentSchemeUri.extractTorrentSchemeFileIdx()
 
     val p2pTrackers: List<String>
         get() = sources
@@ -91,6 +106,32 @@ data class StreamBadge(
 
 private fun String?.isMagnetLink(): Boolean =
     this?.trimStart()?.startsWith("magnet:", ignoreCase = true) == true
+
+private fun String?.isTorrentSchemeUrl(): Boolean =
+    this?.trimStart()?.startsWith("torrent://", ignoreCase = true) == true
+
+private fun String?.extractTorrentSchemeInfoHash(): String? {
+    val raw = this?.trimStart()?.takeIf { it.isTorrentSchemeUrl() } ?: return null
+    return raw.removeRange(0, "torrent://".length)
+        .substringBefore('/')
+        .substringBefore('?')
+        .trim()
+        .takeIf { it.isValidInfoHash() }
+}
+
+private fun String?.extractTorrentSchemeFileIdx(): Int? {
+    val raw = this?.trimStart()?.takeIf { it.isTorrentSchemeUrl() } ?: return null
+    val path = raw.removeRange(0, "torrent://".length).substringBefore('?')
+    if ('/' !in path) return null
+    return path.substringAfter('/')
+        .trim()
+        .takeIf { segment -> segment.isNotEmpty() && segment.all { it.isDigit() } }
+        ?.toIntOrNull()
+}
+
+private fun String.isValidInfoHash(): Boolean =
+    (length == 40 && all { it in '0'..'9' || it.lowercaseChar() in 'a'..'f' }) ||
+        (length == 32 && all { it in '2'..'7' || it.lowercaseChar() in 'a'..'z' })
 
 private fun String?.normalizedInfoHash(): String? =
     this

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/debrid/DebridMagnetBuilderTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/debrid/DebridMagnetBuilderTest.kt
@@ -1,0 +1,52 @@
+package com.nuvio.app.features.debrid
+
+import com.nuvio.app.features.streams.StreamItem
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DebridMagnetBuilderTest {
+
+    private val hexHash = "0123456789abcdef0123456789abcdef01234567"
+
+    @Test
+    fun `builds well-formed magnet from torrent scheme url`() {
+        val stream = stream(url = "torrent://$hexHash")
+        assertEquals("magnet:?xt=urn:btih:$hexHash", DebridMagnetBuilder.fromStream(stream))
+    }
+
+    @Test
+    fun `builds magnet from dedicated infoHash field`() {
+        val stream = stream(infoHash = hexHash)
+        assertEquals("magnet:?xt=urn:btih:$hexHash", DebridMagnetBuilder.fromStream(stream))
+    }
+
+    @Test
+    fun `passes existing magnet url through unchanged`() {
+        val magnet = "magnet:?xt=urn:btih:$hexHash&dn=Test"
+        val stream = stream(url = magnet)
+        assertEquals(magnet, DebridMagnetBuilder.fromStream(stream))
+    }
+
+    @Test
+    fun `returns null for torrent-null sentinel url`() {
+        val stream = stream(url = "torrent://null")
+        assertNull(DebridMagnetBuilder.fromStream(stream))
+    }
+
+    @Test
+    fun `returns null for plain http stream`() {
+        val stream = stream(url = "https://cdn.example.com/video.mp4")
+        assertNull(DebridMagnetBuilder.fromStream(stream))
+    }
+
+    private fun stream(
+        url: String? = null,
+        infoHash: String? = null,
+    ): StreamItem = StreamItem(
+        url = url,
+        infoHash = infoHash,
+        addonName = "TestAddon",
+        addonId = "test.addon",
+    )
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/StreamModelsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/StreamModelsTest.kt
@@ -1,0 +1,289 @@
+package com.nuvio.app.features.streams
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class StreamModelsTest {
+
+    private val hexHash = "0123456789abcdef0123456789abcdef01234567"
+    private val base32Hash = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"
+
+    // -----------------------------------------------------------------------
+    // isTorrentStream
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `torrent scheme url in url field is detected as torrent stream`() {
+        val stream = stream(url = "torrent://$hexHash")
+        assertTrue(stream.isTorrentStream)
+    }
+
+    @Test
+    fun `torrent scheme url with fileIdx path is detected as torrent stream`() {
+        val stream = stream(url = "torrent://$hexHash/0")
+        assertTrue(stream.isTorrentStream)
+    }
+
+    @Test
+    fun `torrent scheme url is detected case-insensitively`() {
+        val stream = stream(url = "TORRENT://$hexHash")
+        assertTrue(stream.isTorrentStream)
+    }
+
+    @Test
+    fun `torrent scheme url in externalUrl is detected as torrent stream`() {
+        val stream = stream(externalUrl = "torrent://$hexHash")
+        assertTrue(stream.isTorrentStream)
+    }
+
+    @Test
+    fun `torrent scheme url with leading whitespace is detected as torrent stream`() {
+        val stream = stream(url = "  torrent://$hexHash")
+        assertTrue(stream.isTorrentStream)
+        assertNull(stream.playableDirectUrl)
+    }
+
+    @Test
+    fun `magnet url with leading whitespace is detected as torrent stream`() {
+        val stream = stream(url = "\nmagnet:?xt=urn:btih:$hexHash")
+        assertTrue(stream.isTorrentStream)
+        assertNull(stream.playableDirectUrl)
+    }
+
+    @Test
+    fun `torrent url sentinel torrent-null-string is still detected as torrent scheme`() {
+        val stream = stream(url = "torrent://null")
+        assertTrue(stream.isTorrentStream)
+    }
+
+    @Test
+    fun `plain http url is not a torrent stream`() {
+        val stream = stream(url = "https://cdn.example.com/video.mp4")
+        assertFalse(stream.isTorrentStream)
+    }
+
+    @Test
+    fun `plain http url with torrent in path is not a torrent stream`() {
+        val stream = stream(url = "https://cdn.example.com/torrent/download.mp4")
+        assertFalse(stream.isTorrentStream)
+    }
+
+    // -----------------------------------------------------------------------
+    // playableDirectUrl — torrent:// and magnet: are never surfaced
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `torrent scheme url yields null playableDirectUrl`() {
+        val stream = stream(url = "torrent://$hexHash")
+        assertNull(stream.playableDirectUrl)
+    }
+
+    @Test
+    fun `torrent scheme url in externalUrl yields null playableDirectUrl`() {
+        val stream = stream(externalUrl = "torrent://$hexHash")
+        assertNull(stream.playableDirectUrl)
+    }
+
+    @Test
+    fun `magnet url yields null playableDirectUrl`() {
+        val stream = stream(url = "magnet:?xt=urn:btih:$hexHash")
+        assertNull(stream.playableDirectUrl)
+    }
+
+    @Test
+    fun `plain http url is surfaced as playableDirectUrl`() {
+        val url = "https://cdn.example.com/video.mp4"
+        val stream = stream(url = url)
+        assertEquals(url, stream.playableDirectUrl)
+    }
+
+    @Test
+    fun `torrent url falls through to http externalUrl`() {
+        val httpUrl = "https://cdn.example.com/video.mp4"
+        val stream = stream(
+            url = "torrent://$hexHash",
+            externalUrl = httpUrl,
+        )
+        assertEquals(httpUrl, stream.playableDirectUrl)
+    }
+
+    // -----------------------------------------------------------------------
+    // p2pInfoHash extraction
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `p2pInfoHash extracts hex hash from torrent scheme url`() {
+        val stream = stream(url = "torrent://$hexHash")
+        assertEquals(hexHash, stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `p2pInfoHash extracts base32 hash from torrent scheme url`() {
+        val stream = stream(url = "torrent://$base32Hash")
+        assertEquals(base32Hash, stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `p2pInfoHash extracts uppercase hex hash from uppercase scheme`() {
+        val upperHash = hexHash.uppercase()
+        val stream = stream(url = "TORRENT://$upperHash")
+        assertEquals(upperHash, stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `p2pInfoHash stops at fileIdx path segment`() {
+        val stream = stream(url = "torrent://$hexHash/3")
+        assertEquals(hexHash, stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `p2pInfoHash stops at query separator`() {
+        val stream = stream(url = "torrent://$hexHash?index=2")
+        assertEquals(hexHash, stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `p2pInfoHash extracts hex hash from magnet url`() {
+        val stream = stream(url = "magnet:?xt=urn:btih:$hexHash&dn=Test")
+        assertEquals(hexHash, stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `p2pInfoHash extracts base32 hash from magnet url`() {
+        val stream = stream(url = "magnet:?xt=urn:btih:$base32Hash&dn=Test")
+        assertEquals(base32Hash, stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `dedicated infoHash field wins over different hash in torrent url`() {
+        val dedicated = "fedcba9876543210fedcba9876543210fedcba98"
+        val stream = stream(
+            url = "torrent://$hexHash",
+            infoHash = dedicated,
+        )
+        assertEquals(dedicated, stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `torrent-null sentinel yields null p2pInfoHash`() {
+        val stream = stream(url = "torrent://null")
+        assertNull(stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `torrent url with invalid hash length yields null p2pInfoHash`() {
+        val stream = stream(url = "torrent://abcdef123456")
+        assertNull(stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `plain http url yields null p2pInfoHash`() {
+        val stream = stream(url = "https://cdn.example.com/video.mp4")
+        assertNull(stream.p2pInfoHash)
+    }
+
+    // -----------------------------------------------------------------------
+    // p2pFileIdx extraction
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `p2pFileIdx extracts trailing index segment from torrent url`() {
+        val stream = stream(url = "torrent://$hexHash/3")
+        assertEquals(3, stream.p2pFileIdx)
+    }
+
+    @Test
+    fun `dedicated fileIdx field wins over torrent url segment`() {
+        val stream = stream(url = "torrent://$hexHash/3", fileIdx = 7)
+        assertEquals(7, stream.p2pFileIdx)
+    }
+
+    @Test
+    fun `p2pFileIdx is null without a path segment`() {
+        val stream = stream(url = "torrent://$hexHash")
+        assertNull(stream.p2pFileIdx)
+    }
+
+    @Test
+    fun `p2pFileIdx is null for non-numeric path segment`() {
+        val stream = stream(url = "torrent://$hexHash/name.mkv")
+        assertNull(stream.p2pFileIdx)
+    }
+
+    @Test
+    fun `p2pFileIdx ignores query parameters`() {
+        val stream = stream(url = "torrent://$hexHash/2?foo=bar")
+        assertEquals(2, stream.p2pFileIdx)
+    }
+
+    // -----------------------------------------------------------------------
+    // Parser integration — torrent:// in JSON url field
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `parser preserves torrent scheme url and stream is correctly classified`() {
+        val streams = StreamParser.parse(
+            payload = """
+                {
+                  "streams": [
+                    {
+                      "url": "torrent://$hexHash",
+                      "name": "1080p"
+                    }
+                  ]
+                }
+            """.trimIndent(),
+            addonName = "Addon",
+            addonId = "addon.id",
+        )
+
+        val stream = streams.single()
+        assertTrue(stream.isTorrentStream)
+        assertNull(stream.playableDirectUrl)
+        assertEquals(hexHash, stream.p2pInfoHash)
+    }
+
+    @Test
+    fun `parser keeps normal http stream playable and not torrent`() {
+        val streams = StreamParser.parse(
+            payload = """
+                {
+                  "streams": [
+                    {
+                      "url": "https://cdn.example.com/video.mp4",
+                      "name": "1080p"
+                    }
+                  ]
+                }
+            """.trimIndent(),
+            addonName = "Addon",
+            addonId = "addon.id",
+        )
+
+        val stream = streams.single()
+        assertFalse(stream.isTorrentStream)
+        assertEquals("https://cdn.example.com/video.mp4", stream.playableDirectUrl)
+        assertNull(stream.p2pInfoHash)
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper
+    // -----------------------------------------------------------------------
+
+    private fun stream(
+        url: String? = null,
+        infoHash: String? = null,
+        fileIdx: Int? = null,
+        externalUrl: String? = null,
+    ): StreamItem = StreamItem(
+        url = url,
+        infoHash = infoHash,
+        fileIdx = fileIdx,
+        externalUrl = externalUrl,
+        addonName = "TestAddon",
+        addonId = "test.addon",
+    )
+}


### PR DESCRIPTION
## Summary

Fix the "unknown protocol: torrent" crash class from NuvioTV#2173 on mobile: addons that embed the torrent identity in the `url` field (`torrent://<hash>[/<fileIdx>]`) with a null `infoHash` were treated as direct HTTP streams. `playableDirectUrl` now filters `torrent://` (it already filtered `magnet:`), `isTorrentStream` detects the scheme, `p2pInfoHash` extracts a validated hash from `torrent://` URLs so the p2p engine can actually play them, a new `p2pFileIdx` carries the trailing `/<index>` segment, and `DebridMagnetBuilder` builds magnets from the effective hash so debrid providers receive well-formed magnet URIs.

## PR type

- [x] Behavior bug/regression fix

## Why

This is the mobile follow-up to the audit requested in NuvioMedia/NuvioTV#2174 (maintainer asked whether mobile needs the same fix). The audit confirmed mobile is affected. For a stream shaped like `{ "url": "torrent://<40-hex-hash>", "infoHash": null }` (e.g. from the All-in-One Torrentio addon), before this fix:

- `playableDirectUrl` (StreamModels.kt) only filtered `magnet:`, so the raw `torrent://` string was surfaced as a direct URL and handed to the player by `openSelectedStream` in App.kt, the player source-switch actions, and the refresh paths — internal and external player both receive an unplayable `torrent://` URL.
- `isTorrentStream` only checked `infoHash` and `magnet:`, so the stream was never classified as a torrent and the debrid resolve path never engaged.
- `p2pInfoHash` extracted from the dedicated field, `clientResolve`, and magnet URIs — but not from `torrent://` URLs — so the p2p engine never engaged either.
- `DebridProviderApis` falls back to `playableDirectUrl` as the source sent to provider APIs, so a raw `torrent://` string could reach debrid endpoints.

Magnet-in-url streams were already fully handled upstream (`playableDirectUrl` filters them, `torrentMagnetUri`/`extractBtihInfoHash` cover debrid and p2p); this PR brings `torrent://` URLs to parity, mirroring `getEffectiveInfoHash`/`getEffectiveFileIdx` from the TV fix.

## What changed

- `StreamModels.kt`: `torrentSchemeUri` (analogous to `torrentMagnetUri`), `torrent://` filtering in `playableDirectUrl` (with KDoc), `torrent://` detection in `isTorrentStream`, hash extraction in `p2pInfoHash` (authority segment, stops at `/` and `?`, validated as 40-char hex or 32-char base32 — `torrent://null` and malformed hashes yield null so the stream stays unselectable), and `p2pFileIdx` (dedicated `fileIdx` wins, else trailing numeric path segment). All scheme helpers are nullable-receiver `String?` extensions for consistency.
- `DebridMagnetBuilder.kt`: builds the magnet from `p2pInfoHash` (effective hash) instead of only the dedicated `infoHash` field, so debrid consumers receive well-formed `magnet:?xt=urn:btih:<hash>` URIs for torrent://-url streams.
- `App.kt`, `PlayerScreenRuntimeSourceActions.kt`: the p2p sentinel/launch/reuse sites read `p2pFileIdx` instead of `fileIdx` so `torrent://hash/<idx>` streams play the right file (behavior unchanged when the dedicated field is set).

## Issue or approval

Mobile counterpart of NuvioMedia/NuvioTV#2173, fixed on TV in NuvioMedia/NuvioTV#2174; maintainer asked there whether mobile needs the same fix.

## Reproduction steps

1. Install an addon that returns torrent streams via the `url` field, e.g. All-in-One Torrentio (`https://raw.githubusercontent.com/D3adlyRocket/All-in-One-Nuvio/refs/heads/main/manifest.json`).
2. Open any movie/series and pick one of its streams.
3. Before fix: the stream card is enabled as a direct stream and the player is launched with a `torrent://...` URL, which the player cannot open.
4. After fix: the stream is classified as a torrent and plays through the p2p engine (or resolves via debrid) exactly like an equivalent stream with a dedicated `infoHash` field; unextractable URLs (e.g. `torrent://null`) leave the card unselectable instead of crashing.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- The model changes are confined to `StreamItem` computed properties and private helpers; all selection/playback/debrid call sites pick the behavior up through `playableDirectUrl`, `isTorrentStream`, `p2pInfoHash`, and `isSelectableForPlayback`.
- The only call-site edits are the mechanical `fileIdx` → `p2pFileIdx` switch at the p2p sites and the one-line effective-hash switch in `DebridMagnetBuilder`.
- Streams with a dedicated `infoHash`, magnet-in-url streams, debrid `clientResolve` streams, and plain HTTP streams behave exactly as before (dedicated fields always win over URL extraction).
- The existing magnet `btih` extractor (`extractBtihInfoHash`) is intentionally untouched; hardening its edge cases (percent-encoded `urn%3Abtih%3A`, `xt.1=` multi-source params, parameter-boundary anchoring) would be a separate change.

## Testing

- Unit tests: `./gradlew :composeApp:testFullDebugUnitTest` — all 47 suites / 255 tests pass, including 37 new tests (`StreamModelsTest` × 32, `DebridMagnetBuilderTest` × 5).
- New tests cover: `torrent://` classification (url/externalUrl, uppercase scheme, leading whitespace, with file-index path), `playableDirectUrl` never surfacing `torrent://`/`magnet:` and falling through to a playable HTTP `externalUrl`, hash extraction (hex and base32, uppercase, stop at `/` and `?`), dedicated-field precedence for both hash and fileIdx, `torrent://null` and short-hash rejection, file-index extraction (numeric segment only, query ignored), magnet building from torrent-scheme streams, magnet passthrough unchanged, and parser round-trips for torrent-scheme and plain HTTP streams.
- Plain HTTP, magnet, and dedicated-`infoHash` paths verified unchanged by the existing upstream suites (`StreamParserTest`, `StreamAutoPlaySelectorTest`, `StreamBadgePresentationTest`, `DirectDebridStreamPreparerTest`, `DebridFileSelectorTest` — all green).

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Mobile audit follow-up to NuvioMedia/NuvioTV#2173 / NuvioMedia/NuvioTV#2174. No NuvioMobile issue filed for this; checked open NuvioMobile PRs/issues for torrent-in-url handling before writing the fix — none exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
