### PR TITLE
fix(watched): pull Trakt watched history when Trakt sync becomes active

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watched/WatchedRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watched/WatchedRepository.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -77,14 +78,15 @@ object WatchedRepository {
                     isAuthenticated = isAuthenticated,
                     source = settings.watchProgressSource,
                 )
-            }.collect { isActive ->
+            }.distinctUntilChanged().collect { isActive ->
                 val shouldPull = shouldPullTraktWatchedHistoryOnActivation(
                     wasActive = wasTraktWatchedSyncActive,
                     isActive = isActive,
                 )
                 wasTraktWatchedSyncActive = isActive
                 if (shouldPull) {
-                    pullFromServer(ProfileRepository.activeProfileId)
+                    runCatching { pullFromServer(ProfileRepository.activeProfileId) }
+                        .onFailure { e -> log.e(e) { "Trakt watched history pull on activation failed" } }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watched/WatchedRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watched/WatchedRepository.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
@@ -64,6 +65,30 @@ object WatchedRepository {
     private var deltaCursorEventId: Long = 0L
     private var deltaInitialized: Boolean = false
     internal var syncAdapter: WatchedSyncAdapter = SupabaseWatchedSyncAdapter
+
+    init {
+        syncScope.launch {
+            var wasTraktWatchedSyncActive = false
+            combine(
+                TraktAuthRepository.isAuthenticated,
+                TraktSettingsRepository.uiState,
+            ) { isAuthenticated, settings ->
+                shouldUseTraktWatchedSync(
+                    isAuthenticated = isAuthenticated,
+                    source = settings.watchProgressSource,
+                )
+            }.collect { isActive ->
+                val shouldPull = shouldPullTraktWatchedHistoryOnActivation(
+                    wasActive = wasTraktWatchedSyncActive,
+                    isActive = isActive,
+                )
+                wasTraktWatchedSyncActive = isActive
+                if (shouldPull) {
+                    pullFromServer(ProfileRepository.activeProfileId)
+                }
+            }
+        }
+    }
 
     fun ensureLoaded() {
         if (hasLoaded) return
@@ -533,6 +558,11 @@ internal fun shouldUseTraktWatchedSync(
     isAuthenticated = isAuthenticated,
     source = source,
 )
+
+internal fun shouldPullTraktWatchedHistoryOnActivation(
+    wasActive: Boolean,
+    isActive: Boolean,
+): Boolean = isActive && !wasActive
 
 private fun String.isSeriesLikeWatchedType(): Boolean =
     trim().lowercase() in setOf("series", "show", "tv", "tvshow")

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/watched/WatchedRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/watched/WatchedRepositoryTest.kt
@@ -100,6 +100,34 @@ class WatchedRepositoryTest {
     }
 
     @Test
+    fun traktWatchedHistoryPull_triggers_only_when_sync_becomes_active() {
+        assertTrue(
+            shouldPullTraktWatchedHistoryOnActivation(
+                wasActive = false,
+                isActive = true,
+            ),
+        )
+        assertFalse(
+            shouldPullTraktWatchedHistoryOnActivation(
+                wasActive = true,
+                isActive = true,
+            ),
+        )
+        assertFalse(
+            shouldPullTraktWatchedHistoryOnActivation(
+                wasActive = true,
+                isActive = false,
+            ),
+        )
+        assertFalse(
+            shouldPullTraktWatchedHistoryOnActivation(
+                wasActive = false,
+                isActive = false,
+            ),
+        )
+    }
+
+    @Test
     fun playbackCompletionWatchedMarks_doNotMirrorToTraktHistory() {
         assertFalse(
             shouldMirrorWatchedMarkToTraktHistory(


### PR DESCRIPTION
## Summary

Shows and movies marked watched on Trakt were largely never marked watched in Nuvio. The only path that mirrors Trakt watched history into the local watched store is the profile-activation sync, which bails out for anonymous (Trakt-only) users entirely and runs before a freshly-connected Trakt session exists for everyone else.

- Fixes #1185: trakt watch history not syncing to nuvio mobile

## PR type

- [x] Behavior bug/regression fix

## Why

`WatchedRepository.pullFromServer` → `TraktWatchedSyncAdapter.pull` is triggered solely by `SyncManager.pullAllForProfile`, which requires a non-anonymous Nuvio account and only fires on profile activation; the 30-minute foreground pull covers library and watch progress but never watched history. Nothing reacts to connecting Trakt or to switching the watch-progress source to Trakt — in contrast to `WatchProgressRepository`, which already listens for exactly those transitions. Result: Trakt-only users never pull watched history at all, and Nuvio-account users need an app restart after connecting Trakt.

`WatchedRepository` now combines `TraktAuthRepository.isAuthenticated` with the watch-progress source setting and pulls watched history once on each inactive→active transition, mirroring the established `WatchProgressRepository` pattern. The transition predicate is a pure helper covered by a transition-matrix unit test. For Nuvio-account users this adds one extra pull at startup alongside the profile-activation sync; pulls are idempotent merges.

## Issue or approval

Fixes #1185

Related but intentionally not claimed: #1234 and #1191. Investigation traced both to the all-or-nothing Trakt snapshot fetch in `TraktProgressRepository.refreshNowInternal`, where one silently-failing endpoint discards all completed-history seeds — but confirming which endpoint fails for those reporters needs live-account logs, and partial-snapshot hardening would interact badly with the next-up cache invalidation.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Mid-session re-sync of watched changes made on trakt.tv while the app is running is unchanged (would need watched history added to the foreground poll — separate concern).
- Series-level catalog badges still resolve via the existing `reconcileSeriesWatchedState` on details visits; this PR only ensures the underlying movie and per-episode marks arrive.
- #1234 / #1191 snapshot behavior untouched.

## Testing

`./gradlew :composeApp:compileFullDebugKotlinAndroid` passes clean. `./gradlew :composeApp:testFullDebugUnitTest` passes.

New unit test `WatchedRepositoryTest`: transition matrix for `shouldPullTraktWatchedHistoryOnActivation` (inactive→active pulls; active→active, active→inactive, inactive→inactive do not).

Manual (please verify during review — needs a Trakt account):
- Fresh install, no Nuvio account, connect Trakt: watched badges appear for Trakt-watched titles without restarting.
- Toggle watch-progress source away from and back to Trakt: a pull fires on re-activation, no repeat pulls while it stays active.
- With a Nuvio account: existing startup sync still works; no duplicate-marking artifacts.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1185
