### PR TITLE
fix(trakt): stop scrobbling the next episode as watched and surface save failures

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryRepository.kt
@@ -2,6 +2,7 @@ package com.nuvio.app.features.library
 
 import co.touchlab.kermit.Logger
 import com.nuvio.app.core.auth.AuthRepository
+import com.nuvio.app.core.ui.NuvioToastController
 import com.nuvio.app.core.auth.AuthState
 import com.nuvio.app.core.network.SupabaseProvider
 import com.nuvio.app.features.home.PosterShape
@@ -40,6 +41,7 @@ import kotlinx.serialization.json.put
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.library_local_tab_title
 import nuvio.composeapp.generated.resources.library_other
+import nuvio.composeapp.generated.resources.trakt_lists_update_failed
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 
@@ -218,7 +220,13 @@ object LibraryRepository {
         if (isTraktLibrarySourceActive()) {
             syncScope.launch {
                 runCatching { TraktLibraryRepository.toggleWatchlist(item) }
-                    .onFailure { e -> log.e(e) { "Failed to toggle Trakt watchlist" } }
+                    .onFailure { e ->
+                        log.e(e) { "Failed to toggle Trakt watchlist" }
+                        NuvioToastController.show(
+                            e.message?.takeIf { it.isNotBlank() }
+                                ?: getString(Res.string.trakt_lists_update_failed),
+                        )
+                    }
                 publish()
             }
             return

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -244,8 +244,17 @@ internal fun PlayerScreenRuntime.BindPlayerRuntimeEffects() {
     BindPlayerMetadataAndSkipEffects()
 
     DisposableEffect(playbackSession.videoId, activeSourceUrl, activeSourceAudioUrl) {
+        val effectVideoId = playbackSession.videoId
+        val effectSourceUrl = activeSourceUrl
+        val effectSourceAudioUrl = activeSourceAudioUrl
         onDispose {
-            flushWatchProgress()
+            if (
+                playbackSession.videoId == effectVideoId &&
+                activeSourceUrl == effectSourceUrl &&
+                activeSourceAudioUrl == effectSourceAudioUrl
+            ) {
+                flushWatchProgress()
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimePlaybackActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimePlaybackActions.kt
@@ -80,16 +80,39 @@ internal fun PlayerScreenRuntime.currentPlaybackProgressPercent(
         .coerceIn(0f, 100f)
 }
 
-internal suspend fun PlayerScreenRuntime.currentTraktScrobbleItem() =
+internal data class TraktScrobbleItemInputs(
+    val contentType: String,
+    val parentMetaId: String,
+    val videoId: String?,
+    val title: String,
+    val seasonNumber: Int?,
+    val episodeNumber: Int?,
+    val episodeTitle: String?,
+)
+
+internal fun PlayerScreenRuntime.snapshotTraktScrobbleItemInputs() = TraktScrobbleItemInputs(
+    contentType = contentType ?: parentMetaType,
+    parentMetaId = parentMetaId,
+    videoId = activeVideoId,
+    title = title,
+    seasonNumber = activeSeasonNumber,
+    episodeNumber = activeEpisodeNumber,
+    episodeTitle = activeEpisodeTitle,
+)
+
+private suspend fun TraktScrobbleItemInputs.buildItem() =
     TraktScrobbleRepository.buildItem(
-        contentType = contentType ?: parentMetaType,
+        contentType = contentType,
         parentMetaId = parentMetaId,
-        videoId = activeVideoId,
+        videoId = videoId,
         title = title,
-        seasonNumber = activeSeasonNumber,
-        episodeNumber = activeEpisodeNumber,
-        episodeTitle = activeEpisodeTitle,
+        seasonNumber = seasonNumber,
+        episodeNumber = episodeNumber,
+        episodeTitle = episodeTitle,
     )
+
+internal suspend fun PlayerScreenRuntime.currentTraktScrobbleItem() =
+    snapshotTraktScrobbleItemInputs().buildItem()
 
 internal fun PlayerScreenRuntime.emitTraktScrobbleStart() {
     if (hasRequestedScrobbleStartForCurrentItem) return
@@ -120,23 +143,9 @@ internal fun PlayerScreenRuntime.emitTraktScrobbleStop(progressPercent: Float? =
 
     val percent = provided ?: currentPlaybackProgressPercent()
     val itemSnapshot = currentTraktScrobbleItem
-    val contentTypeSnapshot = contentType ?: parentMetaType
-    val parentMetaIdSnapshot = parentMetaId
-    val videoIdSnapshot = activeVideoId
-    val titleSnapshot = title
-    val seasonNumberSnapshot = activeSeasonNumber
-    val episodeNumberSnapshot = activeEpisodeNumber
-    val episodeTitleSnapshot = activeEpisodeTitle
+    val inputsSnapshot = snapshotTraktScrobbleItemInputs()
     scope.launch(NonCancellable) {
-        val item = itemSnapshot ?: TraktScrobbleRepository.buildItem(
-            contentType = contentTypeSnapshot,
-            parentMetaId = parentMetaIdSnapshot,
-            videoId = videoIdSnapshot,
-            title = titleSnapshot,
-            seasonNumber = seasonNumberSnapshot,
-            episodeNumber = episodeNumberSnapshot,
-            episodeTitle = episodeTitleSnapshot,
-        ) ?: return@launch
+        val item = itemSnapshot ?: inputsSnapshot.buildItem() ?: return@launch
         TraktScrobbleRepository.scrobbleStop(
             item = item,
             progressPercent = percent,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimePlaybackActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimePlaybackActions.kt
@@ -120,8 +120,23 @@ internal fun PlayerScreenRuntime.emitTraktScrobbleStop(progressPercent: Float? =
 
     val percent = provided ?: currentPlaybackProgressPercent()
     val itemSnapshot = currentTraktScrobbleItem
+    val contentTypeSnapshot = contentType ?: parentMetaType
+    val parentMetaIdSnapshot = parentMetaId
+    val videoIdSnapshot = activeVideoId
+    val titleSnapshot = title
+    val seasonNumberSnapshot = activeSeasonNumber
+    val episodeNumberSnapshot = activeEpisodeNumber
+    val episodeTitleSnapshot = activeEpisodeTitle
     scope.launch(NonCancellable) {
-        val item = itemSnapshot ?: currentTraktScrobbleItem() ?: return@launch
+        val item = itemSnapshot ?: TraktScrobbleRepository.buildItem(
+            contentType = contentTypeSnapshot,
+            parentMetaId = parentMetaIdSnapshot,
+            videoId = videoIdSnapshot,
+            title = titleSnapshot,
+            seasonNumber = seasonNumberSnapshot,
+            episodeNumber = episodeNumberSnapshot,
+            episodeTitle = episodeTitleSnapshot,
+        ) ?: return@launch
         TraktScrobbleRepository.scrobbleStop(
             item = item,
             progressPercent = percent,


### PR DESCRIPTION
## Summary

Two Trakt correctness bugs: partially-watched / never-watched episodes getting scrobbled to Trakt as fully watched, and library saves failing silently.

- Fixes #1196: scrobbling unwatched episodes as watched to trakt
- Addresses the silent-failure half of #1192 (the HTTP 420 message mapping was already fixed upstream in ded51edb)

## PR type

- [x] Behavior bug/regression fix

## Why

**#1196** is a dispose-time race in the player. Every episode/source switch path flushes progress synchronously and then mutates the runtime identity (`activeVideoId`, season/episode). On the next recomposition the old `DisposableEffect(playbackSession.videoId, activeSourceUrl, …)` disposes and called `flushWatchProgress()` again — now reading the NEW episode's identity against the OLD playback snapshot. With autoplay kicking in near the end of an episode (snapshot ≥ 80-90%), that second flush sent a Trakt `scrobble/stop` at high progress for the **next** episode and wrote a completed local watch-progress entry for it, which cascades into watched history via `shouldCascadeCompletedProgressToWatchedHistory` — matching both reported symptoms. A secondary race: `emitTraktScrobbleStop` built the scrobble item inside an async coroutine from live runtime state when no snapshot item existed, so it could also pick up the post-switch episode.

Fixes: the dispose-time flush now runs only when the playback identity is unchanged (a real screen exit; in-player switches already flush synchronously with correct identity before mutating), and `emitTraktScrobbleStop` captures every item-building input synchronously at call time.

**#1192**: `LibraryRepository.toggleSaved` fire-and-forgets `TraktLibraryRepository.toggleWatchlist`, logging failures while the optimistic UI flip silently reverts. Failures now surface a toast carrying the server-mapped message (including the existing 420 → "Trakt list limit reached" mapping from ded51edb), falling back to the existing `trakt_lists_update_failed` string. No new strings.

## Issue or approval

Fixes #1196
Addresses #1192 (error surfacing; the 420 mapping itself shipped in ded51edb)

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Scrobble-start and pause flows unchanged.
- The toast uses `NuvioToastController` from the repository layer, which has precedent (`AppUpdater`, player source actions).
- Skipping the dispose flush on identity change drops one redundant flush; all five switch paths flush synchronously first, so no progress is lost.

## Testing

`./gradlew :composeApp:compileFullDebugKotlinAndroid` passes clean. `./gradlew :composeApp:testFullDebugUnitTest` passes.

No new unit tests: the changed logic is Compose-runtime/singleton glue with no seam to test without a DI refactor, which the contribution rules exclude. The pure pieces (420 mapping, `buildItem`) are untouched.

Manual (please verify during review — needs a Trakt account):
- Watch an episode with autoplay-next enabled to the end; check Trakt history: only the finished episode is recorded, the next one is not.
- Stop an episode at ~30% and exit: Trakt shows paused progress, not a completed watch.
- With Trakt managing the library and a full watchlist (free tier), tap Save: a toast explains the failure instead of the button silently reverting.

## Screenshots / Video (UI changes only)

No new UI surface (toast uses the existing controller).

## Breaking changes

None.

## Linked issues

Fixes #1196