### PR TITLE
fix(plugins): stop mobile plugin sync clobbering CloudStream repos saved by other apps

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/plugins/PluginModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/plugins/PluginModels.kt
@@ -40,6 +40,9 @@ data class PluginRepositoryItem(
     val lastUpdated: Long = 0L,
     val isRefreshing: Boolean = false,
     val errorMessage: String? = null,
+    val serverUrl: String? = null,
+    val serverRepoType: String? = null,
+    val serverEnabled: Boolean? = null,
 )
 
 data class PluginScraper(
@@ -106,6 +109,9 @@ internal data class StoredPluginRepository(
     val version: String? = null,
     val scraperCount: Int = 0,
     val lastUpdated: Long = 0L,
+    val serverUrl: String? = null,
+    val serverRepoType: String? = null,
+    val serverEnabled: Boolean? = null,
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/plugins/PluginSyncPlan.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/plugins/PluginSyncPlan.kt
@@ -1,0 +1,25 @@
+package com.nuvio.app.features.plugins
+
+internal data class PluginPushEntry(
+    val url: String,
+    val name: String,
+    val enabled: Boolean,
+    val repoType: String?,
+    val sortOrder: Int,
+)
+
+internal fun buildPluginPushEntries(repositories: List<PluginRepositoryItem>): List<PluginPushEntry> =
+    repositories.mapIndexed { index, repo ->
+        PluginPushEntry(
+            url = repo.serverUrl?.takeIf { it.isNotBlank() } ?: repo.manifestUrl,
+            name = repo.name,
+            enabled = repo.serverEnabled ?: true,
+            repoType = repo.serverRepoType?.takeIf { it.isNotBlank() },
+            sortOrder = index,
+        )
+    }
+
+internal fun shouldPreserveLocalPluginRepositories(
+    remoteUrls: List<String>,
+    localRepositories: List<PluginRepositoryItem>,
+): Boolean = remoteUrls.isEmpty() && localRepositories.isNotEmpty()

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/plugins/PluginSyncPlanTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/plugins/PluginSyncPlanTest.kt
@@ -1,0 +1,113 @@
+package com.nuvio.app.features.plugins
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class PluginSyncPlanTest {
+
+    private fun repo(
+        manifestUrl: String,
+        name: String = "Repo",
+        serverUrl: String? = null,
+        serverRepoType: String? = null,
+        serverEnabled: Boolean? = null,
+    ) = PluginRepositoryItem(
+        manifestUrl = manifestUrl,
+        name = name,
+        serverUrl = serverUrl,
+        serverRepoType = serverRepoType,
+        serverEnabled = serverEnabled,
+    )
+
+    @Test
+    fun pushEntriesPreserveOriginalServerUrlAndRepoType() {
+        val cloudStreamRepo = repo(
+            manifestUrl = "https://example.com/cs/repo.json/manifest.json",
+            name = "CS Repo",
+            serverUrl = "https://example.com/cs/repo.json",
+            serverRepoType = "CLOUDSTREAM",
+            serverEnabled = false,
+        )
+
+        val entries = buildPluginPushEntries(listOf(cloudStreamRepo))
+
+        assertEquals(1, entries.size)
+        assertEquals("https://example.com/cs/repo.json", entries[0].url)
+        assertEquals("CLOUDSTREAM", entries[0].repoType)
+        assertEquals(false, entries[0].enabled)
+        assertEquals(0, entries[0].sortOrder)
+    }
+
+    @Test
+    fun pushEntriesFallBackToManifestUrlForLocallyAddedRepos() {
+        val localRepo = repo(
+            manifestUrl = "https://example.com/nuvio/manifest.json",
+            name = "Local Repo",
+        )
+
+        val entries = buildPluginPushEntries(listOf(localRepo))
+
+        assertEquals("https://example.com/nuvio/manifest.json", entries[0].url)
+        assertNull(entries[0].repoType)
+        assertTrue(entries[0].enabled)
+    }
+
+    @Test
+    fun pushEntriesIgnoreBlankServerMetadata() {
+        val blankMetadataRepo = repo(
+            manifestUrl = "https://example.com/nuvio/manifest.json",
+            serverUrl = " ",
+            serverRepoType = "",
+        )
+
+        val entries = buildPluginPushEntries(listOf(blankMetadataRepo))
+
+        assertEquals("https://example.com/nuvio/manifest.json", entries[0].url)
+        assertNull(entries[0].repoType)
+    }
+
+    @Test
+    fun pushEntriesAssignSortOrderByPosition() {
+        val entries = buildPluginPushEntries(
+            listOf(
+                repo(manifestUrl = "https://a.example/manifest.json"),
+                repo(manifestUrl = "https://b.example/manifest.json"),
+            ),
+        )
+
+        assertEquals(listOf(0, 1), entries.map { it.sortOrder })
+    }
+
+    @Test
+    fun preservesLocalWhenRemoteEmptyAndLocalHasRepositories() {
+        assertTrue(
+            shouldPreserveLocalPluginRepositories(
+                remoteUrls = emptyList(),
+                localRepositories = listOf(repo(manifestUrl = "https://a.example/manifest.json")),
+            ),
+        )
+    }
+
+    @Test
+    fun doesNotPreserveLocalWhenRemoteHasRepositories() {
+        assertFalse(
+            shouldPreserveLocalPluginRepositories(
+                remoteUrls = listOf("https://a.example/manifest.json"),
+                localRepositories = listOf(repo(manifestUrl = "https://b.example/manifest.json")),
+            ),
+        )
+    }
+
+    @Test
+    fun doesNotPreserveLocalWhenLocalIsEmpty() {
+        assertFalse(
+            shouldPreserveLocalPluginRepositories(
+                remoteUrls = emptyList(),
+                localRepositories = emptyList(),
+            ),
+        )
+    }
+}

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
@@ -116,6 +116,9 @@ actual object PluginRepository {
 
             if (shouldPreserveLocalPluginRepositories(urls, _uiState.value.repositories)) {
                 log.w { "pullFromServer — remote empty while local has repositories; preserving local" }
+                _uiState.value.repositories.forEach { repo ->
+                    refreshRepository(repo.manifestUrl, pushAfterRefresh = false)
+                }
                 initialized = true
                 return
             }

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
@@ -41,6 +41,7 @@ private data class PluginRow(
     val name: String? = null,
     val enabled: Boolean = true,
     @SerialName("sort_order") val sortOrder: Int = 0,
+    @SerialName("repo_type") val repoType: String? = null,
 )
 
 @Serializable
@@ -49,6 +50,7 @@ private data class PluginPushItem(
     val name: String = "",
     val enabled: Boolean = true,
     @SerialName("sort_order") val sortOrder: Int = 0,
+    @SerialName("repo_type") val repoType: String? = null,
 )
 
 actual object PluginRepository {
@@ -60,7 +62,6 @@ actual object PluginRepository {
     actual val uiState: StateFlow<PluginsUiState> = _uiState.asStateFlow()
 
     private var initialized = false
-    private var pulledFromServer = false
     private var currentProfileId = 1
     private val activeRefreshJobs = mutableMapOf<String, Job>()
 
@@ -82,7 +83,6 @@ actual object PluginRepository {
         cancelActiveRefreshes()
         currentProfileId = effectiveProfileId
         initialized = false
-        pulledFromServer = false
         _uiState.value = PluginsUiState()
     }
 
@@ -90,7 +90,6 @@ actual object PluginRepository {
         cancelActiveRefreshes()
         currentProfileId = 1
         initialized = false
-        pulledFromServer = false
         _uiState.value = PluginsUiState()
     }
 
@@ -106,25 +105,35 @@ actual object PluginRepository {
                 }
                 .decodeList<PluginRow>()
 
-            val urls = dedupeManifestUrls(rows.map { it.url })
-            if (urls.isEmpty() && !pulledFromServer) {
-                val localUrls = _uiState.value.repositories.map { it.manifestUrl }
-                if (localUrls.isNotEmpty()) {
-                    initialize()
-                    pulledFromServer = true
-                    pushToServer()
-                    return
+            val rowsByUrl = linkedMapOf<String, PluginRow>()
+            rows.forEach { row ->
+                val manifestUrl = ensureManifestSuffix(row.url)
+                if (!rowsByUrl.containsKey(manifestUrl)) {
+                    rowsByUrl[manifestUrl] = row
                 }
+            }
+            val urls = rowsByUrl.keys.toList()
+
+            if (shouldPreserveLocalPluginRepositories(urls, _uiState.value.repositories)) {
+                log.w { "pullFromServer — remote empty while local has repositories; preserving local" }
+                initialized = true
+                return
             }
 
             val existingReposByUrl = _uiState.value.repositories.associateBy { it.manifestUrl }
             val nextRepos = urls.map { url ->
-                existingReposByUrl[url]?.copy(isRefreshing = true, errorMessage = null)
+                val row = rowsByUrl.getValue(url)
+                val base = existingReposByUrl[url]?.copy(isRefreshing = true, errorMessage = null)
                     ?: PluginRepositoryItem(
                         manifestUrl = url,
                         name = url.substringBefore("?").substringAfterLast('/'),
                         isRefreshing = true,
                     )
+                base.copy(
+                    serverUrl = row.url,
+                    serverRepoType = row.repoType,
+                    serverEnabled = row.enabled,
+                )
             }
             val nextScrapers = _uiState.value.scrapers.filter { scraper ->
                 urls.contains(scraper.repositoryUrl)
@@ -142,7 +151,6 @@ actual object PluginRepository {
                 refreshRepository(url, pushAfterRefresh = false)
             }
 
-            pulledFromServer = true
             initialized = true
         }.onFailure { error ->
             log.e(error) { "pullFromServer failed" }
@@ -228,7 +236,15 @@ actual object PluginRepository {
                     result.fold(
                         onSuccess = { (repo, scrapers) ->
                             val updatedRepos = state.repositories.map { existing ->
-                                if (existing.manifestUrl == manifestUrl) repo else existing
+                                if (existing.manifestUrl == manifestUrl) {
+                                    repo.copy(
+                                        serverUrl = existing.serverUrl,
+                                        serverRepoType = existing.serverRepoType,
+                                        serverEnabled = existing.serverEnabled,
+                                    )
+                                } else {
+                                    existing
+                                }
                             }
                             state.copy(
                                 repositories = updatedRepos,
@@ -438,12 +454,13 @@ actual object PluginRepository {
     private fun pushToServer() {
         scope.launch {
             runCatching {
-                val repos = _uiState.value.repositories.mapIndexed { index, repo ->
+                val repos = buildPluginPushEntries(_uiState.value.repositories).map { entry ->
                     PluginPushItem(
-                        url = repo.manifestUrl,
-                        name = repo.name,
-                        enabled = true,
-                        sortOrder = index,
+                        url = entry.url,
+                        name = entry.name,
+                        enabled = entry.enabled,
+                        sortOrder = entry.sortOrder,
+                        repoType = entry.repoType,
                     )
                 }
 
@@ -471,6 +488,9 @@ actual object PluginRepository {
                     version = repo.version,
                     scraperCount = repo.scraperCount,
                     lastUpdated = repo.lastUpdated,
+                    serverUrl = repo.serverUrl,
+                    serverRepoType = repo.serverRepoType,
+                    serverEnabled = repo.serverEnabled,
                 )
             },
             scrapers = state.scrapers.map { scraper ->
@@ -512,7 +532,6 @@ actual object PluginRepository {
 
         if (currentProfileId != profileId) {
             cancelActiveRefreshes()
-            pulledFromServer = false
         }
 
         currentProfileId = profileId
@@ -536,6 +555,9 @@ actual object PluginRepository {
                         lastUpdated = it.lastUpdated,
                         isRefreshing = false,
                         errorMessage = null,
+                        serverUrl = it.serverUrl,
+                        serverRepoType = it.serverRepoType,
+                        serverEnabled = it.serverEnabled,
                     )
                 }
                 ?: emptyList(),
@@ -560,9 +582,6 @@ actual object PluginRepository {
                 ?: emptyList(),
         )
     }
-
-    private fun dedupeManifestUrls(urls: List<String>): List<String> =
-        urls.map(::ensureManifestSuffix).distinct()
 
     private fun ensureManifestSuffix(url: String): String {
         val path = url.substringBefore("?").trimEnd('/')


### PR DESCRIPTION
## Summary

Opening the mobile app could wipe every CloudStream plugin repository the user had saved from nuvioapp.space or the TV app.

- Fixes #1190: CS plugin repositories loaded in the mobile app get removed from the TV app

## PR type

- [x] Behavior bug/regression fix

## Why

Three interacting defects in the full flavor's `PluginRepository`:

- Every pulled server URL had `/manifest.json` appended (`ensureManifestSuffix`), corrupting CloudStream repo URLs (which end in `.json` but not `manifest.json`) — which is why the issue reports repos "shown, but not properly loaded" on mobile.
- The push payload dropped `repo_type`, which NuvioTV's `PluginSyncService` round-trips (`NUVIO`/`CLOUDSTREAM`), and `sync_push_plugins` replaces the profile's rows wholesale.
- `pullFromServer` auto-pushed the locally cached list whenever the server select returned zero rows — so a transient empty result (RLS / expired JWT; TV guards this with `withJwtRefreshRetry`, mobile does not) silently uploaded the corrupted local list with no user interaction.

The TV app then reconciles with `removeMissingLocal = true` against normalized URLs; mobile's mutated `…repo.json/manifest.json` rows match nothing, so every CloudStream repo is removed. This is the same bug class as home catalogs, fixed in 4eb919df by making the pull preserve-only.

The fix follows that pattern: an empty remote with a non-empty local list now preserves local and never pushes; pushes round-trip the exact server `url`, `repo_type`, and `enabled` captured at pull time (with fallback to the local manifest URL for repos added on mobile); the gating and push-entry construction live in a pure `PluginSyncPlan` helper with unit tests.

## Issue or approval

Fixes #1190

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Mobile still cannot load CloudStream repositories (no CS plugin support in this codebase) — this PR only stops it destroying other apps' data; CS support itself is a feature request.
- `AddonRepository` has the same latent empty-select migration push; untouched here as a separate concern.
- `repo_type` is now explicitly `null` for mobile-added repos where the key was previously absent — equivalent under jsonb population, flagged for SQL review.

## Testing

`./gradlew :composeApp:compileFullDebugKotlinAndroid`, `:composeApp:testFullDebugUnitTest`, and `:composeApp:compilePlaystoreDebugKotlinAndroid` all pass.

New `PluginSyncPlanTest` (7 tests): server URL/repo_type/enabled round-trip, manifest-URL fallback for locally added repos, blank-metadata handling, sort order, and the preserve-local gating for empty/non-empty remote × local combinations.

Manual (please verify during review — needs nuvioapp.space + TV + mobile):
- Save CS plugin repos on nuvioapp.space, open TV (repos load), open mobile, reopen TV: repos must still be present.
- Add a repo on mobile, confirm it appears on TV with type intact.
- Mobile with locally cached repos + a transient empty server response: local list preserved, nothing pushed.

## Screenshots / Video

Not a UI change.

## Breaking changes

None. `StoredPluginRepository` gains defaulted fields; existing persisted payloads decode unchanged.

## Linked issues

Fixes #1190
