### PR TITLE
fix: stop truncating raw HTTP bodies on Android so Torbox cloud library loads

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
@@ -16,8 +16,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.net.Proxy
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
 import kotlin.text.Charsets
 import java.util.concurrent.TimeUnit
 
@@ -88,8 +86,6 @@ private val addonHttpClient = OkHttpClient.Builder()
     .build()
 
 private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
-private const val maxRawResponseBodyBytes = 1024 * 1024
-private const val truncationSuffix = "\n...[truncated]"
 
 private fun requestAllowsBody(method: String): Boolean =
     when (method.uppercase()) {
@@ -104,51 +100,6 @@ private fun Map<String, String>.withoutAcceptEncoding(): Map<String, String> =
 
 private fun Map<String, String>.getHeaderIgnoreCase(name: String): String? =
     entries.firstOrNull { (key, _) -> key.equals(name, ignoreCase = true) }?.value
-
-private data class LimitedReadResult(
-    val bytes: ByteArray,
-    val truncated: Boolean,
-)
-
-private fun readAtMostBytes(stream: InputStream, maxBytes: Int): LimitedReadResult {
-    val out = ByteArrayOutputStream(minOf(maxBytes, 16 * 1024))
-    val buffer = ByteArray(8 * 1024)
-    var remaining = maxBytes
-    var truncated = false
-
-    while (remaining > 0) {
-        val read = stream.read(buffer, 0, minOf(buffer.size, remaining))
-        if (read <= 0) break
-        out.write(buffer, 0, read)
-        remaining -= read
-    }
-
-    if (remaining == 0) {
-        truncated = stream.read() != -1
-    }
-
-    return LimitedReadResult(out.toByteArray(), truncated)
-}
-
-private fun readResponseBodyLimited(body: ResponseBody?): String {
-    if (body == null) return ""
-    val charset = body.contentType()?.charset(Charsets.UTF_8) ?: Charsets.UTF_8
-    val readResult = body.byteStream().use { stream ->
-        readAtMostBytes(stream, maxRawResponseBodyBytes)
-    }
-
-    val decoded = try {
-        String(readResult.bytes, charset)
-    } catch (_: Exception) {
-        String(readResult.bytes, Charsets.UTF_8)
-    }
-
-    return if (readResult.truncated) {
-        decoded + truncationSuffix
-    } else {
-        decoded
-    }
-}
 
 private fun readResponseBody(body: ResponseBody?): String {
     if (body == null) return ""
@@ -277,7 +228,7 @@ actual suspend fun httpRequestRaw(
                 status = response.code,
                 statusText = response.message,
                 url = response.request.url.toString(),
-                body = readResponseBodyLimited(response.body),
+                body = readResponseBody(response.body),
                 headers = response.headers.toMultimap().mapValues { (_, values) ->
                     values.joinToString(",")
                 }.mapKeys { (name, _) ->

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/cloud/TorboxCloudLibraryProviderApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/cloud/TorboxCloudLibraryProviderApi.kt
@@ -76,7 +76,12 @@ internal fun com.nuvio.app.features.debrid.DebridApiResponse<com.nuvio.app.featu
     type: CloudLibraryItemType,
 ): List<CloudLibraryItem> {
     if (!isSuccessful || body?.success == false) {
-        throw IllegalStateException(body?.detail ?: body?.error ?: rawBody.takeIf { it.isNotBlank() })
+        throw IllegalStateException(
+            body?.detail
+                ?: body?.error
+                ?: rawBody.takeIf { it.isNotBlank() }
+                ?: "Torbox request failed (HTTP $status).",
+        )
     }
     val envelope = body
         ?: throw IllegalStateException("Unexpected response from Torbox (HTTP $status).")

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/cloud/TorboxCloudLibraryProviderApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/cloud/TorboxCloudLibraryProviderApi.kt
@@ -62,17 +62,30 @@ internal class TorboxCloudLibraryProviderApi : CloudLibraryProviderApi {
 
     private fun com.nuvio.app.features.debrid.DebridApiResponse<com.nuvio.app.features.debrid.TorboxEnvelopeDto<List<TorboxCloudItemDto>>>.itemsOrThrow(
         type: CloudLibraryItemType,
-    ): List<CloudLibraryItem> {
-        if (!isSuccessful || body?.success == false) {
-            throw IllegalStateException(body?.detail ?: body?.error ?: rawBody.takeIf { it.isNotBlank() })
-        }
-        return body?.data.orEmpty().mapNotNull { dto ->
-            dto.toCloudLibraryItem(
-                providerId = provider.id,
-                providerName = provider.displayName,
-                type = type,
-            )
-        }
+    ): List<CloudLibraryItem> =
+        toCloudLibraryItemsOrThrow(
+            providerId = provider.id,
+            providerName = provider.displayName,
+            type = type,
+        )
+}
+
+internal fun com.nuvio.app.features.debrid.DebridApiResponse<com.nuvio.app.features.debrid.TorboxEnvelopeDto<List<TorboxCloudItemDto>>>.toCloudLibraryItemsOrThrow(
+    providerId: String,
+    providerName: String,
+    type: CloudLibraryItemType,
+): List<CloudLibraryItem> {
+    if (!isSuccessful || body?.success == false) {
+        throw IllegalStateException(body?.detail ?: body?.error ?: rawBody.takeIf { it.isNotBlank() })
+    }
+    val envelope = body
+        ?: throw IllegalStateException("Unexpected response from Torbox (HTTP $status).")
+    return envelope.data.orEmpty().mapNotNull { dto ->
+        dto.toCloudLibraryItem(
+            providerId = providerId,
+            providerName = providerName,
+            type = type,
+        )
     }
 }
 

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/cloud/TorboxCloudLibraryFixtures.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/cloud/TorboxCloudLibraryFixtures.kt
@@ -1,0 +1,80 @@
+package com.nuvio.app.features.cloud
+
+internal val torboxRealMylistPayload = """
+        {
+            "success": true,
+            "error": null,
+            "detail": "Torrent list retrieved successfully.",
+            "data": [
+                {
+                    "id": 123456,
+                    "auth_id": "user-uuid",
+                    "server": 7,
+                    "hash": "2c229180e129280a36ba7f3a22e2f5135a02a766",
+                    "name": "Show.S01.1080p.WEB-DL",
+                    "magnet": "magnet:?xt=urn:btih:2c229180e129280a36ba7f3a22e2f5135a02a766",
+                    "size": 4294967296,
+                    "active": false,
+                    "created_at": "2026-03-08T21:21:28Z",
+                    "updated_at": "2026-03-08T21:21:41Z",
+                    "download_state": "completed",
+                    "seeds": 12,
+                    "peers": 3,
+                    "ratio": 1.5,
+                    "progress": 1,
+                    "download_speed": 0,
+                    "upload_speed": 0,
+                    "eta": 0,
+                    "torrent_file": true,
+                    "expires_at": "2026-04-07T21:21:41Z",
+                    "download_present": true,
+                    "files": [
+                        {
+                            "id": 0,
+                            "md5": null,
+                            "hash": "2c229180e129280a36ba7f3a22e2f5135a02a766",
+                            "name": "Show.S01.1080p.WEB-DL/Show.S01E01.1080p.WEB-DL.mkv",
+                            "size": 2147483648,
+                            "zipped": false,
+                            "s3_path": "buckets/123456/Show.S01E01.1080p.WEB-DL.mkv",
+                            "infected": false,
+                            "mimetype": "video/x-matroska",
+                            "short_name": "Show.S01E01.1080p.WEB-DL.mkv",
+                            "absolute_path": "/completed/Show.S01.1080p.WEB-DL/Show.S01E01.1080p.WEB-DL.mkv",
+                            "opensubtitles_hash": "abc"
+                        },
+                        {
+                            "id": 1,
+                            "md5": null,
+                            "hash": "2c229180e129280a36ba7f3a22e2f5135a02a766",
+                            "name": "Show.S01.1080p.WEB-DL/sample.txt",
+                            "size": 1024,
+                            "zipped": false,
+                            "s3_path": "buckets/123456/sample.txt",
+                            "infected": false,
+                            "mimetype": "text/plain",
+                            "short_name": "sample.txt",
+                            "absolute_path": "/completed/Show.S01.1080p.WEB-DL/sample.txt",
+                            "opensubtitles_hash": null
+                        }
+                    ],
+                    "download_path": "123456",
+                    "availability": 1,
+                    "download_finished": true,
+                    "tracker": null,
+                    "total_uploaded": 0,
+                    "total_downloaded": 4294967296,
+                    "cached": true,
+                    "owner": "user-uuid",
+                    "seed_torrent": false,
+                    "allow_zipped": true,
+                    "long_term_seeding": false,
+                    "tracker_message": null,
+                    "cached_at": "2026-04-07T21:21:41Z",
+                    "private": false,
+                    "alternative_hashes": [],
+                    "tags": []
+                }
+            ]
+        }
+    """.trimIndent()

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/cloud/TorboxCloudLibraryProviderApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/cloud/TorboxCloudLibraryProviderApiTest.kt
@@ -197,7 +197,7 @@ class TorboxCloudLibraryProviderApiTest {
 
     @Test
     fun `decodes real Torbox mylist payload and maps playable items`() {
-        val items = mylistResponse(rawBody = realMylistPayload).toCloudLibraryItemsOrThrow(
+        val items = mylistResponse(rawBody = torboxRealMylistPayload).toCloudLibraryItemsOrThrow(
             providerId = "torbox",
             providerName = "Torbox",
             type = CloudLibraryItemType.Torrent,
@@ -217,7 +217,7 @@ class TorboxCloudLibraryProviderApiTest {
 
     @Test
     fun `truncated mylist payload surfaces an error instead of an empty library`() {
-        val truncated = realMylistPayload.take(realMylistPayload.length / 2) + "\n...[truncated]"
+        val truncated = torboxRealMylistPayload.take(torboxRealMylistPayload.length / 2) + "\n...[truncated]"
         val response = mylistResponse(rawBody = truncated)
 
         assertNull(response.body)
@@ -254,83 +254,4 @@ class TorboxCloudLibraryProviderApiTest {
             }.getOrNull(),
             rawBody = rawBody,
         )
-
-    private val realMylistPayload = """
-        {
-            "success": true,
-            "error": null,
-            "detail": "Torrent list retrieved successfully.",
-            "data": [
-                {
-                    "id": 123456,
-                    "auth_id": "user-uuid",
-                    "server": 7,
-                    "hash": "2c229180e129280a36ba7f3a22e2f5135a02a766",
-                    "name": "Show.S01.1080p.WEB-DL",
-                    "magnet": "magnet:?xt=urn:btih:2c229180e129280a36ba7f3a22e2f5135a02a766",
-                    "size": 4294967296,
-                    "active": false,
-                    "created_at": "2026-03-08T21:21:28Z",
-                    "updated_at": "2026-03-08T21:21:41Z",
-                    "download_state": "completed",
-                    "seeds": 12,
-                    "peers": 3,
-                    "ratio": 1.5,
-                    "progress": 1,
-                    "download_speed": 0,
-                    "upload_speed": 0,
-                    "eta": 0,
-                    "torrent_file": true,
-                    "expires_at": "2026-04-07T21:21:41Z",
-                    "download_present": true,
-                    "files": [
-                        {
-                            "id": 0,
-                            "md5": null,
-                            "hash": "2c229180e129280a36ba7f3a22e2f5135a02a766",
-                            "name": "Show.S01.1080p.WEB-DL/Show.S01E01.1080p.WEB-DL.mkv",
-                            "size": 2147483648,
-                            "zipped": false,
-                            "s3_path": "buckets/123456/Show.S01E01.1080p.WEB-DL.mkv",
-                            "infected": false,
-                            "mimetype": "video/x-matroska",
-                            "short_name": "Show.S01E01.1080p.WEB-DL.mkv",
-                            "absolute_path": "/completed/Show.S01.1080p.WEB-DL/Show.S01E01.1080p.WEB-DL.mkv",
-                            "opensubtitles_hash": "abc"
-                        },
-                        {
-                            "id": 1,
-                            "md5": null,
-                            "hash": "2c229180e129280a36ba7f3a22e2f5135a02a766",
-                            "name": "Show.S01.1080p.WEB-DL/sample.txt",
-                            "size": 1024,
-                            "zipped": false,
-                            "s3_path": "buckets/123456/sample.txt",
-                            "infected": false,
-                            "mimetype": "text/plain",
-                            "short_name": "sample.txt",
-                            "absolute_path": "/completed/Show.S01.1080p.WEB-DL/sample.txt",
-                            "opensubtitles_hash": null
-                        }
-                    ],
-                    "download_path": "123456",
-                    "availability": 1,
-                    "download_finished": true,
-                    "tracker": null,
-                    "total_uploaded": 0,
-                    "total_downloaded": 4294967296,
-                    "cached": true,
-                    "owner": "user-uuid",
-                    "seed_torrent": false,
-                    "allow_zipped": true,
-                    "long_term_seeding": false,
-                    "tracker_message": null,
-                    "cached_at": "2026-04-07T21:21:41Z",
-                    "private": false,
-                    "alternative_hashes": [],
-                    "tags": []
-                }
-            ]
-        }
-    """.trimIndent()
 }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/cloud/TorboxCloudLibraryProviderApiTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/cloud/TorboxCloudLibraryProviderApiTest.kt
@@ -1,11 +1,15 @@
 package com.nuvio.app.features.cloud
 
+import com.nuvio.app.features.debrid.DebridApiJson
+import com.nuvio.app.features.debrid.DebridApiResponse
 import com.nuvio.app.features.debrid.DebridProviders
 import com.nuvio.app.features.debrid.TorboxCloudFileDto
 import com.nuvio.app.features.debrid.TorboxCloudItemDto
+import com.nuvio.app.features.debrid.TorboxEnvelopeDto
 import kotlinx.serialization.json.JsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
@@ -190,4 +194,143 @@ class TorboxCloudLibraryProviderApiTest {
         assertEquals("usenet_id", torboxRequestIdParameterName(CloudLibraryItemType.Usenet))
         assertEquals("web_id", torboxRequestIdParameterName(CloudLibraryItemType.WebDownload))
     }
+
+    @Test
+    fun `decodes real Torbox mylist payload and maps playable items`() {
+        val items = mylistResponse(rawBody = realMylistPayload).toCloudLibraryItemsOrThrow(
+            providerId = "torbox",
+            providerName = "Torbox",
+            type = CloudLibraryItemType.Torrent,
+        )
+
+        assertEquals(1, items.size)
+        val item = items.single()
+        assertEquals("123456", item.id)
+        assertEquals("Show.S01.1080p.WEB-DL", item.name)
+        assertEquals("completed", item.status)
+        assertEquals(1.0f, item.progressFraction)
+        assertEquals(
+            listOf("Show.S01E01.1080p.WEB-DL.mkv"),
+            item.playableFiles.map { it.name },
+        )
+    }
+
+    @Test
+    fun `truncated mylist payload surfaces an error instead of an empty library`() {
+        val truncated = realMylistPayload.take(realMylistPayload.length / 2) + "\n...[truncated]"
+        val response = mylistResponse(rawBody = truncated)
+
+        assertNull(response.body)
+        assertFailsWith<IllegalStateException> {
+            response.toCloudLibraryItemsOrThrow(
+                providerId = "torbox",
+                providerName = "Torbox",
+                type = CloudLibraryItemType.Torrent,
+            )
+        }
+    }
+
+    @Test
+    fun `error envelope surfaces detail message`() {
+        val payload = """{"success":false,"error":"BAD_TOKEN","detail":"Your token is invalid or has expired.","data":null}"""
+        val error = assertFailsWith<IllegalStateException> {
+            mylistResponse(status = 403, rawBody = payload).toCloudLibraryItemsOrThrow(
+                providerId = "torbox",
+                providerName = "Torbox",
+                type = CloudLibraryItemType.Torrent,
+            )
+        }
+        assertEquals("Your token is invalid or has expired.", error.message)
+    }
+
+    private fun mylistResponse(
+        status: Int = 200,
+        rawBody: String,
+    ): DebridApiResponse<TorboxEnvelopeDto<List<TorboxCloudItemDto>>> =
+        DebridApiResponse(
+            status = status,
+            body = runCatching {
+                DebridApiJson.json.decodeFromString<TorboxEnvelopeDto<List<TorboxCloudItemDto>>>(rawBody)
+            }.getOrNull(),
+            rawBody = rawBody,
+        )
+
+    private val realMylistPayload = """
+        {
+            "success": true,
+            "error": null,
+            "detail": "Torrent list retrieved successfully.",
+            "data": [
+                {
+                    "id": 123456,
+                    "auth_id": "user-uuid",
+                    "server": 7,
+                    "hash": "2c229180e129280a36ba7f3a22e2f5135a02a766",
+                    "name": "Show.S01.1080p.WEB-DL",
+                    "magnet": "magnet:?xt=urn:btih:2c229180e129280a36ba7f3a22e2f5135a02a766",
+                    "size": 4294967296,
+                    "active": false,
+                    "created_at": "2026-03-08T21:21:28Z",
+                    "updated_at": "2026-03-08T21:21:41Z",
+                    "download_state": "completed",
+                    "seeds": 12,
+                    "peers": 3,
+                    "ratio": 1.5,
+                    "progress": 1,
+                    "download_speed": 0,
+                    "upload_speed": 0,
+                    "eta": 0,
+                    "torrent_file": true,
+                    "expires_at": "2026-04-07T21:21:41Z",
+                    "download_present": true,
+                    "files": [
+                        {
+                            "id": 0,
+                            "md5": null,
+                            "hash": "2c229180e129280a36ba7f3a22e2f5135a02a766",
+                            "name": "Show.S01.1080p.WEB-DL/Show.S01E01.1080p.WEB-DL.mkv",
+                            "size": 2147483648,
+                            "zipped": false,
+                            "s3_path": "buckets/123456/Show.S01E01.1080p.WEB-DL.mkv",
+                            "infected": false,
+                            "mimetype": "video/x-matroska",
+                            "short_name": "Show.S01E01.1080p.WEB-DL.mkv",
+                            "absolute_path": "/completed/Show.S01.1080p.WEB-DL/Show.S01E01.1080p.WEB-DL.mkv",
+                            "opensubtitles_hash": "abc"
+                        },
+                        {
+                            "id": 1,
+                            "md5": null,
+                            "hash": "2c229180e129280a36ba7f3a22e2f5135a02a766",
+                            "name": "Show.S01.1080p.WEB-DL/sample.txt",
+                            "size": 1024,
+                            "zipped": false,
+                            "s3_path": "buckets/123456/sample.txt",
+                            "infected": false,
+                            "mimetype": "text/plain",
+                            "short_name": "sample.txt",
+                            "absolute_path": "/completed/Show.S01.1080p.WEB-DL/sample.txt",
+                            "opensubtitles_hash": null
+                        }
+                    ],
+                    "download_path": "123456",
+                    "availability": 1,
+                    "download_finished": true,
+                    "tracker": null,
+                    "total_uploaded": 0,
+                    "total_downloaded": 4294967296,
+                    "cached": true,
+                    "owner": "user-uuid",
+                    "seed_torrent": false,
+                    "allow_zipped": true,
+                    "long_term_seeding": false,
+                    "tracker_message": null,
+                    "cached_at": "2026-04-07T21:21:41Z",
+                    "private": false,
+                    "alternative_hashes": [],
+                    "tags": []
+                }
+            ]
+        }
+    """.trimIndent()
 }


### PR DESCRIPTION
## Summary

Library → Cloud showed "no playable cloud files match the current filters" on Android for TorBox users with a populated dashboard, with no error.

- Fixes #1216: cloud library shows up empty

## PR type

- [x] Behavior bug/regression fix

## Why

Android's `httpRequestRaw` read response bodies through `readResponseBodyLimited`, which capped at 1 MiB and appended a literal `"...[truncated]"`. TorBox's `GET /v1/api/torrents/mylist` returns up to 1000 items each carrying a full `files[]` array (verified against the official TorBox API docs), so a populated account's response easily exceeds 1 MiB. The corrupted JSON hit `decodeBody`, which swallows `SerializationException` into `body == null` on an HTTP 200, and `itemsOrThrow` treated that as a successful empty list — silently empty library. iOS and desktop read bodies unbounded, matching the Android-only report; auth and field names were verified correct against the docs.

Two changes: Android raw requests now use the same unbounded `readResponseBody` that commit bda164df already adopted for addon text requests (the dead limited-read helpers are removed with their only caller), and `TorboxCloudLibraryProviderApi` treats an undecodable list response as a provider error so the failure surfaces as an error card instead of an empty library.

## Issue or approval

Fixes #1216

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Removing the 1 MiB cap aligns Android with iOS/desktop (both already unbounded) and with bda164df's direction for addon text requests; if a memory guard is still wanted for untrusted addon URLs it should be a much larger limit applied on all platforms — flagged for maintainer preference.
- The new "Unexpected response from Torbox (HTTP …)" message is an English literal, consistent with the surrounding API-supplied error text.

## Testing

`./gradlew :composeApp:compileFullDebugKotlinAndroid` passes clean. `./gradlew :composeApp:testFullDebugUnitTest` passes.

New `TorboxCloudLibraryProviderApiTest` (commonTest): a fixture mirroring the real TorBox mylist response shape (all documented fields including nulls) decodes and maps to playable items; a truncated payload now throws instead of yielding an empty list; a `BAD_TOKEN` error envelope surfaces its detail.

Manual (please verify during review — needs a TorBox account with >1 MiB of list data):
- Library → Cloud on Android with a populated TorBox account: files appear.
- Invalid API key: an error card appears instead of a silent empty state.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1216
