### PR TITLE
fix: styled ASS/SSA subtitles rendering flattened on iOS

### DIFF
--- a/iosApp/iosApp/Player/MPVPlayerBridge.swift
+++ b/iosApp/iosApp/Player/MPVPlayerBridge.swift
@@ -621,7 +621,7 @@ final class MPVPlayerViewController: UIViewController {
     ) {
         guard mpv != nil else { return }
 
-        checkError(mpv_set_property_string(mpv, "sub-ass-override", "force"))
+        checkError(mpv_set_property_string(mpv, "sub-ass-override", "no"))
         checkError(mpv_set_property_string(mpv, "sub-color", textColor))
         checkError(mpv_set_property_string(mpv, "sub-back-color", backgroundColor))
         checkError(mpv_set_property_string(mpv, "sub-outline-color", outlineColor))


### PR DESCRIPTION
## Summary

Fixes styled ASS and SSA subtitles rendering flattened on iOS. The MPV bridge set
`sub-ass-override` to `force`, overriding the embedded ASS styling with the app's
subtitle style. Setting it to `no` restores their intended styling.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On iOS, styled ASS and SSA subtitles lost their formatting because the player forced
`sub-ass-override`, replacing the embedded styles with the app's subtitle settings. This
turns the override off so those subtitles keep their intended look.

## Issue or approval

Fixes https://github.com/NuvioMedia/NuvioMobile/issues/1410

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only changes `sub-ass-override` from `force` to `no` in the iOS MPV bridge; all other subtitle style properties are still applied
- Styled ASS and SSA subtitles now keep their embedded styling on iOS instead of being flattened
- SRT subtitles still use the app's built in subtitle styles
- Subtitle delay still applies to all subtitles, styled ASS/SSA included
- iOS only; no change to Android

## Testing

- Played a video with styled ASS/SSA subtitles on iOS: styling (positions, colors, fonts) renders as authored, not flattened
- Played a video with SRT subtitles on iOS: still uses the app's subtitle style
- Adjusted subtitle delay on a styled ASS/SSA subtitle on iOS: still applies
- Tested on iPad simulator via Xcode

## Screenshots / Video

<img width="2752" height="2064" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-06-13" src="https://github.com/user-attachments/assets/ddbfd27a-26f9-47fb-84c6-d742d0f9f720" />
<img width="2752" height="2064" alt="Simulator Screenshot - iPad Pro 13-inch (M5) - 2026-06-13" src="https://github.com/user-attachments/assets/9a7c08bf-e3bc-4f43-8cb6-3b419ce23d05" />

## Breaking changes

None

## Linked issues

Fixes https://github.com/NuvioMedia/NuvioMobile/issues/1410