### PR TITLE
fix(player): resolve unrecognized input format during HLS stream playback

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlaybackMediaItems.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlaybackMediaItems.android.kt
@@ -2,6 +2,8 @@ package com.nuvio.app.features.player
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MimeTypes
+import java.net.HttpURLConnection
+import java.net.URL
 import java.util.Locale
 
 internal fun playbackMediaItemFromUrl(
@@ -68,7 +70,7 @@ private fun inferMimeTypeFromResponseHeaders(headers: Map<String, String>): Stri
     return inferMimeTypeFromPath(filename)
 }
 
-private fun normalizeMimeType(contentType: String?): String? {
+internal fun normalizeMimeType(contentType: String?): String? {
     val normalized = contentType
         ?.substringBefore(';')
         ?.trim()
@@ -187,12 +189,44 @@ private fun inferMimeTypeFromQuery(query: String): String? {
 private fun inferMimeTypeFromDelimitedToken(value: String): String? =
     when {
         DELIMITED_M3U8_PATTERN.containsMatchIn(value) -> MimeTypes.APPLICATION_M3U8
+        DELIMITED_HLS_PATTERN.containsMatchIn(value) -> MimeTypes.APPLICATION_M3U8
         DELIMITED_MPD_PATTERN.containsMatchIn(value) -> MimeTypes.APPLICATION_MPD
         DELIMITED_SS_PATTERN.containsMatchIn(value) -> MimeTypes.APPLICATION_SS
         else -> null
     }
 
+internal fun probeMimeType(url: String, headers: Map<String, String>): String? {
+    if (!url.startsWith("http://") && !url.startsWith("https://")) return null
+    val methods = listOf("HEAD", "GET")
+    methods.forEach { method ->
+        runCatching {
+            val connection = (URL(url).openConnection() as HttpURLConnection).apply {
+                requestMethod = method
+                connectTimeout = 3_000
+                readTimeout = 3_000
+                instanceFollowRedirects = true
+                setRequestProperty("User-Agent", "Mozilla/5.0")
+                setRequestProperty("Accept", "*/*")
+                headers.forEach { (key, value) ->
+                    setRequestProperty(key, value)
+                }
+            }
+            try {
+                val responseCode = connection.responseCode
+                if (responseCode in 200..299) {
+                    val contentType = connection.contentType
+                    normalizeMimeType(contentType)
+                } else null
+            } finally {
+                connection.disconnect()
+            }
+        }.getOrNull()?.let { return it }
+    }
+    return null
+}
+
 private const val MIME_VIDEO_QUICK_TIME = "video/quicktime"
-private val DELIMITED_M3U8_PATTERN = Regex("(^|[=/_.?&-])m3u8($|[=/_.?&-])")
-private val DELIMITED_MPD_PATTERN = Regex("(^|[=/_.?&-])mpd($|[=/_.?&-])")
-private val DELIMITED_SS_PATTERN = Regex("(^|[=/_.?&-])(ism|isml)($|[=/_.?&-])")
+private val DELIMITED_M3U8_PATTERN = Regex("(^|[=/_.?&%-])m3u8($|[=/_.?&%-])")
+private val DELIMITED_HLS_PATTERN = Regex("(^|[=/_.?&%-])hls($|[=/_.?&%-])")
+private val DELIMITED_MPD_PATTERN = Regex("(^|[=/_.?&%-])mpd($|[=/_.?&%-])")
+private val DELIMITED_SS_PATTERN = Regex("(^|[=/_.?&%-])(ism|isml)($|[=/_.?&%-])")

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -126,6 +126,17 @@ actual fun PlatformPlayerSurface(
     var fallbackStartPositionMs by remember(playerSourceKey) { mutableStateOf<Long?>(null) }
     val effectiveDecoderPriority = decoderPriorityOverride ?: playerSettings.decoderPriority
 
+    val initialMediaItem = remember(playerSourceKey) {
+        playbackMediaItemFromUrl(
+            url = sourceUrl,
+            responseHeaders = sanitizedSourceResponseHeaders,
+            streamType = normalizedStreamType,
+        )
+    }
+
+    var resolvedMediaItem by remember(playerSourceKey) { mutableStateOf(initialMediaItem) }
+    var probeAttempted by remember(playerSourceKey) { mutableStateOf(false) }
+
     val extractorsFactory = remember {
         DefaultExtractorsFactory()
             .setTsExtractorFlags(DefaultTsPayloadReaderFactory.FLAG_ENABLE_HDMV_DTS_AUDIO_STREAMS)
@@ -228,18 +239,13 @@ actual fun PlatformPlayerSurface(
                 .build()
         }
 
-        player.apply {
-            setPlaybackMediaItem(
-                videoMediaItem = playbackMediaItemFromUrl(
-                    url = sourceUrl,
-                    responseHeaders = sanitizedSourceResponseHeaders,
-                    streamType = normalizedStreamType,
-                ),
-                startPositionMs = fallbackStartPositionMs,
-            )
-            prepare()
-            this.playWhenReady = playWhenReady
-        }
+        player
+    }
+
+    LaunchedEffect(exoPlayer, resolvedMediaItem) {
+        val mediaItem = resolvedMediaItem ?: return@LaunchedEffect
+        exoPlayer.setPlaybackMediaItem(mediaItem, fallbackStartPositionMs)
+        exoPlayer.prepare()
     }
 
     val pendingSubtitleTrackIndex = remember { mutableListOf<Int>() }
@@ -264,25 +270,54 @@ actual fun PlatformPlayerSurface(
             exoPlayer.pause()
         }
 
+        fun reportPlayerError(error: PlaybackException) {
+            if (
+                playerSettings.decoderPriority == DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON &&
+                effectiveDecoderPriority != DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER &&
+                error.isDecoderFailure()
+            ) {
+                Log.w(
+                    TAG,
+                    "Decoder failure (${error.errorCodeName}); retrying with app decoders",
+                    error,
+                )
+                fallbackStartPositionMs = exoPlayer.currentPosition.coerceAtLeast(0L)
+                decoderPriorityOverride = DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER
+                latestOnError.value(null)
+                return
+            }
+            latestOnError.value(error.localizedMessage ?: runBlocking { getString(Res.string.player_unable_to_play_stream) })
+        }
+
         val listener = object : Player.Listener {
             override fun onPlayerError(error: PlaybackException) {
                 syncPlayerViewKeepScreenOn()
-                if (
-                    playerSettings.decoderPriority == DefaultRenderersFactory.EXTENSION_RENDERER_MODE_ON &&
-                    effectiveDecoderPriority != DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER &&
-                    error.isDecoderFailure()
-                ) {
-                    Log.w(
-                        TAG,
-                        "Decoder failure (${error.errorCodeName}); retrying with app decoders",
-                        error,
-                    )
-                    fallbackStartPositionMs = exoPlayer.currentPosition.coerceAtLeast(0L)
-                    decoderPriorityOverride = DefaultRenderersFactory.EXTENSION_RENDERER_MODE_PREFER
-                    latestOnError.value(null)
+
+                val isSourceError = error.errorCode == PlaybackException.ERROR_CODE_BEHIND_LIVE_WINDOW ||
+                        error.errorCode == PlaybackException.ERROR_CODE_IO_UNSPECIFIED ||
+                        error.cause?.toString()?.contains("UnrecognizedInputFormatException") == true
+
+                if (isSourceError && !probeAttempted) {
+                    probeAttempted = true
+                    coroutineScope.launch {
+                        val probedMime = withContext(Dispatchers.IO) {
+                            probeMimeType(sourceUrl, sanitizedSourceHeaders)
+                        }
+                        if (probedMime != null) {
+                            Log.d(TAG, "Playback failed with source error. Probed MIME type: $probedMime. Retrying...")
+                            resolvedMediaItem = MediaItem.Builder()
+                                .setUri(sourceUrl)
+                                .setMimeType(probedMime)
+                                .build()
+                            latestOnError.value(null)
+                            return@launch
+                        }
+                        reportPlayerError(error)
+                    }
                     return
                 }
-                latestOnError.value(error.localizedMessage ?: runBlocking { getString(Res.string.player_unable_to_play_stream) })
+
+                reportPlayerError(error)
             }
 
             override fun onPlaybackStateChanged(playbackState: Int) {


### PR DESCRIPTION
## Summary

This PR resolves a playback error (`UnrecognizedInputFormatException` inside `ExoPlaybackException: Source error`) when attempting to play HLS streams that lack a `.m3u8` extension or the `hls` keyword in their URL path, and when the addon omits the `type: "hls"` property in its stream definition (e.g. Vidmody streams).

- **Static URL Pattern Improvements**: Updated regex delimiters to support `%` (to handle URL-encoded path segments like `%2Fm3u8%2F`) and recognized the delimited `hls` keyword in paths/query strings.
- **Fallback Probing Logic**: The player immediately attempts normal playback (zero overhead/requests for standard streams). If a source error is encountered, a background `HEAD`/`GET` request probes the HTTP response headers (following redirects). If HLS is resolved (e.g. `application/x-mpegURL`), the stream's MIME type is updated and the player automatically restarts playback.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Users trying to play HLS streams served by certain addons (like Vidmody, which uses clean paths like `/vs/tt123456` with no extension and doesn't specify `type: "hls"`) were met with a playback failure error, making the streams completely unplayable.

## Issue or approval

#1300

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- No cosmetic or UI changes. No new dependencies or architecture changes.

## Testing

- **Compilation**: Compiled the project locally using `./gradlew :composeApp:compileFullDebugKotlinAndroid` (Passed successfully).
- **Unit Tests**: Ran tests using `./gradlew :composeApp:testFullDebugUnitTest` (Passed successfully).
- **Manual Verification**: Deployed and installed the application using `./gradlew :composeApp:installFullDebug` on  '24129PN74G - 16' (Passed successfully).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

#1300
