### PR TITLE
fix(player): clamp skip-outro seekTo against actual video duration

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -335,7 +335,7 @@ private fun BoxScope.RenderPlaybackOverlays(
         onSkipInterval = { interval ->
             val rawMs = (interval.endTime * 1000.0).toLong()
             val durationMs = playbackSnapshot.durationMs
-            val seekMs = if (durationMs > 0L) rawMs.coerceAtMost(durationMs) else rawMs
+            val seekMs = if (durationMs > 0L) rawMs.coerceAtMost(durationMs - 1) else rawMs
             playerController?.seekTo(seekMs)
             scheduleProgressSyncAfterSeek()
             skipIntervalDismissed = true

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -333,7 +333,10 @@ private fun BoxScope.RenderPlaybackOverlays(
         skipIntervalDismissed = skipIntervalDismissed,
         controlsVisible = controlsVisible,
         onSkipInterval = { interval ->
-            playerController?.seekTo((interval.endTime * 1000).toLong())
+            val rawMs = (interval.endTime * 1000.0).toLong()
+            val durationMs = playbackSnapshot.durationMs
+            val seekMs = if (durationMs > 0L) rawMs.coerceAtMost(durationMs) else rawMs
+            playerController?.seekTo(seekMs)
             scheduleProgressSyncAfterSeek()
             skipIntervalDismissed = true
         },


### PR DESCRIPTION
## Summary

Clamps the skip-outro `seekTo` target to the known video duration so tapping "Skip outro" jumps to the end cleanly instead of triggering a playback error.

## PR type

- [x] Behavior bug/regression fix

## Why

`SkipIntroRepository` stores the last AnimSkip segment's `endTime` as `Double.MAX_VALUE` to signal "play to the end". The `onSkipInterval` handler converted that to milliseconds with `(interval.endTime * 1000).toLong()`, and on Kotlin/JVM `(Double.MAX_VALUE * 1000.0).toLong()` saturates to `Long.MAX_VALUE`. Handing `Long.MAX_VALUE` to ExoPlayer's `seekTo` produces the playback error reported in #1148 instead of seeking to the final frame. The handler now clamps the target to `playbackSnapshot.durationMs` when the duration is known and keeps the previous value when it is not, so only the overflow case changes.

## Issue or approval

Fixes #1148

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the `onSkipInterval` handler in `PlayerScreenRuntimeUi.kt` changes. The `Double.MAX_VALUE` sentinel in `SkipIntroRepository` is intentional and left as-is; the clamp is applied at the call site only. No other seek paths or player state are touched.

## Testing

`./gradlew :composeApp:testFullDebugUnitTest` — BUILD SUCCESSFUL (2m 43s, 34 tasks). The change is an arithmetic guard using `coerceAtMost` against the existing `playbackSnapshot.durationMs`, with no new state or dependencies. On-device confirmation of the skip-outro tap from #1148 is still worth a check during review.

## Screenshots / Video

Not a UI change.

## Breaking changes

None. Segments with a real `endTime` are unaffected; only the `Double.MAX_VALUE` sentinel case is corrected.

## Linked issues

Fixes #1148
