### PR TITLE
fix(player): apply tv/series alias and singular resource name in subtitle addon matching

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleRepository.kt
@@ -101,7 +101,7 @@ object SubtitleRepository {
             }
 
             _addonSubtitles.value = allSubs
-            if (allSubs.isEmpty() && addons.any { it.manifest?.resources?.any { r -> r.name == "subtitles" } == true }) {
+            if (allSubs.isEmpty() && addons.any { it.manifest?.resources?.any { r -> r.name.isSubtitleResourceName() } == true }) {
                 _error.value = getString(Res.string.compose_player_no_subtitles_found)
             }
             _isLoading.value = false
@@ -123,7 +123,8 @@ private fun String.isSubtitleResourceName(): Boolean =
     equals("subtitles", ignoreCase = true) || equals("subtitle", ignoreCase = true)
 
 private fun AddonResource.supportsSubtitleType(type: String, videoId: String): Boolean {
-    val typeMatches = types.isEmpty() || types.any { it.equals(type, ignoreCase = true) }
+    val canonical = canonicalSubtitleType(type)
+    val typeMatches = types.isEmpty() || types.any { canonicalSubtitleType(it).equals(canonical, ignoreCase = true) }
     if (!typeMatches) return false
     return idPrefixes.isEmpty() || idPrefixes.any { prefix -> videoId.startsWith(prefix) }
 }


### PR DESCRIPTION
## Summary

Applies the `tv`↔`series` type alias and the singular `subtitle` resource name when matching subtitle addons, so addons that declare `tv` (instead of `series`) or the singular resource name are no longer silently skipped.

## PR type

- [x] Behavior bug/regression fix

## Why

`SubtitleRepository.supportsSubtitleType` compared the request content type against addon-declared types without applying the `tv`↔`series` alias that `canonicalSubtitleType()` already expresses, so an addon declaring `types: ["movie", "tv"]` was skipped for `series` content with no subtitles and no error. Separately, the empty-result guard used a case-sensitive `r.name == "subtitles"` check while the resource-finder loop accepts both `subtitles` and singular `subtitle` via `isSubtitleResourceName()`; that mismatch suppressed the "no subtitles found" message for addons that declare the singular name. `StreamsRepository` already handles the same alias bidirectionally, so this brings subtitle matching in line with stream matching.

## Issue or approval

Related to #1319 and #1033 (addon subtitles not appearing). This addresses the specific `tv`-declared-type and singular `subtitle` resource-name cases; it is not claimed as a full fix for the broader "no addon subtitles at all" reports, whose root cause is elsewhere. Surfaced via a code audit comparing subtitle matching against the equivalent logic in `StreamsRepository`.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only `SubtitleRepository.kt` is modified. `StreamsRepository.kt` already handles the `tv`↔`series` alias and is not touched. No URL building, manifest parsing, or addon-enable logic is changed.

## Testing

`./gradlew :composeApp:testFullDebugUnitTest --rerun-tasks` — BUILD SUCCESSFUL (1m 41s, 34 tasks, all executed with no cache). The change delegates to the existing in-file `canonicalSubtitleType()` and `isSubtitleResourceName()` helpers; no new functions, imports, or dependencies. No unit tests currently cover `supportsSubtitleType`; behavior parity was confirmed against the equivalent alias handling in `StreamsRepository`.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Related to #1319, #1033 — not claimed as a full fix; see Issue or approval.
