### PR TITLE
fix(ios): serialize catalog route target kind

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -305,7 +305,7 @@ data class StreamRoute(
 data class CatalogRoute(
     val title: String,
     val subtitle: String,
-    val targetKind: CatalogTargetKind,
+    val targetKind: String,
     val contentType: String,
     val supportsPagination: Boolean = false,
     val manifestUrl: String? = null,
@@ -327,7 +327,7 @@ data class CatalogRoute(
             is CatalogTarget.Addon -> CatalogTargetKind.ADDON
             is CatalogTarget.Library -> CatalogTargetKind.LIBRARY
             is CatalogTarget.CollectionSource -> CatalogTargetKind.COLLECTION_SOURCE
-        },
+        }.name,
         contentType = target.contentType,
         supportsPagination = target.supportsPagination,
         manifestUrl = (target as? CatalogTarget.Addon)?.manifestUrl,
@@ -340,7 +340,7 @@ data class CatalogRoute(
     )
 
     fun toCatalogTarget(): CatalogTarget =
-        when (targetKind) {
+        when (CatalogTargetKind.valueOf(targetKind)) {
             CatalogTargetKind.ADDON -> CatalogTarget.Addon(
                 manifestUrl = requireNotNull(manifestUrl),
                 contentType = contentType,


### PR DESCRIPTION
## Summary

Fixes the iOS startup crash reported in #1359 by keeping `CatalogRoute.targetKind` on a primitive typed-navigation boundary.

`CatalogRoute` previously stored `targetKind` as the enum `CatalogTargetKind`. On iOS source builds, Compose Navigation failed while constructing the typed navigation graph because no enum `NavType` was provided for that route argument:

```text
Route com.nuvio.app.CatalogRoute could not find any NavType for argument targetKind of type com.nuvio.app.features.catalog.CatalogTargetKind - typeMap received was {}
```

This PR stores the route argument as `CatalogTargetKind.name` (`String`) and converts it back with `CatalogTargetKind.valueOf(targetKind)` in `toCatalogTarget()`.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The old behavior prevented the iOS app from launching from a source build because the navigation graph could not resolve `CatalogRoute.targetKind` as a route argument type.

The broken behavior was an immediate app termination at startup with the `CatalogRoute` / `CatalogTargetKind` `NavType` exception above.

The new behavior preserves the same catalog target semantics while serializing only the route boundary as a supported primitive `String`, avoiding the need for a custom enum `NavType` during graph construction.

## Issue or approval

Fixes #1359

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only changes `CatalogRoute.targetKind` serialization.
- Does not change catalog loading, addon behavior, profile sync, UI, navigation destinations, dependencies, or architecture.
- Does not include any startup/profile sync fix from local debugging; that is intentionally separate.

## Testing

- `git diff --check` passed.
- Added-line static scan found no secret/danger patterns.
- Independent review of the 3-line route-serialization diff found no security concerns or logic errors.
- Linux/JDK 21: `./gradlew :composeApp:compileKotlinMetadata :composeApp:compileCommonMainKotlinMetadata --stacktrace` passed using a temporary blank `local.properties` with no secrets.
- macOS/Xcode/JDK 21 on the exact PR branch: `./gradlew :composeApp:compileKotlinIosSimulatorArm64 --stacktrace` passed using a temporary blank `local.properties` with no secrets.
- Physical-device verification was performed on the same source pattern before opening this PR: after rebuilding/signing and installing the local fix over `com.nuvio.app` on an iPhone 16 Pro Max, `xcrun devicectl device process launch --console` no longer produced the `CatalogRoute` / `CatalogTargetKind` `NavType` exception or signal-6 startup termination.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1359