### PR TITLE
feat: Add download option to title and episode action sheets

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="action_close">Close</string>
     <string name="action_delete">Delete</string>
     <string name="action_done">Done</string>
+    <string name="action_download">Download</string>
     <string name="action_edit">Edit</string>
     <string name="action_import">Import</string>
     <string name="action_next">Next</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -1182,11 +1182,12 @@ private fun MainAppContent(
             resumeProgressFraction: Float?,
             manualSelection: Boolean,
             startFromBeginning: Boolean,
+            isDownloadMode: Boolean = false,
         ) {
             val targetResumePositionMs = if (startFromBeginning) 0L else (resumePositionMs ?: 0L)
             val targetResumeProgressFraction = if (startFromBeginning) null else resumeProgressFraction
 
-            if (!manualSelection) {
+            if (!manualSelection && !isDownloadMode) {
                 val downloadedItem = DownloadsRepository.findPlayableDownload(
                     parentMetaId = parentMetaId,
                     seasonNumber = seasonNumber,
@@ -1251,6 +1252,7 @@ private fun MainAppContent(
                     resumeProgressFraction = targetResumeProgressFraction,
                     manualSelection = manualSelection,
                     startFromBeginning = startFromBeginning,
+                    isDownloadMode = isDownloadMode,
                 ),
             )
             navController.navigate(
@@ -1301,6 +1303,30 @@ private fun MainAppContent(
                     resumeProgressFraction = null,
                     manualSelection = true,
                     startFromBeginning = false,
+                )
+            }
+
+        val onDownload: (String, String, String, String, String, String?, String?, String?, Int?, Int?, String?, String?, String?, Long?) -> Unit =
+            { type, videoId, parentMetaId, parentMetaType, title, logo, poster, background, seasonNumber, episodeNumber, episodeTitle, episodeThumbnail, pauseDescription, resumePositionMs ->
+                launchPlaybackWithDownloadPreference(
+                    type = type,
+                    videoId = videoId,
+                    parentMetaId = parentMetaId,
+                    parentMetaType = parentMetaType,
+                    title = title,
+                    logo = logo,
+                    poster = poster,
+                    background = background,
+                    seasonNumber = seasonNumber,
+                    episodeNumber = episodeNumber,
+                    episodeTitle = episodeTitle,
+                    episodeThumbnail = episodeThumbnail,
+                    pauseDescription = pauseDescription,
+                    resumePositionMs = resumePositionMs,
+                    resumeProgressFraction = null,
+                    manualSelection = false,
+                    startFromBeginning = false,
+                    isDownloadMode = true,
                 )
             }
 
@@ -1653,6 +1679,7 @@ private fun MainAppContent(
                         },
                         onPlay = onPlay,
                         onPlayManually = onPlayManually,
+                        onDownload = onDownload,
                         onOpenMeta = { preview ->
                             coroutineScope.launch {
                                 val resolvedId = if (preview.id.startsWith("tmdb:")) {
@@ -2119,6 +2146,30 @@ private fun MainAppContent(
                             selectedStream
                         }
                         val sourceUrl = stream.playableDirectUrl
+
+                        if (launch.isDownloadMode) {
+                            val result = DownloadsRepository.enqueueFromStream(
+                                contentType = launch.type,
+                                videoId = effectiveVideoId,
+                                parentMetaId = launch.parentMetaId ?: effectiveVideoId,
+                                parentMetaType = launch.parentMetaType ?: launch.type,
+                                title = launch.title,
+                                logo = launch.logo,
+                                poster = launch.poster,
+                                background = launch.background,
+                                seasonNumber = launch.seasonNumber,
+                                episodeNumber = launch.episodeNumber,
+                                episodeTitle = launch.episodeTitle,
+                                episodeThumbnail = launch.episodeThumbnail,
+                                stream = stream,
+                            )
+                            NuvioToastController.show(result.toastMessage())
+                            StreamsRepository.consumeAutoPlay()
+                            StreamsRepository.cancelLoading()
+                            navController.popBackStack()
+                            return@LaunchedEffect
+                        }
+
                         if (sourceUrl == null && stream.needsLocalDebridResolve && stream.p2pInfoHash != null) {
                             autoPlayHandled = true
                             requestOrOpenP2pStream(
@@ -2265,6 +2316,29 @@ private fun MainAppContent(
                             return
                         }
                         val sourceUrl = stream.playableDirectUrl ?: return
+
+                        if (launch.isDownloadMode) {
+                            val result = DownloadsRepository.enqueueFromStream(
+                                contentType = launch.type,
+                                videoId = effectiveVideoId,
+                                parentMetaId = launch.parentMetaId ?: effectiveVideoId,
+                                parentMetaType = launch.parentMetaType ?: launch.type,
+                                title = launch.title,
+                                logo = launch.logo,
+                                poster = launch.poster,
+                                background = launch.background,
+                                seasonNumber = launch.seasonNumber,
+                                episodeNumber = launch.episodeNumber,
+                                episodeTitle = launch.episodeTitle,
+                                episodeThumbnail = launch.episodeThumbnail,
+                                stream = stream,
+                            )
+                            NuvioToastController.show(result.toastMessage())
+                            StreamsRepository.cancelLoading()
+                            navController.popBackStack()
+                            return
+                        }
+
                         if (playerSettings.streamReuseLastLinkEnabled) {
                             val cacheKey = StreamLinkCacheRepository.contentKey(
                                 type = launch.type,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -2304,19 +2304,6 @@ private fun MainAppContent(
                             }
                             return
                         }
-                        if (stream.needsLocalDebridResolve && stream.p2pInfoHash != null) {
-                            requestOrOpenP2pStream(
-                                stream = stream,
-                                resolvedResumePositionMs = resolvedResumePositionMs,
-                                resolvedResumeProgressFraction = resolvedResumeProgressFraction,
-                                forceExternal = forceExternal,
-                                forceInternal = forceInternal,
-                                isAutoPlay = false,
-                            )
-                            return
-                        }
-                        val sourceUrl = stream.playableDirectUrl ?: return
-
                         if (launch.isDownloadMode) {
                             val result = DownloadsRepository.enqueueFromStream(
                                 contentType = launch.type,
@@ -2338,6 +2325,19 @@ private fun MainAppContent(
                             navController.popBackStack()
                             return
                         }
+
+                        if (stream.needsLocalDebridResolve && stream.p2pInfoHash != null) {
+                            requestOrOpenP2pStream(
+                                stream = stream,
+                                resolvedResumePositionMs = resolvedResumePositionMs,
+                                resolvedResumeProgressFraction = resolvedResumeProgressFraction,
+                                forceExternal = forceExternal,
+                                forceInternal = forceInternal,
+                                isAutoPlay = false,
+                            )
+                            return
+                        }
+                        val sourceUrl = stream.playableDirectUrl ?: return
 
                         if (playerSettings.streamReuseLastLinkEnabled) {
                             val cacheKey = StreamLinkCacheRepository.contentKey(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.CheckCircleOutline
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.CircularProgressIndicator
@@ -114,6 +115,7 @@ import com.nuvio.app.features.watching.application.WatchingState
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import nuvio.composeapp.generated.resources.*
+import nuvio.composeapp.generated.resources.action_download
 import org.jetbrains.compose.resources.getString
 import org.jetbrains.compose.resources.stringResource
 
@@ -125,6 +127,7 @@ fun MetaDetailsScreen(
     onBack: () -> Unit,
     onPlay: ((type: String, videoId: String, parentMetaId: String, parentMetaType: String, title: String, logo: String?, poster: String?, background: String?, seasonNumber: Int?, episodeNumber: Int?, episodeTitle: String?, episodeThumbnail: String?, pauseDescription: String?, resumePositionMs: Long?) -> Unit)? = null,
     onPlayManually: ((type: String, videoId: String, parentMetaId: String, parentMetaType: String, title: String, logo: String?, poster: String?, background: String?, seasonNumber: Int?, episodeNumber: Int?, episodeTitle: String?, episodeThumbnail: String?, pauseDescription: String?, resumePositionMs: Long?) -> Unit)? = null,
+    onDownload: ((type: String, videoId: String, parentMetaId: String, parentMetaType: String, title: String, logo: String?, poster: String?, background: String?, seasonNumber: Int?, episodeNumber: Int?, episodeTitle: String?, episodeThumbnail: String?, pauseDescription: String?, resumePositionMs: Long?) -> Unit)? = null,
     onOpenMeta: ((MetaPreview) -> Unit)? = null,
     onCastClick: ((MetaPerson, String?) -> Unit)? = null,
     onCompanyClick: ((MetaCompany, String) -> Unit)? = null,
@@ -607,6 +610,47 @@ fun MetaDetailsScreen(
                         }
                     }
                 }
+                val onPrimaryDownloadClick: () -> Unit = {
+                    when {
+                        (meta.type == "series" || hasEpisodes) && seriesAction != null -> {
+                            onDownload?.invoke(
+                                meta.type,
+                                seriesStreamVideoId ?: seriesAction.videoId,
+                                meta.id,
+                                meta.type,
+                                meta.name,
+                                meta.logo,
+                                meta.poster,
+                                meta.background,
+                                seriesAction.seasonNumber,
+                                seriesAction.episodeNumber,
+                                seriesAction.episodeTitle,
+                                seriesAction.episodeThumbnail,
+                                seriesPauseDescription,
+                                seriesAction.resumePositionMs,
+                            )
+                        }
+
+                        else -> {
+                            onDownload?.invoke(
+                                meta.type,
+                                meta.id,
+                                meta.id,
+                                meta.type,
+                                meta.name,
+                                meta.logo,
+                                meta.poster,
+                                meta.background,
+                                null,
+                                null,
+                                null,
+                                null,
+                                meta.description,
+                                movieProgress?.lastPositionMs,
+                            )
+                        }
+                    }
+                }
                 val manualPlayHandler = onPlayManually
                 val showManualPlayOption = manualPlayHandler != null && StreamAutoPlayPolicy.isEffectivelyEnabled(playerSettingsUiState)
                 val onPrimaryPlayLongClick: (() -> Unit)? = manualPlayHandler
@@ -696,6 +740,35 @@ fun MetaDetailsScreen(
                     val savedProgress = watchProgressUiState.byVideoId[streamVideoId]
                         ?.takeUnless { it.isCompleted }
                     onPlayManually?.invoke(
+                        meta.type,
+                        streamVideoId,
+                        meta.id,
+                        meta.type,
+                        meta.name,
+                        meta.logo,
+                        meta.poster,
+                        meta.background,
+                        season,
+                        episode,
+                        video.title,
+                        video.thumbnail,
+                        video.overview,
+                        savedProgress?.lastPositionMs,
+                    )
+                }
+                val onEpisodeDownloadClick: (MetaVideo) -> Unit = { video ->
+                    val season = video.season
+                    val episode = video.episode
+                    val playbackVideoId = buildPlaybackVideoId(
+                        parentMetaId = meta.id,
+                        seasonNumber = season,
+                        episodeNumber = episode,
+                        fallbackVideoId = video.id,
+                    )
+                    val streamVideoId = video.id.takeIf { it.isNotBlank() } ?: playbackVideoId
+                    val savedProgress = watchProgressUiState.byVideoId[streamVideoId]
+                        ?.takeUnless { it.isCompleted }
+                    onDownload?.invoke(
                         meta.type,
                         streamVideoId,
                         meta.id,
@@ -826,6 +899,7 @@ fun MetaDetailsScreen(
                                 isSaved = isSaved,
                                 isWatched = isWatched,
                                 onPrimaryPlayClick = onPrimaryPlayClick,
+                                onPrimaryDownloadClick = onPrimaryDownloadClick,
                                 onPrimaryPlayLongClick = onPrimaryPlayLongClick,
                                 onSaveClick = toggleSaved,
                                 onSaveLongClick = openLibraryListPicker,
@@ -1012,6 +1086,10 @@ fun MetaDetailsScreen(
                                 showPlayManually = showManualPlayOption,
                                 onPlayManually = {
                                     onEpisodeManualPlayClick(selectedEpisode)
+                                },
+                                showDownload = true,
+                                onDownload = {
+                                    onEpisodeDownloadClick(selectedEpisode)
                                 },
                             )
                         }
@@ -1277,6 +1355,7 @@ private fun LazyListScope.configuredMetaSectionItems(
     isSaved: Boolean,
     isWatched: Boolean,
     onPrimaryPlayClick: () -> Unit,
+    onPrimaryDownloadClick: () -> Unit,
     onPrimaryPlayLongClick: (() -> Unit)?,
     onSaveClick: () -> Unit,
     onSaveLongClick: (() -> Unit)?,
@@ -1352,6 +1431,7 @@ private fun LazyListScope.configuredMetaSectionItems(
                     isSaved = isSaved,
                     isWatched = isWatched,
                     onPrimaryPlayClick = onPrimaryPlayClick,
+                    onPrimaryDownloadClick = onPrimaryDownloadClick,
                     onPrimaryPlayLongClick = onPrimaryPlayLongClick,
                     onSaveClick = onSaveClick,
                     onSaveLongClick = onSaveLongClick,
@@ -1500,6 +1580,7 @@ private fun ConfiguredMetaSections(
     isSaved: Boolean,
     isWatched: Boolean,
     onPrimaryPlayClick: () -> Unit,
+    onPrimaryDownloadClick: () -> Unit,
     onPrimaryPlayLongClick: (() -> Unit)?,
     onSaveClick: () -> Unit,
     onSaveLongClick: (() -> Unit)?,
@@ -1590,6 +1671,12 @@ private fun ConfiguredMetaSections(
                             isActive = isSaved,
                             onClick = onSaveClick,
                             onLongClick = onSaveLongClick,
+                        ),
+                        DetailSecondaryAction(
+                            label = stringResource(Res.string.action_download),
+                            icon = Icons.Default.Download,
+                            isActive = false,
+                            onClick = onPrimaryDownloadClick,
                         ),
                     ),
                     isTablet = isTablet,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/EpisodeWatchedActionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/EpisodeWatchedActionSheet.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material.icons.filled.DoneAll
+import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.PlaylistAddCheckCircle
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -45,6 +46,8 @@ fun EpisodeWatchedActionSheet(
     onToggleSeasonWatched: () -> Unit,
     showPlayManually: Boolean = false,
     onPlayManually: (() -> Unit)? = null,
+    showDownload: Boolean = false,
+    onDownload: (() -> Unit)? = null,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val coroutineScope = rememberCoroutineScope()
@@ -120,6 +123,19 @@ fun EpisodeWatchedActionSheet(
                     title = stringResource(Res.string.play_manually),
                     onClick = {
                         onPlayManually()
+                        coroutineScope.launch {
+                            dismissNuvioBottomSheet(sheetState = sheetState, onDismiss = onDismiss)
+                        }
+                    },
+                )
+            }
+            if (showDownload && onDownload != null) {
+                NuvioBottomSheetDivider()
+                NuvioBottomSheetActionRow(
+                    icon = Icons.Default.Download,
+                    title = stringResource(Res.string.action_download),
+                    onClick = {
+                        onDownload()
                         coroutineScope.launch {
                             dismissNuvioBottomSheet(sheetState = sheetState, onDismiss = onDismiss)
                         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamLaunchStore.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamLaunchStore.kt
@@ -19,6 +19,7 @@ data class StreamLaunch(
     val resumeProgressFraction: Float? = null,
     val manualSelection: Boolean = false,
     val startFromBeginning: Boolean = false,
+    val isDownloadMode: Boolean = false,
 )
 
 object StreamLaunchStore {


### PR DESCRIPTION
## Summary

Added a secondary "Download" action to the MetaDetailsScreen hero buttons and the episode long-press action sheet. When triggered, it respects the user's existing Autoplay and source selection preferences, effectively allowing users to download a stream directly from the details page without triggering playback.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

When Autoplay is enabled in settings, users are prevented from manually selecting a stream to download because the app automatically begins playing it. This change introduces a dedicated Download button alongside the Play button and within the episode context menu, allowing users to queue a download using the exact same stream resolution logic (including their regex preferences) without triggering the player.

## Desktop scope

This branch updates shared Compose multiplatform UI code (MetaDetailsScreen and episode context menus). While tested primarily on Android, the UI changes apply to all platforms using the shared UI components.

## Issue or approval

No linked issue.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is scoped to the desktop app, desktop packaging, desktop documentation, or shared code required for desktop behavior.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This change only adds the download entry points to the UI. It intentionally reuses the existing `DownloadsRepository.enqueueFromStream` and stream resolution logic without modifying the core player, the Stremio addon fetching logic, or the download manager itself.

## Testing

Tested manually on an Android device:
- Verified the Download button appears correctly in the main hero section as a secondary action.
- Verified the Download button appears in the episode long-press action sheet with the correct icon.
- Verified that pressing the Download button successfully enqueues the stream via the existing toast notification.
- Verified it correctly respects the user's Autoplay settings (both enabled and disabled).
- Verified the existing "Play" and "Play manually" options still function without regression.

## Screenshots / Video

<img width="921" height="2048" alt="image" src="https://github.com/user-attachments/assets/2fcfdd06-6fcc-498a-82b4-da8de2ef9d10" />
<img width="921" height="2048" alt="image" src="https://github.com/user-attachments/assets/97fdb09d-ddfc-4fba-958d-7d69eaea2ffb" />



## Breaking changes

None.

## Linked issues

Fixes #833 