### PR TITLE
fix(plugin): resolve network deadlock in PluginRuntime

### DIFF
--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRuntime.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRuntime.kt
@@ -1,6 +1,7 @@
 package com.nuvio.app.features.plugins
 
 import co.touchlab.kermit.Logger
+import com.dokar.quickjs.binding.asyncFunction
 import com.dokar.quickjs.binding.define
 import com.dokar.quickjs.binding.function
 import com.dokar.quickjs.quickJs
@@ -10,7 +11,6 @@ import com.fleeksoft.ksoup.nodes.Element
 import com.fleeksoft.ksoup.select.Elements
 import com.nuvio.app.features.addons.httpRequestRaw
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
@@ -76,6 +76,7 @@ internal object PluginRuntime {
         val elementCache = mutableMapOf<String, Element>()
         var idCounter = 0
         var resultJson = "[]"
+        val unknownString = getString(Res.string.generic_unknown)
 
         try {
             quickJs(Dispatchers.IO) {
@@ -102,7 +103,7 @@ internal object PluginRuntime {
                     }
                 }
 
-                function("__native_fetch") { args ->
+                asyncFunction("__native_fetch") { args ->
                     val url = args.getOrNull(0)?.toString() ?: ""
                     val method = args.getOrNull(1)?.toString() ?: "GET"
                     val headersJson = args.getOrNull(2)?.toString() ?: "{}"
@@ -308,14 +309,14 @@ internal object PluginRuntime {
                 evaluate<Any?>(callCode)
             }
 
-            return parseJsonResults(resultJson)
+            return parseJsonResults(resultJson, unknownString)
         } finally {
             documentCache.clear()
             elementCache.clear()
         }
     }
 
-    private fun performNativeFetch(
+    private suspend fun performNativeFetch(
         url: String,
         method: String,
         headersJson: String,
@@ -329,15 +330,13 @@ internal object PluginRuntime {
             }
 
             val startedAt = kotlin.time.TimeSource.Monotonic.markNow()
-            val response = runBlocking(Dispatchers.IO) {
-                httpRequestRaw(
-                    method = method,
-                    url = url,
-                    headers = headers,
-                    body = body,
-                    followRedirects = followRedirects,
-                )
-            }
+            val response = httpRequestRaw(
+                method = method,
+                url = url,
+                headers = headers,
+                body = body,
+                followRedirects = followRedirects,
+            )
             val elapsed = startedAt.elapsedNow()
             if (elapsed.inWholeMilliseconds >= SLOW_PLUGIN_FETCH_MS) {
                 log.w { "Slow plugin fetch $method $url status=${response.status} elapsed=$elapsed" }
@@ -428,7 +427,7 @@ internal object PluginRuntime {
         return value.substring(0, end) + FETCH_TRUNCATION_SUFFIX
     }
 
-    private fun parseJsonResults(rawJson: String): List<PluginRuntimeResult> {
+    private fun parseJsonResults(rawJson: String, unknownString: String): List<PluginRuntimeResult> {
         return runCatching {
             val array = json.parseToJsonElement(rawJson) as? JsonArray ?: return emptyList()
             array.mapNotNull { element ->
@@ -447,7 +446,7 @@ internal object PluginRuntime {
                     ?.takeIf { it.isNotEmpty() }
 
                 PluginRuntimeResult(
-                    title = item.stringOrNull("title") ?: item.stringOrNull("name") ?: runBlocking { getString(Res.string.generic_unknown) },
+                    title = item.stringOrNull("title") ?: item.stringOrNull("name") ?: unknownString,
                     name = item.stringOrNull("name"),
                     url = url,
                     quality = item.stringOrNull("quality"),
@@ -503,7 +502,7 @@ internal object PluginRuntime {
                 var headers = options.headers || {};
                 var body = options.body || '';
                 var followRedirects = options.redirect !== 'manual';
-                var result = __native_fetch(url, method, JSON.stringify(headers), body, followRedirects);
+                var result = await __native_fetch(url, method, JSON.stringify(headers), body, followRedirects);
                 var parsed = JSON.parse(result);
                 return {
                     ok: parsed.ok,


### PR DESCRIPTION
## Summary

Resolves the network deadlock issue inside the QuickJS runtime (`PluginRuntime`). Since the JS engine called the synchronous `__native_fetch` bridge function which invoked `runBlocking(Dispatchers.IO)`, the thread pool became starved/deadlocked when multiple plugins ran concurrently. This PR replaces `runBlocking` with QuickJS's asynchronous `asyncFunction` bridge support, making plugin network requests fully non-blocking.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Commit [41b732b](https://github.com/NuvioMedia/NuvioMobile/commit/41b732bbe53d44970baa80ce2eaac31c0494515d) changed the runtime dispatcher to `Dispatchers.IO` and used `runBlocking(Dispatchers.IO)` inside `__native_fetch`. This blocked all available threads in the `Dispatchers.IO` pool, preventing the Ktor/Java HTTP client (which also schedules work on `Dispatchers.IO`) from executing any requests, freezing the network completely.

## Issue or approval

No linked issue: regression fix for commit [41b732b](https://github.com/NuvioMedia/NuvioMobile/commit/41b732bbe53d44970baa80ce2eaac31c0494515d).

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only modified the JS/Kotlin native fetch bridge inside [PluginRuntime.kt](composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRuntime.kt) to use `asyncFunction`/`await` and removed `runBlocking` usages (including the resource string lookup which was pre-fetched to avoid blocking the parser). No other plugin features or runtime configurations were touched.

## Testing

- Compiled the shared module using Gradle build verification.
- Tested that the asynchronous Kotlin-JS bridge resolves properly using QuickJS's built-in coroutine support.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - Regression fix for commit [41b732b](https://github.com/NuvioMedia/NuvioMobile/commit/41b732bbe53d44970baa80ce2eaac31c0494515d).