### PR TITLE
Fix: Persist renamed addon names across app restart

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
@@ -25,6 +25,7 @@ actual object AddonStorage {
     private const val preferencesName = "nuvio_addons"
     private const val addonUrlsKey = "installed_manifest_urls"
     private const val addonEnabledStatesKey = "installed_manifest_enabled_states"
+    private const val addonNamesKey = "installed_manifest_names"
 
     private var preferences: SharedPreferences? = null
 
@@ -63,6 +64,18 @@ actual object AddonStorage {
         preferences
             ?.edit()
             ?.putString("${addonEnabledStatesKey}_$profileId", payload)
+            ?.apply()
+    }
+
+    actual fun loadAddonNames(profileId: Int): Map<String, String> =
+        AddonNameStorageCodec.decode(
+            preferences?.getString("${addonNamesKey}_$profileId", null),
+        )
+
+    actual fun saveAddonNames(profileId: Int, names: Map<String, String>) {
+        preferences
+            ?.edit()
+            ?.putString("${addonNamesKey}_$profileId", AddonNameStorageCodec.encode(names))
             ?.apply()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonNameStorageCodec.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonNameStorageCodec.kt
@@ -1,0 +1,38 @@
+package com.nuvio.app.features.addons
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+
+internal object AddonNameStorageCodec {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    fun encode(names: Map<String, String>): String {
+        val sanitized = names
+            .filter { (url, name) -> url.isNotBlank() && name.isNotBlank() }
+            .mapValues { (_, name) -> JsonPrimitive(name) }
+        return json.encodeToString(JsonObject.serializer(), JsonObject(sanitized))
+    }
+
+    fun decode(payload: String?): Map<String, String> {
+        if (payload.isNullOrBlank()) return emptyMap()
+        val root = runCatching { json.parseToJsonElement(payload) as? JsonObject }
+            .getOrNull() ?: return emptyMap()
+        return buildMap {
+            root.forEach { (url, element) ->
+                if (url.isBlank()) return@forEach
+                val name = (element as? JsonPrimitive)
+                    ?.takeIf { it.isString }
+                    ?.contentOrNull
+                    ?.takeIf { it.isNotBlank() }
+                    ?: return@forEach
+                put(url, name)
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.kt
@@ -5,6 +5,8 @@ internal expect object AddonStorage {
     fun saveInstalledAddonUrls(profileId: Int, urls: List<String>)
     fun loadAddonEnabledStates(profileId: Int): Map<String, Boolean>
     fun saveAddonEnabledStates(profileId: Int, states: Map<String, Boolean>)
+    fun loadAddonNames(profileId: Int): Map<String, String>
+    fun saveAddonNames(profileId: Int, names: Map<String, String>)
 }
 
 data class RawHttpResponse(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonRepository.kt
@@ -64,6 +64,7 @@ object AddonRepository {
 
         val storedUrls = dedupeManifestUrls(AddonStorage.loadInstalledAddonUrls(currentProfileId))
         val enabledByUrl = loadLocalEnabledStates()
+        val namesByUrl = loadLocalAddonNames()
         log.d { "initialize() — local addon count: ${storedUrls.size}" }
         if (storedUrls.isEmpty()) return
 
@@ -72,6 +73,7 @@ object AddonRepository {
             addons = storedUrls.map { manifestUrl ->
                 existingByUrl[manifestUrl].toPendingAddon(
                     manifestUrl = manifestUrl,
+                    userSetName = namesByUrl[manifestUrl],
                     enabled = enabledByUrl[manifestUrl],
                 )
             },
@@ -136,14 +138,18 @@ object AddonRepository {
                     initialize()
                     pulledFromServer = true
                     val enabledByUrl = loadLocalEnabledStates()
+                    val namesByUrl = loadLocalAddonNames()
                     val addons = localUrls.mapIndexed { index, addonUrl ->
                         val manifestUrl = ensureManifestSuffix(addonUrl)
+                        val inMemory = _uiState.value.addons.find { it.manifestUrl == manifestUrl }
                         AddonPushItem(
                             url = manifestUrl,
-                            name = _uiState.value.addons
-                                .find { it.manifestUrl == manifestUrl }?.manifest?.name ?: "",
+                            name = (inMemory?.userSetName ?: namesByUrl[manifestUrl])
+                                ?.takeIf { it.isNotBlank() }
+                                ?: inMemory?.manifest?.name
+                                ?: "",
                             enabled = enabledByUrl[manifestUrl]
-                                ?: _uiState.value.addons.find { it.manifestUrl == manifestUrl }?.enabled
+                                ?: inMemory?.enabled
                                 ?: true,
                             sortOrder = index,
                         )
@@ -163,11 +169,13 @@ object AddonRepository {
                 if (localUrls.isNotEmpty()) {
                     log.w { "pullFromServer() — remote empty while local has ${localUrls.size} addons; preserving local addons" }
                     val enabledByUrl = loadLocalEnabledStates()
+                    val namesByUrl = loadLocalAddonNames()
                     val existingByUrl = _uiState.value.addons.associateBy(ManagedAddon::manifestUrl)
                     _uiState.value = AddonsUiState(
                         addons = localUrls.map { url ->
                             existingByUrl[url].toPendingAddon(
                                 manifestUrl = url,
+                                userSetName = namesByUrl[url],
                                 enabled = enabledByUrl[url],
                             )
                         },
@@ -432,10 +440,22 @@ object AddonRepository {
             currentProfileId,
             addons.associate { it.manifestUrl to it.enabled },
         )
+        AddonStorage.saveAddonNames(
+            currentProfileId,
+            addons.mapNotNull { addon ->
+                addon.userSetName
+                    ?.takeIf { it.isNotBlank() }
+                    ?.let { addon.manifestUrl to it }
+            }.toMap(),
+        )
     }
 
     private fun loadLocalEnabledStates(): Map<String, Boolean> =
         AddonStorage.loadAddonEnabledStates(currentProfileId)
+            .mapKeys { (url, _) -> ensureManifestSuffix(url) }
+
+    private fun loadLocalAddonNames(): Map<String, String> =
+        AddonStorage.loadAddonNames(currentProfileId)
             .mapKeys { (url, _) -> ensureManifestSuffix(url) }
 
     private fun cancelActiveRefreshes() {

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt
@@ -25,6 +25,7 @@ import platform.Foundation.NSUserDefaults
 actual object AddonStorage {
     private const val addonUrlsKey = "installed_manifest_urls"
     private const val addonEnabledStatesKey = "installed_manifest_enabled_states"
+    private const val addonNamesKey = "installed_manifest_names"
 
     actual fun loadInstalledAddonUrls(profileId: Int): List<String> =
         NSUserDefaults.standardUserDefaults
@@ -57,6 +58,18 @@ actual object AddonStorage {
         NSUserDefaults.standardUserDefaults.setObject(
             payload,
             forKey = "${addonEnabledStatesKey}_$profileId",
+        )
+    }
+
+    actual fun loadAddonNames(profileId: Int): Map<String, String> =
+        AddonNameStorageCodec.decode(
+            NSUserDefaults.standardUserDefaults.stringForKey("${addonNamesKey}_$profileId"),
+        )
+
+    actual fun saveAddonNames(profileId: Int, names: Map<String, String>) {
+        NSUserDefaults.standardUserDefaults.setObject(
+            AddonNameStorageCodec.encode(names),
+            forKey = "${addonNamesKey}_$profileId",
         )
     }
 }


### PR DESCRIPTION
## Summary
Fixed an issue where addon names were not being persisted across app restarts when edited from the website. Addon names now correctly save and restore, so users don't lose their custom naming.

## PR type
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
So edited addon names actually persist.

## Issue or approval
Fixes #1398 

## UI / behavior impact
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
This change is limited to persisting and restoring addon names. It adds local storage of custom names (Android SharedPreferences, iOS NSUserDefaults) via a small JSON codec, restores those names on app startup, and ensures a userset name is preferred over the manifest name when migrating local addons to the server. It does not change addon name validation, the rename UI, or any other addon property

## Testing
I am not able to test.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
Fixes #1398