### PR TITLE
Send resolved intro/outro skip segments to external players

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/ExternalPlayerPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/ExternalPlayerPlatform.android.kt
@@ -93,6 +93,10 @@ internal actual object ExternalPlayerPlatform {
         // Required by MX Player; harmless for other players.
         putExtra("return_result", true)
 
+        // Intro/outro skip segments for players that support auto-skipping.
+        // Players that don't understand this extra simply ignore it.
+        request.skipSegmentsJson?.let { putExtra("skip_segments", it) }
+
         // Headers
         if (request.sourceHeaders.isNotEmpty()) {
             val headerArray = request.sourceHeaders.entries

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.android.kt
@@ -26,6 +26,7 @@ actual object PlayerSettingsStorage {
     private const val touchGesturesEnabledKey = "touch_gestures_enabled"
     private const val externalPlayerEnabledKey = "external_player_enabled"
     private const val externalPlayerForwardSubtitlesKey = "external_player_forward_subtitles"
+    private const val externalPlayerSendSkipSegmentsKey = "external_player_send_skip_segments"
     private const val externalPlayerIdKey = "external_player_id"
     private const val preferredAudioLanguageKey = "preferred_audio_language"
     private const val secondaryPreferredAudioLanguageKey = "secondary_preferred_audio_language"
@@ -93,6 +94,7 @@ actual object PlayerSettingsStorage {
         touchGesturesEnabledKey,
         externalPlayerEnabledKey,
         externalPlayerForwardSubtitlesKey,
+        externalPlayerSendSkipSegmentsKey,
         externalPlayerIdKey,
         preferredAudioLanguageKey,
         secondaryPreferredAudioLanguageKey,
@@ -267,6 +269,23 @@ actual object PlayerSettingsStorage {
         preferences
             ?.edit()
             ?.putBoolean(ProfileScopedKey.of(externalPlayerForwardSubtitlesKey), enabled)
+            ?.apply()
+    }
+
+    actual fun loadExternalPlayerSendSkipSegments(): Boolean? =
+        preferences?.let { sharedPreferences ->
+            val key = ProfileScopedKey.of(externalPlayerSendSkipSegmentsKey)
+            if (sharedPreferences.contains(key)) {
+                sharedPreferences.getBoolean(key, false)
+            } else {
+                null
+            }
+        }
+
+    actual fun saveExternalPlayerSendSkipSegments(enabled: Boolean) {
+        preferences
+            ?.edit()
+            ?.putBoolean(ProfileScopedKey.of(externalPlayerSendSkipSegmentsKey), enabled)
             ?.apply()
     }
 
@@ -1042,6 +1061,7 @@ actual object PlayerSettingsStorage {
         loadTouchGesturesEnabled()?.let { put(touchGesturesEnabledKey, encodeSyncBoolean(it)) }
         loadExternalPlayerEnabled()?.let { put(externalPlayerEnabledKey, encodeSyncBoolean(it)) }
         loadExternalPlayerForwardSubtitles()?.let { put(externalPlayerForwardSubtitlesKey, encodeSyncBoolean(it)) }
+        loadExternalPlayerSendSkipSegments()?.let { put(externalPlayerSendSkipSegmentsKey, encodeSyncBoolean(it)) }
         loadExternalPlayerId()?.let { put(externalPlayerIdKey, encodeSyncString(it)) }
         loadPreferredAudioLanguage()?.let { put(preferredAudioLanguageKey, encodeSyncString(it)) }
         loadSecondaryPreferredAudioLanguage()?.let { put(secondaryPreferredAudioLanguageKey, encodeSyncString(it)) }
@@ -1115,6 +1135,7 @@ actual object PlayerSettingsStorage {
         payload.decodeSyncBoolean(touchGesturesEnabledKey)?.let(::saveTouchGesturesEnabled)
         payload.decodeSyncBoolean(externalPlayerEnabledKey)?.let(::saveExternalPlayerEnabled)
         payload.decodeSyncBoolean(externalPlayerForwardSubtitlesKey)?.let(::saveExternalPlayerForwardSubtitles)
+        payload.decodeSyncBoolean(externalPlayerSendSkipSegmentsKey)?.let(::saveExternalPlayerSendSkipSegments)
         payload.decodeSyncString(externalPlayerIdKey)?.let(::saveExternalPlayerId)
         payload.decodeSyncString(preferredAudioLanguageKey)?.let(::savePreferredAudioLanguage)
         payload.decodeSyncString(secondaryPreferredAudioLanguageKey)?.let(::saveSecondaryPreferredAudioLanguage)

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -855,6 +855,8 @@
     <string name="settings_playback_external_player_description_ios">Open new playback with the selected installed player.</string>
     <string name="settings_playback_external_player_forward_subtitles">Forward Subtitles to External Player</string>
     <string name="settings_playback_external_player_forward_subtitles_description">Fetch addon subtitles in your preferred language and pass them to the external player.</string>
+    <string name="settings_playback_external_player_send_skip_segments">Send Intro and Outro Timestamps</string>
+    <string name="settings_playback_external_player_send_skip_segments_description">Pass resolved intro and outro skip timestamps to the external player for auto-skipping. Only works in players that support it; other players ignore it.</string>
     <string name="settings_playback_external_player_none_available">No supported external players installed</string>
     <string name="settings_playback_player_preference">Player</string>
     <string name="settings_playback_player_preference_internal">Internal</string>
@@ -1317,6 +1319,7 @@
     <string name="streams_fetching">Fetching…</string>
     <string name="streams_finding_source">Finding source…</string>
     <string name="streams_loading_subtitles">Loading subtitles from addons…</string>
+    <string name="streams_loading_skip_segments">Loading skip segments…</string>
     <string name="streams_finding_streams">Finding streams…</string>
     <string name="streams_link_copied">Stream link copied</string>
     <string name="streams_no_direct_link">No direct stream link available</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -1082,14 +1082,18 @@ private fun MainAppContent(
             val baseRequest = launch.toExternalPlayerPlaybackRequest()
             val shouldForwardSubtitles = playerSettingsUiState.externalPlayerForwardSubtitles &&
                 !playerSettingsUiState.preferredSubtitleLanguage.equals(SubtitleLanguageOption.NONE, ignoreCase = true)
+            val shouldSendSkipSegments = playerSettingsUiState.externalPlayerSendSkipSegments
             if (shouldForwardSubtitles) {
                 StreamsRepository.setOverlayVisible(true, getString(Res.string.streams_loading_subtitles))
+            } else if (shouldSendSkipSegments) {
+                StreamsRepository.setOverlayVisible(true, getString(Res.string.streams_loading_skip_segments))
             }
             val enrichedRequest = prepareExternalPlayerLaunch(
                 request = baseRequest,
                 type = launch.contentType ?: launch.parentMetaType,
                 videoId = launch.videoId ?: launch.parentMetaId,
                 forwardSubtitles = playerSettingsUiState.externalPlayerForwardSubtitles,
+                sendSkipSegments = shouldSendSkipSegments,
                 preferredLanguage = playerSettingsUiState.preferredSubtitleLanguage,
                 secondaryLanguage = playerSettingsUiState.secondaryPreferredSubtitleLanguage,
                 onOverlayMessage = { _ -> },

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerLaunchCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerLaunchCoordinator.kt
@@ -2,12 +2,21 @@ package com.nuvio.app.features.player
 
 import com.nuvio.app.features.player.skip.SkipInterval
 import com.nuvio.app.features.player.skip.SkipIntroRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.json.addJsonObject
 import kotlinx.serialization.json.buildJsonArray
 import kotlinx.serialization.json.put
 
 private const val SkipSegmentResolveTimeoutMs = 4_000L
+
+// Skip resolution runs on an app-lifetime scope rather than the caller's (often
+// composition-bound) scope, so navigating to the external player cannot cancel an
+// in-flight network lookup partway through.
+private val skipResolveScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
 /**
  * Orchestrates the full external player launch flow:
@@ -66,23 +75,25 @@ suspend fun prepareExternalPlayerLaunch(
  */
 private suspend fun resolveSkipSegmentsJson(videoId: String, season: Int?, episode: Int?): String? {
     val ep = episode ?: return null
-    val intervals = withTimeoutOrNull(SkipSegmentResolveTimeoutMs) {
-        when {
-            videoId.startsWith("mal:") -> {
-                val malId = videoId.removePrefix("mal:").substringBefore(':')
-                SkipIntroRepository.getSkipIntervalsForMal(malId, ep, requireSkipIntroEnabled = false)
-            }
-            videoId.startsWith("kitsu:") -> {
-                val kitsuId = videoId.removePrefix("kitsu:").substringBefore(':')
-                SkipIntroRepository.getSkipIntervalsForKitsu(kitsuId, ep, requireSkipIntroEnabled = false)
-            }
-            else -> {
-                val imdbId = videoId.substringBefore(':').takeIf { it.startsWith("tt") } ?: return@withTimeoutOrNull null
-                val s = season ?: return@withTimeoutOrNull null
-                SkipIntroRepository.getSkipIntervals(imdbId, s, ep, requireSkipIntroEnabled = false)
+    val intervals = skipResolveScope.async {
+        withTimeoutOrNull(SkipSegmentResolveTimeoutMs) {
+            when {
+                videoId.startsWith("mal:") -> {
+                    val malId = videoId.removePrefix("mal:").substringBefore(':')
+                    SkipIntroRepository.getSkipIntervalsForMal(malId, ep, requireSkipIntroEnabled = false)
+                }
+                videoId.startsWith("kitsu:") -> {
+                    val kitsuId = videoId.removePrefix("kitsu:").substringBefore(':')
+                    SkipIntroRepository.getSkipIntervalsForKitsu(kitsuId, ep, requireSkipIntroEnabled = false)
+                }
+                else -> {
+                    val imdbId = videoId.substringBefore(':').takeIf { it.startsWith("tt") } ?: return@withTimeoutOrNull null
+                    val s = season ?: return@withTimeoutOrNull null
+                    SkipIntroRepository.getSkipIntervals(imdbId, s, ep, requireSkipIntroEnabled = false)
+                }
             }
         }
-    }
+    }.await()
 
     if (intervals.isNullOrEmpty()) return null
     return intervals.toSkipSegmentsJson()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerLaunchCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerLaunchCoordinator.kt
@@ -1,19 +1,32 @@
 package com.nuvio.app.features.player
 
+import com.nuvio.app.features.player.skip.SkipInterval
+import com.nuvio.app.features.player.skip.SkipIntroRepository
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.put
+
+private const val SkipSegmentResolveTimeoutMs = 4_000L
+
 /**
  * Orchestrates the full external player launch flow:
  * fetches subtitles if forwarding is enabled, downloads them to local cache,
- * then returns an enriched request for the caller to dispatch.
+ * resolves intro/outro skip segments if enabled, then returns an enriched
+ * request for the caller to dispatch.
  */
 suspend fun prepareExternalPlayerLaunch(
     request: ExternalPlayerPlaybackRequest,
     type: String,
     videoId: String,
     forwardSubtitles: Boolean,
+    sendSkipSegments: Boolean,
     preferredLanguage: String,
     secondaryLanguage: String?,
     onOverlayMessage: (String?) -> Unit,
 ): ExternalPlayerPlaybackRequest {
+    var result = request
+
     if (forwardSubtitles && !preferredLanguage.equals(SubtitleLanguageOption.NONE, ignoreCase = true)) {
         onOverlayMessage("Loading subtitles from addons...")
 
@@ -27,13 +40,61 @@ suspend fun prepareExternalPlayerLaunch(
         if (subtitles != null) {
             onOverlayMessage("Downloading subtitles...")
             val cachedSubtitles = SubtitleCacheProvider.cacheForExternalPlayer(subtitles)
-            if (cachedSubtitles != null) {
-                return request.copy(subtitles = cachedSubtitles)
-            }
             // Fallback: use original URLs if caching fails
-            return request.copy(subtitles = subtitles)
+            result = result.copy(subtitles = cachedSubtitles ?: subtitles)
         }
     }
 
-    return request
+    if (sendSkipSegments) {
+        val skipSegmentsJson = resolveSkipSegmentsJson(videoId, request.season, request.episode)
+        if (skipSegmentsJson != null) {
+            result = result.copy(skipSegmentsJson = skipSegmentsJson)
+        }
+    }
+
+    return result
 }
+
+/**
+ * Resolves intro/outro skip segments for the given content and serializes them to the
+ * JSON contract understood by supporting external players: a JSON array of objects with
+ * `type` (String), `start` (seconds) and `end` (seconds). Returns null if nothing resolved.
+ *
+ * Bounded by a timeout so a slow provider never delays the player launch. Resolution is
+ * intentionally independent of the in-app skip-intro toggle (requireSkipIntroEnabled = false):
+ * this is its own opt-in setting.
+ */
+private suspend fun resolveSkipSegmentsJson(videoId: String, season: Int?, episode: Int?): String? {
+    val ep = episode ?: return null
+    val intervals = withTimeoutOrNull(SkipSegmentResolveTimeoutMs) {
+        when {
+            videoId.startsWith("mal:") -> {
+                val malId = videoId.removePrefix("mal:").substringBefore(':')
+                SkipIntroRepository.getSkipIntervalsForMal(malId, ep, requireSkipIntroEnabled = false)
+            }
+            videoId.startsWith("kitsu:") -> {
+                val kitsuId = videoId.removePrefix("kitsu:").substringBefore(':')
+                SkipIntroRepository.getSkipIntervalsForKitsu(kitsuId, ep, requireSkipIntroEnabled = false)
+            }
+            else -> {
+                val imdbId = videoId.substringBefore(':').takeIf { it.startsWith("tt") } ?: return@withTimeoutOrNull null
+                val s = season ?: return@withTimeoutOrNull null
+                SkipIntroRepository.getSkipIntervals(imdbId, s, ep, requireSkipIntroEnabled = false)
+            }
+        }
+    }
+
+    if (intervals.isNullOrEmpty()) return null
+    return intervals.toSkipSegmentsJson()
+}
+
+private fun List<SkipInterval>.toSkipSegmentsJson(): String =
+    buildJsonArray {
+        forEach { interval ->
+            addJsonObject {
+                put("type", interval.type)
+                put("start", interval.startTime)
+                put("end", interval.endTime)
+            }
+        }
+    }.toString()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerPlatform.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerPlatform.kt
@@ -21,6 +21,8 @@ data class ExternalPlayerPlaybackRequest(
     val season: Int? = null,
     val episode: Int? = null,
     val episodeTitle: String? = null,
+    // JSON array of intro/outro skip segments, passed to players that support auto-skipping.
+    val skipSegmentsJson: String? = null,
 ) {
     /**
      * Builds a display title for external players.

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsRepository.kt
@@ -39,6 +39,7 @@ data class PlayerSettingsUiState(
     val touchGesturesEnabled: Boolean = true,
     val externalPlayerEnabled: Boolean = false,
     val externalPlayerForwardSubtitles: Boolean = false,
+    val externalPlayerSendSkipSegments: Boolean = false,
     val externalPlayerId: String? = ExternalPlayerPlatform.defaultPlayerId(),
     val preferredAudioLanguage: String = AudioLanguageOption.DEVICE,
     val secondaryPreferredAudioLanguage: String? = null,
@@ -103,6 +104,7 @@ object PlayerSettingsRepository {
     private var touchGesturesEnabled = true
     private var externalPlayerEnabled = false
     private var externalPlayerForwardSubtitles = false
+    private var externalPlayerSendSkipSegments = false
     private var externalPlayerId: String? = ExternalPlayerPlatform.defaultPlayerId()
     private var preferredAudioLanguage = AudioLanguageOption.DEVICE
     private var secondaryPreferredAudioLanguage: String? = null
@@ -172,6 +174,7 @@ object PlayerSettingsRepository {
         touchGesturesEnabled = true
         externalPlayerEnabled = false
         externalPlayerForwardSubtitles = false
+        externalPlayerSendSkipSegments = false
         externalPlayerId = ExternalPlayerPlatform.defaultPlayerId()
         preferredAudioLanguage = AudioLanguageOption.DEVICE
         secondaryPreferredAudioLanguage = null
@@ -236,6 +239,7 @@ object PlayerSettingsRepository {
         touchGesturesEnabled = PlayerSettingsStorage.loadTouchGesturesEnabled() ?: true
         externalPlayerEnabled = PlayerSettingsStorage.loadExternalPlayerEnabled() ?: false
         externalPlayerForwardSubtitles = PlayerSettingsStorage.loadExternalPlayerForwardSubtitles() ?: false
+        externalPlayerSendSkipSegments = PlayerSettingsStorage.loadExternalPlayerSendSkipSegments() ?: false
         externalPlayerId = PlayerSettingsStorage.loadExternalPlayerId()
             ?: ExternalPlayerPlatform.defaultPlayerId()
         preferredAudioLanguage =
@@ -430,6 +434,14 @@ object PlayerSettingsRepository {
         externalPlayerForwardSubtitles = enabled
         publish()
         PlayerSettingsStorage.saveExternalPlayerForwardSubtitles(enabled)
+    }
+
+    fun setExternalPlayerSendSkipSegments(enabled: Boolean) {
+        ensureLoaded()
+        if (externalPlayerSendSkipSegments == enabled) return
+        externalPlayerSendSkipSegments = enabled
+        publish()
+        PlayerSettingsStorage.saveExternalPlayerSendSkipSegments(enabled)
     }
 
     fun setPreferredAudioLanguage(language: String) {
@@ -893,6 +905,7 @@ object PlayerSettingsRepository {
             touchGesturesEnabled = touchGesturesEnabled,
             externalPlayerEnabled = externalPlayerEnabled,
             externalPlayerForwardSubtitles = externalPlayerForwardSubtitles,
+            externalPlayerSendSkipSegments = externalPlayerSendSkipSegments,
             externalPlayerId = externalPlayerId,
             preferredAudioLanguage = preferredAudioLanguage,
             secondaryPreferredAudioLanguage = secondaryPreferredAudioLanguage,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.kt
@@ -17,6 +17,8 @@ internal expect object PlayerSettingsStorage {
     fun saveExternalPlayerEnabled(enabled: Boolean)
     fun loadExternalPlayerForwardSubtitles(): Boolean?
     fun saveExternalPlayerForwardSubtitles(enabled: Boolean)
+    fun loadExternalPlayerSendSkipSegments(): Boolean?
+    fun saveExternalPlayerSendSkipSegments(enabled: Boolean)
     fun loadExternalPlayerId(): String?
     fun saveExternalPlayerId(playerId: String?)
     fun loadPreferredAudioLanguage(): String?

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipIntroRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipIntroRepository.kt
@@ -12,10 +12,15 @@ object SkipIntroRepository {
     private val introDbConfigured: Boolean
         get() = IntroDbConfig.URL.isNotBlank()
 
-    suspend fun getSkipIntervals(imdbId: String?, season: Int, episode: Int): List<SkipInterval> {
+    suspend fun getSkipIntervals(
+        imdbId: String?,
+        season: Int,
+        episode: Int,
+        requireSkipIntroEnabled: Boolean = true,
+    ): List<SkipInterval> {
         if (imdbId == null) return emptyList()
         val settings = PlayerSettingsRepository.uiState.value
-        if (!settings.skipIntroEnabled) return emptyList()
+        if (requireSkipIntroEnabled && !settings.skipIntroEnabled) return emptyList()
 
         val cacheKey = "$imdbId:$season:$episode"
         cache[cacheKey]?.let { return it }
@@ -46,9 +51,13 @@ object SkipIntroRepository {
         return emptyList<SkipInterval>().also { cache[cacheKey] = it }
     }
 
-    suspend fun getSkipIntervalsForMal(malId: String, episode: Int): List<SkipInterval> {
+    suspend fun getSkipIntervalsForMal(
+        malId: String,
+        episode: Int,
+        requireSkipIntroEnabled: Boolean = true,
+    ): List<SkipInterval> {
         val settings = PlayerSettingsRepository.uiState.value
-        if (!settings.skipIntroEnabled) return emptyList()
+        if (requireSkipIntroEnabled && !settings.skipIntroEnabled) return emptyList()
 
         val cacheKey = "mal:$malId:$episode"
         cache[cacheKey]?.let { return it }
@@ -90,9 +99,13 @@ object SkipIntroRepository {
         return emptyList<SkipInterval>().also { cache[cacheKey] = it }
     }
 
-    suspend fun getSkipIntervalsForKitsu(kitsuId: String, episode: Int): List<SkipInterval> {
+    suspend fun getSkipIntervalsForKitsu(
+        kitsuId: String,
+        episode: Int,
+        requireSkipIntroEnabled: Boolean = true,
+    ): List<SkipInterval> {
         val settings = PlayerSettingsRepository.uiState.value
-        if (!settings.skipIntroEnabled) return emptyList()
+        if (requireSkipIntroEnabled && !settings.skipIntroEnabled) return emptyList()
 
         val cacheKey = "kitsu:$kitsuId:$episode"
         cache[cacheKey]?.let { return it }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/PlaybackSettingsPage.kt
@@ -368,6 +368,14 @@ private fun PlaybackSettingsSection(
                         isTablet = isTablet,
                         onCheckedChange = PlayerSettingsRepository::setExternalPlayerForwardSubtitles,
                     )
+                    SettingsGroupDivider(isTablet = isTablet)
+                    SettingsSwitchRow(
+                        title = stringResource(Res.string.settings_playback_external_player_send_skip_segments),
+                        description = stringResource(Res.string.settings_playback_external_player_send_skip_segments_description),
+                        checked = autoPlayPlayerSettings.externalPlayerSendSkipSegments,
+                        isTablet = isTablet,
+                        onCheckedChange = PlayerSettingsRepository::setExternalPlayerSendSkipSegments,
+                    )
                 }
                 SettingsGroupDivider(isTablet = isTablet)
                 SettingsSwitchRow(

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerSettingsStorage.ios.kt
@@ -24,6 +24,7 @@ actual object PlayerSettingsStorage {
     private const val touchGesturesEnabledKey = "touch_gestures_enabled"
     private const val externalPlayerEnabledKey = "external_player_enabled"
     private const val externalPlayerForwardSubtitlesKey = "external_player_forward_subtitles"
+    private const val externalPlayerSendSkipSegmentsKey = "external_player_send_skip_segments"
     private const val externalPlayerIdKey = "external_player_id"
     private const val preferredAudioLanguageKey = "preferred_audio_language"
     private const val secondaryPreferredAudioLanguageKey = "secondary_preferred_audio_language"
@@ -91,6 +92,7 @@ actual object PlayerSettingsStorage {
         touchGesturesEnabledKey,
         externalPlayerEnabledKey,
         externalPlayerForwardSubtitlesKey,
+        externalPlayerSendSkipSegmentsKey,
         externalPlayerIdKey,
         preferredAudioLanguageKey,
         secondaryPreferredAudioLanguageKey,
@@ -254,6 +256,20 @@ actual object PlayerSettingsStorage {
 
     actual fun saveExternalPlayerForwardSubtitles(enabled: Boolean) {
         NSUserDefaults.standardUserDefaults.setBool(enabled, forKey = ProfileScopedKey.of(externalPlayerForwardSubtitlesKey))
+    }
+
+    actual fun loadExternalPlayerSendSkipSegments(): Boolean? {
+        val defaults = NSUserDefaults.standardUserDefaults
+        val key = ProfileScopedKey.of(externalPlayerSendSkipSegmentsKey)
+        return if (defaults.objectForKey(key) != null) {
+            defaults.boolForKey(key)
+        } else {
+            null
+        }
+    }
+
+    actual fun saveExternalPlayerSendSkipSegments(enabled: Boolean) {
+        NSUserDefaults.standardUserDefaults.setBool(enabled, forKey = ProfileScopedKey.of(externalPlayerSendSkipSegmentsKey))
     }
 
     actual fun loadExternalPlayerId(): String? {


### PR DESCRIPTION
## Summary

Adds an **opt-in** External Player setting that hands the resolved intro/outro skip timestamps to external players, so a supporting player can auto-skip the opening and ending the same way the internal player already does. This is the NuvioMobile counterpart to the NuvioTV change in NuvioMedia/NuvioTV#2435.

When **External Player** is selected and the new **"Send Intro and Outro Timestamps"** toggle is on, the external launch intent carries a `skip_segments` JSON extra. Nuvio resolves the segments with the **existing `SkipIntroRepository`** (IntroDB, ARM, AniSkip, Anime-Skip), the same one the internal player uses, so there is **no new API, key, provider, or dependency**. Players that do not read the extra simply ignore it.

- Off by default. The toggle sits in the External Player section, directly under "Forward Subtitles to External Player", and only shows for Android external playback.
- Resolution reuses the existing providers, runs on an app-lifetime scope (so navigating into the external player cannot cancel an in-flight lookup), is bounded by a 4s timeout, and is cached.
- Resume, watched-marking, and auto-play-next are untouched: the launch/result path is unchanged and resolution is gated behind the new off-by-default setting.

### Implementing this in another external player

The contract is a single intent extra and is trivial to adopt.

**Extra:** `skip_segments`, a `String` (`intent.getStringExtra("skip_segments")`).

**Value:** a JSON array of segment objects, with times in **seconds**:

```json
[
  { "type": "op", "start": 84.5,   "end": 174.5  },
  { "type": "ed", "start": 1320.0, "end": 1410.0 }
]
```

**`type`** is one of: `intro`, `op`, `mixed-op`, `recap`, `outro`, `ed`, `mixed-ed`, `credits`, `ending`. Unknown types can be treated as a generic skippable segment.

**How a player uses it:**
1. On launch, read and parse the extra. It is absent or empty when the user has not enabled the feature or no data was found, so just ignore that case.
2. On each playback position tick, if the current time is within `[start, end)`, either auto-seek to `end` or show a "Skip" button that seeks to `end`.

No SDK, no callback, no auth. Reference implementation: mpvNova reads this extra and auto-skips.

## PR type

- [x] Approved larger or directional change

## Why

Nuvio already resolves intro/outro segments and auto-skips them in the internal player, but external-player users get none of it. This forwards the already-resolved timestamps so a supporting external player can offer the same skip experience, with zero extra API work (it reuses the internal resolution). Same feature, now on mobile, matching NuvioMedia/NuvioTV#2435.

## Issue or approval

Maintainer-approved by @tapframe and @skoruppa (parity with the approved NuvioTV change in NuvioMedia/NuvioTV#2435).

## UI / behavior impact

- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

Adds one opt-in toggle in the External Player settings and, when enabled, attaches the `skip_segments` extra to the external launch intent.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Adds the `externalPlayerSendSkipSegments` setting (UI-state field, storage key with load/save plus sync on Android and iOS, repository setter), segment resolution in the external launch coordinator, and a `skip_segments` intent extra in the Android external-player launch path.
- Reuses the existing `SkipIntroRepository`; no new networking, API keys, or providers.
- Does not touch internal-player skip, the external result/tracking path (resume, watched, auto-next), or any unrelated screen.
- Off by default.

## Testing

- `:composeApp:compileAndroidMain` clean; built and installed `:androidApp:assemblePlaystoreDebug` to an NVIDIA Shield with mpvNova as the external player.
- IMDb title (Family Guy S07E01) via IntroDB: intro skipped.
- Anime via AniSkip: OP and ED skipped.
- With the setting OFF: no `skip_segments` sent, and resume, watched-marking, and auto-play-next behave exactly as before.

## Screenshots / Video (UI changes only)

The new "Send Intro and Outro Timestamps" toggle, directly under "Forward Subtitles to External Player" in the External Player settings (Android external playback only):

![Send Intro and Outro Timestamps toggle](https://github.com/user-attachments/assets/9b842153-8efd-4a4f-8a57-b7bf85e3000f)

Demo (mobile to external player, intro/outro auto-skipped):

https://github.com/user-attachments/assets/6c55d991-3789-46e3-bc05-393e8b99735f

## Breaking changes

None.

## Linked issues

Maintainer-approved directional change; parity with NuvioMedia/NuvioTV#2435.


