### PR TITLE
Fix debrid device-auth giving up on transient poll errors (#1409)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/DebridSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/DebridSettingsPage.kt
@@ -72,6 +72,8 @@ import com.nuvio.app.features.debrid.DebridStreamSortCriterion
 import com.nuvio.app.features.debrid.DebridStreamSortDirection
 import com.nuvio.app.features.debrid.DebridStreamSortKey
 import com.nuvio.app.features.debrid.DebridStreamVisualTag
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TimeSource
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.delay
@@ -209,6 +211,11 @@ import org.jetbrains.compose.resources.stringResource
 import kotlinx.coroutines.runBlocking
 
 private const val CLOUD_SERVICES_FAQ_URL = "https://nuvioapp.space/faq#common-cloud-library-and-cloud-services"
+
+// Upper bound for device-authorization polling when every redeem keeps throwing. Device codes
+// expire server-side within minutes (TorBox/Premiumize), so this is comfortably beyond any code's
+// lifetime — it only exists to stop an indefinitely-offline dialog from polling forever.
+private val DEVICE_AUTH_MAX_POLL_DURATION = 15.minutes
 
 internal fun LazyListScope.debridSettingsContent(
     isTablet: Boolean,
@@ -1499,6 +1506,10 @@ private fun DebridDeviceAuthDialog(
     LaunchedEffect(session?.deviceCode, restartNonce, isConnected) {
         if (isConnected) return@LaunchedEffect
         val activeSession = session ?: return@LaunchedEffect
+        // Watchdog for the throwing path below: device codes expire server-side within minutes,
+        // so if every redeem keeps throwing past this deadline the failure is persistent (e.g.
+        // airplane mode / captive portal), not a brief background-network blip — give up then.
+        val pollDeadline = TimeSource.Monotonic.markNow() + DEVICE_AUTH_MAX_POLL_DURATION
         while (true) {
             delay(activeSession.intervalSeconds.coerceAtLeast(1) * 1_000L)
             isPolling = true
@@ -1508,10 +1519,18 @@ private fun DebridDeviceAuthDialog(
                     ?: DebridDeviceAuthorizationTokenResult.Unsupported
             }.getOrElse { error ->
                 if (error is CancellationException) throw error
-                if (error.isCancelledHttpRequest()) {
-                    DebridDeviceAuthorizationTokenResult.Pending
-                } else {
+                // A throwing redeem is almost always transient connectivity loss rather than a
+                // fatal error: aggressive ROMs (OxygenOS/MIUI/etc.) sever the backgrounded app's
+                // sockets + DNS while the user approves in the browser, so the in-flight poll
+                // throws UnknownHostException/IOException. Keep polling instead of terminating —
+                // terminating here on a transient error is what caused "Could not start sign-in"
+                // on OnePlus devices (issue #1409). A response-bearing expiry still surfaces via
+                // the Expired branch once requests reach the server; the pollDeadline watchdog
+                // bounds the loop when the failure is persistent and no response ever arrives.
+                if (pollDeadline.hasPassedNow()) {
                     DebridDeviceAuthorizationTokenResult.Failed(null)
+                } else {
+                    DebridDeviceAuthorizationTokenResult.Pending
                 }
             }
             isPolling = false
@@ -1698,14 +1717,6 @@ private fun savePendingDeviceAuthorization(session: DebridDeviceAuthorization) {
 
 private fun clearPendingDeviceAuthorization(providerId: String) {
     DebridSettingsStorage.clearPendingDeviceAuthorization(providerId)
-}
-
-private fun Throwable.isCancelledHttpRequest(): Boolean {
-    val text = listOfNotNull(message, toString())
-        .joinToString(" ")
-        .lowercase()
-    return "code=-999" in text ||
-        ("nsurlerrordomain" in text && ("cancelled" in text || "canceled" in text))
 }
 
 private fun String?.toDeviceAuthStatusMessage(fallback: String): String {


### PR DESCRIPTION
## Summary

Fixes #1409. Debrid device-authorization login (TorBox / Premiumize) fails with **"Could not start sign-in"** on OnePlus devices even though the browser confirms approval.

## Root cause

The login is a device-auth **polling** flow: after `device/start` the app polls `device/token` every ~5s until the token is granted. The poll loop treated *any* thrown redeem request as fatal — it called `Failed(null)` and `return@LaunchedEffect`, permanently stopping the poll. The only thrown error it tolerated was **iOS** request cancellation:

```kotlin
private fun Throwable.isCancelledHttpRequest(): Boolean {
    ...
    return "code=-999" in text ||
        ("nsurlerrordomain" in text && ("cancelled" in text || "canceled" in text))
}
```

On Android that always returns `false`, so a thrown poll terminates the flow.

The trigger is ROM-level background-network management. Debugged on a OnePlus 13 (OxygenOS, Android 16) with `adb logcat` — during the window where the user is in the browser approving the code (app backgrounded):

```
Chrome opens torbox.app/oauth/device                                  ← app backgrounded
InetDiagMessage: Destroyed live tcp sockets for uids={10716}          ← OxygenOS kills the app's sockets
DnsDomainBlock onDnsEvent: returnCode=4, uid=10716                    ← DNS fails while backgrounded
DnsDomainBlock onDnsEvent: returnCode=4, uid=10716
(return to app)  onDnsEvent: returnCode=0                             ← DNS only works in foreground
```

The in-flight poll throws `UnknownHostException`/`IOException`, which on Android is treated as fatal → the loop dies → by the time the user returns, TorBox has approved them but the app already gave up. This is why it's device-specific (reported by two OnePlus 13 users in #1409); ROMs that don't sever background sockets that aggressively survive the round trip to the browser.

The API contract itself is fine — verified live that `device/start`, the pending response, and the approved success response all behave and parse exactly as expected.

## Fix

Treat a thrown redeem as **transient → `Pending`** and keep polling, instead of failing. The device code has a server-side expiry already handled by the `Expired` branch, so the loop stays bounded. The next poll after the user returns to the foreground succeeds and completes the login.

This also makes the iOS-only `isCancelledHttpRequest()` helper redundant (its `Pending` case is now the default), so it's removed.

```kotlin
}.getOrElse { error ->
    if (error is CancellationException) throw error
    // transient connectivity loss (backgrounded sockets/DNS cut) → keep polling
    DebridDeviceAuthorizationTokenResult.Pending
}
```

Net diff: 8 insertions, 13 deletions in `DebridSettingsPage.kt`.

## Testing

- Confirmed on OnePlus 13 / Android 16 that setting the app's battery mode to **Allow background activity** (which stops the socket/DNS cut) lets the *current* build complete auth — confirming the diagnosis. This PR makes the default battery mode work without that change.
- `redeemDeviceAuthorization` mapping is unchanged; existing `TorboxDeviceAuthTest` cases (pending / authorized / expired) still hold.
