### PR TITLE
fix: fixed the Trakt custom list which does not sort by recently added

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktLibraryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktLibraryRepository.kt
@@ -573,10 +573,7 @@ object TraktLibraryRepository {
 
         return (movieItems + showItems)
             .mapNotNull(::mapToLibraryItem)
-            .sortedWith(
-                compareBy<LibraryItem> { it.traktRank ?: Int.MAX_VALUE }
-                    .thenByDescending { it.savedAtEpochMs },
-            )
+            .sortedByDescending { it.savedAtEpochMs }
     }
 
     private suspend fun fetchPagedListItems(


### PR DESCRIPTION
## Summary
Fixed Trakt custom lists in the Library tab sorting in a seemingly random order instead of by recently added. Updated `TraktLibraryRepository.fetchPersonalListItems` to sort items by `savedAtEpochMs` (derived from Trakt's `listed_at` field) descending, matching the existing sort behavior already used for the Watchlist tab.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Custom Trakt lists in the Library tab were sorted primarily by `traktRank`, with date-added used only as a tiebreaker. `traktRank` reflects Trakt's manual list ordering, which is often unset or unrelated to when an item was added, so the grid appeared randomly arranged instead of showing the most recently added items first.

## Issue or approval

Fixes #1346 

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->
Only the sort logic in `fetchPersonalListItems` was changed. No changes to the Watchlist sort logic (already correct), no UI/layout changes, no changes to API request params (`sort_by`/`sort_how` query still sent to Trakt as before), and no unrelated cleanup.

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is docs/translation-only. -->
- Code review/static verification: confirmed `savedAtEpochMs` is populated from Trakt's `listed_at` field in `mapToLibraryItem`, with fallback to current time only when missing.
- Tested on virtual emulator.
- Tested on physical device (Samsung S series device)
- All items sort by recently added as it should be (like default watchlist) 

## Screenshots / Video 

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->
Not a UI change

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None.

## Linked issues

Fixes #1346 

