### PR TITLE
fix: Fixed Continue Watching card bottom edge clipped on Home screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PlatformInsets.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PlatformInsets.kt
@@ -15,12 +15,32 @@ internal expect fun nuvioBottomNavigationBarInsets(): WindowInsets
 
 internal val LocalNuvioBottomNavigationOverlayPadding = staticCompositionLocalOf { 0.dp }
 
+// Content height of NuvioNavigationBar's Row (icon + its own padding), excluding the
+// hairline divider and any system inset padding, which are added on top of this.
+private val NuvioNavigationBarContentHeight: Dp = NuvioTokens.Icon.xl + (NuvioTokens.Space.s10 * 2)
+
 @Composable
 internal fun nuvioSafeBottomPadding(extra: Dp = 0.dp): Dp {
-	val navigationBarBottom = nuvioBottomNavigationBarInsets()
-		.asPaddingValues()
-		.calculateBottomPadding()
-	return navigationBarBottom.coerceAtLeast(nuvioPlatformExtraBottomPadding) +
-		LocalNuvioBottomNavigationOverlayPadding.current +
-		extra
+    val navigationBarBottom = nuvioBottomNavigationBarInsets()
+        .asPaddingValues()
+        .calculateBottomPadding()
+    return navigationBarBottom.coerceAtLeast(nuvioPlatformExtraBottomPadding) +
+            LocalNuvioBottomNavigationOverlayPadding.current +
+            extra
+}
+
+// Full rendered height of the standard (non-native-tabs) floating bottom NuvioNavigationBar,
+// including the hairline divider, the row's own vertical padding, and the system navigation
+// bar inset it draws underneath itself. Used by screens that render content behind the bar
+// (edge-to-edge) and need to reserve real clearance above it, since that bar is not placed
+// via Scaffold's innerPadding consumption in every layout path.
+@Composable
+internal fun nuvioStandardBottomNavigationBarHeight(): Dp {
+    val systemInsetBottom = nuvioBottomNavigationBarInsets()
+        .asPaddingValues()
+        .calculateBottomPadding()
+    return NuvioTokens.Border.hairline +
+            NuvioNavigationBarContentHeight +
+            (nuvioBottomNavigationExtraVerticalPadding * 2) +
+            systemInsetBottom
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -20,6 +20,7 @@ import com.nuvio.app.core.ui.LocalNuvioBottomNavigationOverlayPadding
 import com.nuvio.app.core.ui.NuvioScreen
 import com.nuvio.app.core.ui.NuvioNetworkOfflineCard
 import com.nuvio.app.core.ui.nuvioSafeBottomPadding
+import com.nuvio.app.core.ui.nuvioStandardBottomNavigationBarHeight
 import com.nuvio.app.core.ui.rememberPosterCardStyleUiState
 import com.nuvio.app.features.addons.AddonRepository
 import com.nuvio.app.features.addons.enabledAddons
@@ -145,7 +146,7 @@ fun HomeScreen(
         when (networkStatusUiState.condition) {
             NetworkCondition.NoInternet,
             NetworkCondition.ServersUnreachable,
-            -> {
+                -> {
                 observedOfflineState = true
             }
 
@@ -158,7 +159,7 @@ fun HomeScreen(
 
             NetworkCondition.Unknown,
             NetworkCondition.Checking,
-            -> Unit
+                -> Unit
         }
     }
 
@@ -551,9 +552,9 @@ fun HomeScreen(
                     withContext(Dispatchers.Main) {
                         nextUpItemsBySeries = progressiveResults
                         processedNextUpContentIds = (
-                            cachedResolvedNextUpItems.keys +
-                                processedFreshContentIds
-                            ).toSet()
+                                cachedResolvedNextUpItems.keys +
+                                        processedFreshContentIds
+                                ).toSet()
                     }
                 }
 
@@ -566,9 +567,9 @@ fun HomeScreen(
             withContext(Dispatchers.Main) {
                 nextUpItemsBySeries = results
                 processedNextUpContentIds = (
-                    cachedResolvedNextUpItems.keys +
-                        processedFreshContentIds
-                    ).toSet()
+                        cachedResolvedNextUpItems.keys +
+                                processedFreshContentIds
+                        ).toSet()
             }
 
             saveContinueWatchingSnapshots(
@@ -618,9 +619,9 @@ fun HomeScreen(
                     withContext(Dispatchers.Main) {
                         nextUpItemsBySeries = progressiveResults
                         processedNextUpContentIds = (
-                            cachedResolvedNextUpItems.keys +
-                                processedFreshContentIds
-                            ).toSet()
+                                cachedResolvedNextUpItems.keys +
+                                        processedFreshContentIds
+                                ).toSet()
                     }
                     saveContinueWatchingSnapshots(
                         profileId = activeProfileId,
@@ -639,8 +640,8 @@ fun HomeScreen(
     val showHeroSlot = homeSettingsUiState.heroEnabled
     val isResolvingHeroSources = enabledAddons.any { it.isRefreshing } || homeUiState.isLoading
     val showHeroSkeleton = showHeroSlot &&
-        homeUiState.heroItems.isEmpty() &&
-        isResolvingHeroSources
+            homeUiState.heroItems.isEmpty() &&
+            isResolvingHeroSources
     var firstCatalogReported by remember { mutableStateOf(false) }
 
     LaunchedEffect(homeUiState.sections.firstOrNull()?.key, onFirstCatalogRendered) {
@@ -674,11 +675,17 @@ fun HomeScreen(
         val continueWatchingCardHeight = remember(posterCardStyle.widthDp) {
             continueWatchingLandscapeCardHeight(posterCardStyle.widthDp)
         }
+        val standardBottomNavigationBarHeight = nuvioStandardBottomNavigationBarHeight()
         val nativeBottomNavigationOverlayHeight =
             if (LocalNuvioBottomNavigationOverlayPadding.current > 0.dp) {
+                // Native (e.g. iOS Liquid Glass) tab bar overlay: its height is reported via
+                // nuvioSafeBottomPadding/LocalNuvioBottomNavigationOverlayPadding.
                 nuvioSafeBottomPadding()
             } else {
-                0.dp
+                // Standard floating NuvioNavigationBar (Android, and iOS when native tabs are
+                // unavailable/disabled): reserve its real rendered height so the hero doesn't
+                // size the Continue Watching row so tall that the bar clips its bottom edge.
+                standardBottomNavigationBarHeight
             }
         val mobileHeroBelowSectionHeightHint = remember(
             maxWidth.value,
@@ -784,8 +791,8 @@ fun HomeScreen(
                 }
 
                 homeUiState.sections.isEmpty() && homeUiState.heroItems.isEmpty() &&
-                    (!continueWatchingPreferences.isVisible || continueWatchingItems.isEmpty()) &&
-                    !hasRenderableCollectionRows -> {
+                        (!continueWatchingPreferences.isVisible || continueWatchingItems.isEmpty()) &&
+                        !hasRenderableCollectionRows -> {
                     item {
                         if (networkStatusUiState.isOfflineLike) {
                             NuvioNetworkOfflineCard(
@@ -938,10 +945,10 @@ internal fun buildHomeNextUpSeedCandidates(
         .toList()
     val watchedSeeds = watchedItems.filter { item ->
         item.type.isSeriesTypeForContinueWatching() &&
-            item.season != null &&
-            item.episode != null &&
-            item.season != 0 &&
-            !isMalformedNextUpSeedContentId(item.id)
+                item.season != null &&
+                item.episode != null &&
+                item.season != 0 &&
+                !isMalformedNextUpSeedContentId(item.id)
     }
 
     return WatchingState.latestCompletedBySeries(
@@ -978,7 +985,7 @@ internal fun filterNextUpItemsByCurrentSeeds(
         val item = pair.second
         val currentSeed = currentSeedByContentId[contentId] ?: return@filter true
         item.nextUpSeedSeasonNumber == currentSeed.first &&
-            item.nextUpSeedEpisodeNumber == currentSeed.second
+                item.nextUpSeedEpisodeNumber == currentSeed.second
     }
 
 private suspend fun resolveHomeNextUpCandidate(
@@ -1045,7 +1052,7 @@ private fun MetaDetails.videoForSeriesAction(action: SeriesPrimaryAction): MetaV
     if (action.seasonNumber != null && action.episodeNumber != null) {
         videos.firstOrNull { video ->
             video.season == action.seasonNumber &&
-                video.episode == action.episodeNumber
+                    video.episode == action.episodeNumber
         }?.let { return it }
     }
     return videos.firstOrNull { video ->
@@ -1090,10 +1097,10 @@ private fun heroMobileBelowSectionHeightHint(
     if (maxWidthDp >= 600f || !continueWatchingVisible || !hasContinueWatchingItems) return null
 
     val sectionHeight = when (continueWatchingStyle) {
-        ContinueWatchingSectionStyle.Card -> continueWatchingCardHeight + 56.dp
-        ContinueWatchingSectionStyle.Wide -> continueWatchingLayout.wideCardHeight + 56.dp
+        ContinueWatchingSectionStyle.Card -> continueWatchingCardHeight
+        ContinueWatchingSectionStyle.Wide -> continueWatchingLayout.wideCardHeight
         ContinueWatchingSectionStyle.Poster ->
-            continueWatchingLayout.posterCardHeight + continueWatchingLayout.posterTitleBlockHeight + 70.dp
+            continueWatchingLayout.posterCardHeight + continueWatchingLayout.posterTitleBlockHeight
     }
     return sectionHeight + bottomNavigationOverlayHeight
 }
@@ -1420,7 +1427,7 @@ private fun ContinueWatchingItem.hasPlaceholderCloudTitle(): Boolean {
     if (!isCloudLibraryContinueWatchingItem()) return false
     val normalizedTitle = title.trim()
     return normalizedTitle.equals(parentMetaId, ignoreCase = true) ||
-        normalizedTitle.equals(videoId, ignoreCase = true)
+            normalizedTitle.equals(videoId, ignoreCase = true)
 }
 
 private fun ContinueWatchingItem.isCloudLibraryContinueWatchingItem(): Boolean =
@@ -1428,7 +1435,7 @@ private fun ContinueWatchingItem.isCloudLibraryContinueWatchingItem(): Boolean =
 
 private fun WatchProgressEntry.isCloudLibraryProgressEntry(): Boolean =
     contentType.equals(CloudLibraryContentType, ignoreCase = true) ||
-        parentMetaType.equals(CloudLibraryContentType, ignoreCase = true)
+            parentMetaType.equals(CloudLibraryContentType, ignoreCase = true)
 
 private suspend fun remapTraktProgressEntries(
     entries: List<WatchProgressEntry>,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeHeroSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeHeroSection.kt
@@ -474,7 +474,7 @@ internal fun homeHeroLayout(
             contentMaxWidth = 480.dp,
             contentWidthFraction = 1f,
             contentHorizontalPadding = 24.dp,
-            contentVerticalPadding = 16.dp,
+            contentVerticalPadding = 0.dp,
             bottomFadeHeight = 220.dp,
             logoWidthFraction = 0.62f,
         )
@@ -489,14 +489,27 @@ private fun mobileHeroHeight(
     val widthFallbackHeight = (maxWidthDp * 1.16f).dp
     val baseHeight = viewportDrivenHeight ?: widthFallbackHeight
 
-    val cappedHeight = if (viewportHeightDp != null && mobileBelowSectionHeightHintDp != null) {
-        val maxAllowedFromViewport = (viewportHeightDp - mobileBelowSectionHeightHintDp).dp
+    val maxAllowedFromViewport = if (viewportHeightDp != null && mobileBelowSectionHeightHintDp != null) {
+        (viewportHeightDp - mobileBelowSectionHeightHintDp).dp
+    } else {
+        null
+    }
+    val cappedHeight = if (maxAllowedFromViewport != null) {
         baseHeight.coerceAtMost(maxAllowedFromViewport)
     } else {
         baseHeight
     }
 
-    return cappedHeight.coerceIn(MOBILE_HERO_MIN_HEIGHT_DP.dp, MOBILE_HERO_MAX_HEIGHT_DP.dp)
+    // The minimum height floor exists for readability of the hero itself, but it must never
+    // push the hero taller than the space the viewport actually has left below it — doing so
+    // would re-clip whatever section (e.g. Continue Watching) is reserved underneath.
+    val safeFlooredHeight = if (maxAllowedFromViewport != null && maxAllowedFromViewport >= cappedHeight) {
+        cappedHeight.coerceAtLeast(MOBILE_HERO_MIN_HEIGHT_DP.dp.coerceAtMost(maxAllowedFromViewport))
+    } else {
+        cappedHeight.coerceAtLeast(MOBILE_HERO_MIN_HEIGHT_DP.dp)
+    }
+
+    return safeFlooredHeight.coerceAtMost(MOBILE_HERO_MAX_HEIGHT_DP.dp)
 }
 
 @Composable
@@ -594,7 +607,7 @@ private fun resolveHeroTargetPage(
     widthPx: Float,
 ): Int {
     val thresholdPassed = abs(totalDx) > widthPx * HERO_SWIPE_THRESHOLD_FRACTION ||
-        abs(velocityX) > HERO_SWIPE_VELOCITY_THRESHOLD
+            abs(velocityX) > HERO_SWIPE_VELOCITY_THRESHOLD
     if (!thresholdPassed) return startPage
 
     val currentPage = startPage.coerceIn(0, itemCount - 1)


### PR DESCRIPTION
## Summary

On the Home screen, the Continue Watching row (Card, Wide, and Poster styles) had its bottom edge clipped by the floating bottom navigation bar on mobile. The hero carousel's height-capping calculation only reserved clearance for the bottom nav overlay on the iOS native-tabs path; on Android (and standard iOS), that reservation was 0.dp, so the hero sized itself tall enough to let Continue Watching sit flush against the literal bottom of the screen, where the nav bar then drew on top of it. Also hardened the hero's minimum-height floor so it can no longer override the viewport safety cap on shorter screens, which was a latent version of the same bug.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The Continue Watching card's title/subtitle text (and the Poster style's title in particular) was visibly cut off by the bottom navigation bar on first load of the Home screen, on Android. This affected all three Continue Watching layout styles (Card, Wide, Poster).

## Issue or approval

Fixes #1343

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

No changes to Continue Watching card content, data loading, or other Home shelves. No changes to the native (iOS Liquid Glass) tab bar path's existing behavior. Did not touch unrelated layout constants beyond what was needed to compute correct bottom clearance.

## Testing

- Manually verified on Android (Samsung device, gesture navigation) across all three Continue Watching styles (Card, Wide, Poster) that the card's title/subtitle is no longer clipped by the bottom nav bar on Home screen first load.
- tested on both virtual and physical devices. 

## Screenshots / Video
Card
| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/ab1d9171-b82c-48e5-82d7-4b0dcb6f0b65" width="242" alt="Before Update" /> | <img src="https://github.com/user-attachments/assets/f0e80ab2-c000-420c-ba55-0102239e81cc" width="242" alt="After Update" /> |

Wide
| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/b9c6184d-06e1-4528-bc2a-7a528408c203" width="242" alt="Before Update" /> | <img src="https://github.com/user-attachments/assets/3496f9e2-b268-4da3-8677-108a1dd0bb53" width="242" alt="After Update" /> |

Poster
| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/174a3ae5-d8e4-4046-a2ec-45456f2ef256" width="242" alt="Before Update" /> | <img src="https://github.com/user-attachments/assets/dca9c8a5-a471-41a3-b0ae-54c7b6581723" width="242" alt="After Update" /> |


## Breaking changes

None.

## Linked issues

Fixes #1343
