### PR TITLE
Add Xtream Codes IPTV (Live TV, VOD, Series)

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/MainActivity.kt
@@ -68,6 +68,7 @@ class MainActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         window.setBackgroundDrawableResource(R.color.nuvio_background)
         AddonStorage.initialize(applicationContext)
+        com.nuvio.app.features.iptv.XtreamAccountStorage.initialize(applicationContext)
         AuthStorage.initialize(applicationContext)
         SyncBackendStorage.initialize(applicationContext)
         LibraryStorage.initialize(applicationContext)

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/iptv/XtreamAccountStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/iptv/XtreamAccountStorage.android.kt
@@ -1,0 +1,30 @@
+package com.nuvio.app.features.iptv
+
+import android.content.Context
+import android.content.SharedPreferences
+
+internal actual object XtreamAccountStorage {
+    private const val preferencesName = "nuvio_iptv"
+    private const val accountsKey = "xtream_accounts"
+
+    private var preferences: SharedPreferences? = null
+
+    /** Called once at app startup (MainActivity), like AddonStorage.initialize. */
+    fun initialize(context: Context) {
+        preferences = context.getSharedPreferences(preferencesName, Context.MODE_PRIVATE)
+    }
+
+    actual fun loadAccountsJson(profileId: Int): String? =
+        preferences?.getString("${accountsKey}_$profileId", null)
+
+    actual fun saveAccountsJson(profileId: Int, json: String) {
+        preferences?.edit()?.putString("${accountsKey}_$profileId", json)?.apply()
+    }
+
+    actual fun loadRecentsJson(profileId: Int): String? =
+        preferences?.getString("xtream_live_recents_$profileId", null)
+
+    actual fun saveRecentsJson(profileId: Int, json: String) {
+        preferences?.edit()?.putString("xtream_live_recents_$profileId", json)?.apply()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -108,8 +108,14 @@ actual fun PlatformPlayerSurface(
         normalizeStreamType(streamType).orEmpty(),
         useYoutubeChunkedPlayback,
     )
+    // Live IPTV is raw continuous MPEG-TS, which ExoPlayer can't sustain (buffers forever) —
+    // force libmpv regardless of the user's engine setting. VOD/series keep their choice.
+    val forceLibmpvForLive = normalizeStreamType(streamType) == "live"
     var activeEngine by remember(playerSourceKey, playerSettings.androidPlaybackEngine) {
-        mutableStateOf(playerSettings.androidPlaybackEngine.initialAndroidEngine())
+        mutableStateOf(
+            if (forceLibmpvForLive) ResolvedAndroidPlaybackEngine.Libmpv
+            else playerSettings.androidPlaybackEngine.initialAndroidEngine()
+        )
     }
 
     when (activeEngine) {

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -419,6 +419,7 @@
     <string name="compose_settings_page_content_discovery">Content &amp; Discovery</string>
     <string name="compose_settings_page_continue_watching">Continue Watching</string>
     <string name="compose_settings_page_debrid">Connected Services</string>
+    <string name="compose_settings_page_iptv">IPTV (Xtream Codes)</string>
     <string name="compose_settings_page_homescreen">Home Layout</string>
     <string name="compose_settings_page_integrations">Integrations</string>
     <string name="compose_settings_page_licenses_attributions">Licenses &amp; Attribution</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -28,6 +28,11 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.LiveTv
+import com.nuvio.app.features.iptv.XtreamHubScreen
+import com.nuvio.app.features.iptv.XtreamItemRegistry
+import com.nuvio.app.features.iptv.XtreamLiveRecents
+import com.nuvio.app.features.iptv.XtreamRepository
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -135,6 +140,7 @@ import com.nuvio.app.features.details.PersonDetailScreen
 import com.nuvio.app.features.details.TmdbEntityBrowseScreen
 import com.nuvio.app.features.tmdb.TmdbEntityKind
 import com.nuvio.app.features.home.HomeCatalogSection
+import com.nuvio.app.features.home.PosterShape
 import com.nuvio.app.features.home.HomeScreen
 import com.nuvio.app.features.home.MetaPreview
 import com.nuvio.app.features.library.LibraryItem
@@ -343,14 +349,18 @@ enum class AppScreenTab {
     Home,
     Search,
     Library,
+    Iptv,
     Settings,
 }
 
-private fun AppScreenTab.toNativeNavigationTab(): NativeNavigationTab = when (this) {
+// null for tabs the iOS liquid-glass native tab bar doesn't carry (IPTV isn't in the native
+// bar yet — needs Swift work; on Android the Compose nav bar renders it).
+private fun AppScreenTab.toNativeNavigationTab(): NativeNavigationTab? = when (this) {
     AppScreenTab.Home -> NativeNavigationTab.Home
     AppScreenTab.Search -> NativeNavigationTab.Search
     AppScreenTab.Library -> NativeNavigationTab.Library
     AppScreenTab.Settings -> NativeNavigationTab.Settings
+    AppScreenTab.Iptv -> null
 }
 
 private fun NativeNavigationTab.toAppScreenTab(): AppScreenTab = when (this) {
@@ -788,6 +798,7 @@ private fun MainAppContent(
                 searchScrollToTopRequests.tryEmit(Unit)
             }
             AppScreenTab.Library -> libraryScrollToTopRequests.tryEmit(Unit)
+            AppScreenTab.Iptv -> {}
             AppScreenTab.Settings -> settingsRootActionRequests.tryEmit(Unit)
         }
     }
@@ -823,7 +834,7 @@ private fun MainAppContent(
     }
 
     LaunchedEffect(selectedTab) {
-        NativeTabBridge.publishSelectedTab(selectedTab.toNativeNavigationTab())
+        selectedTab.toNativeNavigationTab()?.let { NativeTabBridge.publishSelectedTab(it) }
         if (selectedTab != AppScreenTab.Search) {
             searchFocusRequestCount = 0
         }
@@ -955,6 +966,30 @@ private fun MainAppContent(
     var resumePromptItem by remember { mutableStateOf<ContinueWatchingItem?>(null) }
     var lastExternalPlayerLaunch by remember { mutableStateOf<PlayerLaunch?>(null) }
     val activePlaybackProfileId = profileState.activeProfile?.profileIndex ?: ProfileRepository.activeProfileId
+
+    // Shared launch for an Xtream LIVE channel (from the hub or the Library) — forces libmpv via
+    // streamType="live". The URL is rebuilt from the id when the caller doesn't have one (e.g. a
+    // favorite opened from the Library after a fresh launch, when the registry is empty).
+    fun playLiveXtreamChannel(contentId: String, name: String, logo: String?, url: String?) {
+        val resolvedUrl = url ?: XtreamItemRegistry.liveStreamUrlFor(contentId) ?: return
+        XtreamLiveRecents.record(contentId, name, logo)
+        val liveLaunch = PlayerLaunch(
+            profileId = activePlaybackProfileId,
+            title = name,
+            sourceUrl = resolvedUrl,
+            streamTitle = name,
+            streamType = "live",
+            providerName = XtreamItemRegistry.accountNameFor(contentId) ?: "Xtream",
+            providerAddonId = "xtream",
+            logo = logo,
+            contentType = "live",
+            videoId = contentId,
+            parentMetaId = contentId,
+            parentMetaType = "tv",
+        )
+        navController.navigate(PlayerRoute(launchId = PlayerLaunchStore.put(liveLaunch)))
+    }
+
     val launchExternalPlayer = rememberExternalPlayerLauncher { result ->
         if (result != null && result.positionMs > 0L) {
             coroutineScope.launch {
@@ -1501,6 +1536,12 @@ private fun MainAppContent(
                                             contentDescription = stringResource(Res.string.compose_nav_library),
                                         )
                                         NavItem(
+                                            selected = selectedTab == AppScreenTab.Iptv,
+                                            onClick = { handleRootTabClick(AppScreenTab.Iptv) },
+                                            icon = Icons.Filled.LiveTv,
+                                            contentDescription = "IPTV",
+                                        )
+                                        NavItem(
                                             selected = selectedTab == AppScreenTab.Settings,
                                             onClick = { handleRootTabClick(AppScreenTab.Settings) },
                                         ) {
@@ -1533,13 +1574,64 @@ private fun MainAppContent(
                                         animateHomeCollectionGifs = tabsRouteActive,
                                         onCatalogClick = onCatalogClick,
                                         onPosterClick = { meta ->
-                                            navController.navigate(DetailRoute(type = meta.type, id = meta.id))
+                                            // A live channel (e.g. from Search) has no detail — play it directly.
+                                            if (XtreamItemRegistry.isLiveId(meta.id)) {
+                                                playLiveXtreamChannel(
+                                                    contentId = meta.id,
+                                                    name = meta.name,
+                                                    logo = meta.logo ?: meta.poster,
+                                                    url = XtreamItemRegistry.get(meta.id)?.streamUrl,
+                                                )
+                                            } else {
+                                                navController.navigate(DetailRoute(type = meta.type, id = meta.id))
+                                            }
                                         },
                                         onPosterLongClick = { meta ->
                                             openPosterActions(PosterActionTarget(preview = meta))
                                         },
+                                        onIptvAddProvider = {
+                                            requestedSettingsPageName = "Iptv"
+                                            selectedTab = AppScreenTab.Settings
+                                        },
+                                        onPlayLiveChannel = { contentId ->
+                                            val item = XtreamItemRegistry.get(contentId)
+                                            playLiveXtreamChannel(
+                                                contentId = contentId,
+                                                name = item?.name ?: "Live TV",
+                                                logo = item?.logo ?: item?.poster,
+                                                url = item?.streamUrl,
+                                            )
+                                        },
+                                        onIptvFavoriteChannel = { contentId ->
+                                            XtreamItemRegistry.get(contentId)?.let { item ->
+                                                LibraryRepository.toggleSaved(
+                                                    LibraryItem(
+                                                        id = contentId,
+                                                        type = "tv",
+                                                        name = item.name,
+                                                        poster = item.logo ?: item.poster,
+                                                        logo = item.logo,
+                                                        posterShape = PosterShape.Landscape,
+                                                        savedAtEpochMs = 0L, // set by LibraryRepository.save()
+                                                    )
+                                                )
+                                                NuvioToastController.show(
+                                                    if (LibraryRepository.isSaved(contentId, "tv")) "Added to Library" else "Removed from Library"
+                                                )
+                                            }
+                                        },
                                         onLibraryPosterClick = { item ->
-                                            navController.navigate(DetailRoute(type = item.type, id = item.id))
+                                            if (XtreamItemRegistry.isLiveId(item.id)) {
+                                                // Live channels have no detail screen — play directly (mpv).
+                                                playLiveXtreamChannel(
+                                                    contentId = item.id,
+                                                    name = item.name,
+                                                    logo = item.logo ?: item.poster,
+                                                    url = XtreamItemRegistry.get(item.id)?.streamUrl,
+                                                )
+                                            } else {
+                                                navController.navigate(DetailRoute(type = item.type, id = item.id))
+                                            }
                                         },
                                         onLibraryPosterLongClick = { item, section ->
                                             openPosterActions(
@@ -3007,6 +3099,9 @@ private fun AppTabHost(
     onCatalogClick: ((HomeCatalogSection) -> Unit)? = null,
     onPosterClick: ((MetaPreview) -> Unit)? = null,
     onPosterLongClick: ((MetaPreview) -> Unit)? = null,
+    onIptvAddProvider: () -> Unit = {},
+    onPlayLiveChannel: (String) -> Unit = {},
+    onIptvFavoriteChannel: (String) -> Unit = {},
     onLibraryPosterClick: ((LibraryItem) -> Unit)? = null,
     onLibraryPosterLongClick: ((LibraryItem, LibrarySection) -> Unit)? = null,
     onLibrarySectionViewAllClick: ((LibrarySection) -> Unit)? = null,
@@ -3070,6 +3165,16 @@ private fun AppTabHost(
                         onSectionViewAllClick = onLibrarySectionViewAllClick,
                         onCloudFilePlay = onCloudFilePlay,
                         onConnectCloudClick = onConnectCloudClick,
+                    )
+                }
+
+                AppScreenTab.Iptv -> {
+                    XtreamHubScreen(
+                        modifier = Modifier.fillMaxSize(),
+                        onPosterClick = { meta -> onPosterClick?.invoke(meta) },
+                        onPlayLiveChannel = onPlayLiveChannel,
+                        onFavoriteLiveChannel = onIptvFavoriteChannel,
+                        onAddProvider = onIptvAddProvider,
                     )
                 }
 
@@ -3171,6 +3276,23 @@ private fun TabletFloatingTopBar(
                             contentDescription = stringResource(Res.string.compose_nav_library),
                             modifier = Modifier.size(NuvioTokens.Space.s18),
                             tint = if (selectedTab == AppScreenTab.Library) {
+                                tokens.colors.textPrimary
+                            } else {
+                                tokens.colors.textMuted
+                            },
+                        )
+                    },
+                )
+                TabletTopPillItem(
+                    label = "IPTV",
+                    selected = selectedTab == AppScreenTab.Iptv,
+                    onClick = { onTabSelected(AppScreenTab.Iptv) },
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Filled.LiveTv,
+                            contentDescription = "IPTV",
+                            modifier = Modifier.size(NuvioTokens.Space.s18),
+                            tint = if (selectedTab == AppScreenTab.Iptv) {
                                 tokens.colors.textPrimary
                             } else {
                                 tokens.colors.textMuted

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsRepository.kt
@@ -8,6 +8,12 @@ import com.nuvio.app.features.addons.enabledAddons
 import com.nuvio.app.features.addons.httpGetText
 import com.nuvio.app.features.home.HomeCatalogSettingsRepository
 import com.nuvio.app.features.home.filterReleasedItems
+import com.nuvio.app.features.iptv.XtreamClient
+import com.nuvio.app.features.iptv.XtreamItemRegistry
+import com.nuvio.app.features.iptv.XtreamKind
+import com.nuvio.app.features.iptv.XtreamRepository
+import com.nuvio.app.features.iptv.XtreamResolvedItem
+import com.nuvio.app.features.streams.StreamItem
 import com.nuvio.app.features.mdblist.MdbListMetadataService
 import com.nuvio.app.features.mdblist.MdbListSettingsRepository
 import com.nuvio.app.features.tmdb.TmdbMetadataService
@@ -112,6 +118,10 @@ object MetaDetailsRepository {
         _uiState.value = MetaDetailsUiState(isLoading = true)
 
         scope.launch {
+            if (XtreamItemRegistry.isXtreamId(id)) {
+                loadXtreamMeta(requestKey = requestKey, id = id)
+                return@launch
+            }
             val metaLookupId = resolveMetaLookupId(itemId = id, itemType = type)
             val manifests = findMetaManifests(type = type, id = metaLookupId)
 
@@ -524,5 +534,119 @@ object MetaDetailsRepository {
         }
 
         return emptyList()
+    }
+
+    // --- Xtream IPTV short-circuit (bypasses addons; native detail for VOD/series) ---
+
+    private suspend fun loadXtreamMeta(requestKey: String, id: String) {
+        XtreamRepository.ensureLoaded()
+        val parsed = XtreamItemRegistry.parseId(id)
+        val account = parsed?.let { p -> XtreamRepository.uiState.value.accounts.firstOrNull { it.id == p.accountId } }
+        if (parsed == null || account == null) {
+            log.w { "Xtream meta short-circuit: no account for id=$id" }
+            _uiState.value = MetaDetailsUiState(errorMessage = getString(Res.string.details_no_addon_meta))
+            activeRequestKey = null
+            return
+        }
+
+        val meta = withContext(Dispatchers.Default) {
+            when (parsed.kind) {
+                XtreamKind.SERIES -> buildXtreamSeriesMeta(id, parsed.accountId, account, parsed.id.toIntOrNull())
+                else -> buildXtreamVodMeta(id, parsed.accountId, account, parsed.id.toIntOrNull())
+            }
+        }
+        if (meta == null) {
+            _uiState.value = MetaDetailsUiState(errorMessage = getString(Res.string.details_no_addon_meta))
+            activeRequestKey = null
+            return
+        }
+
+        val fingerprint = buildMetaScreenSettingsFingerprint(MdbListSettingsRepository.snapshot())
+        cachedMetaByRequestKey[requestKey] = CachedMetaEntry(
+            baseMeta = meta,
+            metaScreenMeta = meta,
+            metaScreenSettingsFingerprint = fingerprint,
+        )
+        _uiState.value = MetaDetailsUiState(meta = meta.withUnreleasedFilter())
+        activeRequestKey = requestKey
+    }
+
+    private suspend fun buildXtreamVodMeta(
+        id: String,
+        accountId: String,
+        account: com.nuvio.app.features.iptv.XtreamAccount,
+        streamId: Int?,
+    ): MetaDetails? {
+        if (streamId == null) return null
+        val registered = XtreamItemRegistry.get(id)
+        val detail = XtreamClient.vodInfo(account, streamId).getOrNull()
+        val name = detail?.name ?: registered?.name ?: "Movie"
+        val poster = registered?.poster
+        val streamUrl = registered?.streamUrl
+            ?: XtreamClient.movieStreamUrl(account, streamId, detail?.containerExtension ?: "mp4")
+        XtreamItemRegistry.register(XtreamResolvedItem(id, accountId, XtreamKind.VOD, name, streamUrl, poster))
+
+        var meta = MetaDetails(
+            id = id,
+            type = "movie",
+            name = name,
+            poster = poster,
+            description = detail?.plot,
+            genres = detail?.genres ?: emptyList(),
+            imdbRating = detail?.rating,
+            releaseInfo = detail?.releaseDate?.take(4)?.ifBlank { null },
+        )
+        detail?.tmdbId?.let { meta = enrichXtreamMeta(meta, it) }
+        return meta
+    }
+
+    private suspend fun buildXtreamSeriesMeta(
+        id: String,
+        accountId: String,
+        account: com.nuvio.app.features.iptv.XtreamAccount,
+        seriesId: Int?,
+    ): MetaDetails? {
+        if (seriesId == null) return null
+        val registered = XtreamItemRegistry.get(id)
+        val detail = XtreamClient.seriesInfo(account, seriesId).getOrNull()
+        val videos = detail?.episodes.orEmpty().map { ep ->
+            val episodeContentId = XtreamItemRegistry.episodeId(accountId, ep.episodeId)
+            val episodeUrl = XtreamClient.episodeStreamUrl(account, ep.episodeId, ep.containerExtension ?: "mp4")
+            XtreamItemRegistry.register(
+                XtreamResolvedItem(episodeContentId, accountId, XtreamKind.EPISODE, ep.title, episodeUrl)
+            )
+            MetaVideo(
+                id = episodeContentId,
+                title = ep.title,
+                season = ep.season,
+                episode = ep.episodeNum,
+                overview = ep.plot,
+                thumbnail = ep.still,
+                streams = listOf(
+                    StreamItem(name = "Direct", title = ep.title, url = episodeUrl, addonName = account.name, addonId = "xtream")
+                ),
+            )
+        }
+        val name = detail?.name ?: registered?.name ?: "Series"
+        var meta = MetaDetails(
+            id = id,
+            type = "series",
+            name = name,
+            poster = registered?.poster ?: detail?.poster,
+            description = detail?.plot,
+            genres = detail?.genres ?: emptyList(),
+            imdbRating = detail?.rating,
+            videos = videos,
+        )
+        detail?.tmdbId?.let { meta = enrichXtreamMeta(meta, it) }
+        return meta
+    }
+
+    private suspend fun enrichXtreamMeta(meta: MetaDetails, tmdbId: Int): MetaDetails {
+        val settings = TmdbSettingsRepository.snapshot()
+        if (!settings.enabled || !settings.hasApiKey) return meta
+        return runCatching { TmdbMetadataService.enrichMeta(meta, "tmdb:$tmdbId", settings) }
+            .onFailure { log.w { "Xtream TMDB enrichment failed for tmdb:$tmdbId: ${it.message}" } }
+            .getOrDefault(meta)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -1,6 +1,7 @@
 package com.nuvio.app.features.home
 
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -32,8 +33,12 @@ import com.nuvio.app.features.details.MetaDetailsRepository
 import com.nuvio.app.features.details.MetaVideo
 import com.nuvio.app.features.details.SeriesPrimaryAction
 import com.nuvio.app.features.details.seriesPrimaryAction
+import com.nuvio.app.features.catalog.CatalogTarget
 import com.nuvio.app.features.home.components.HomeCatalogRowSection
 import com.nuvio.app.features.home.components.HomeContinueWatchingSection
+import com.nuvio.app.features.iptv.XtreamItemRegistry
+import com.nuvio.app.features.iptv.XtreamLiveRecents
+import com.nuvio.app.features.iptv.toMetaPreview
 import com.nuvio.app.features.home.components.HomeEmptyStateCard
 import com.nuvio.app.features.home.components.HomeHeroReservedSpace
 import com.nuvio.app.features.home.components.HomeHeroSection
@@ -416,6 +421,12 @@ fun HomeScreen(
             cloudLibraryUiState = cloudLibraryUiState,
         )
     }
+    // Live channels don't record watch progress, so recently-watched channels feed the Live TV
+    // row of the split Continue Watching UI.
+    val liveRecentsRaw by XtreamLiveRecents.recents.collectAsStateWithLifecycle()
+    LaunchedEffect(Unit) { XtreamLiveRecents.ensureLoaded() }
+    val liveRecentPreviews = remember(liveRecentsRaw) { liveRecentsRaw.map { it.toMetaPreview() } }
+
     val enabledAddons = remember(addonsUiState.addons) {
         addonsUiState.addons.enabledAddons()
     }
@@ -735,18 +746,19 @@ fun HomeScreen(
 
             when {
                 !hasActiveAddons && !hasRenderableCollectionRows -> {
-                    if (continueWatchingPreferences.isVisible && continueWatchingItems.isNotEmpty()) {
+                    if (continueWatchingPreferences.isVisible && (continueWatchingItems.isNotEmpty() || liveRecentPreviews.isNotEmpty())) {
                         item(key = HOME_CONTINUE_WATCHING_SECTION_KEY) {
-                            HomeContinueWatchingSection(
+                            HomeContinueWatchingSplit(
                                 items = continueWatchingItems,
+                                liveRecents = liveRecentPreviews,
                                 style = continueWatchingPreferences.style,
                                 useEpisodeThumbnails = continueWatchingPreferences.useEpisodeThumbnails,
                                 blurNextUp = continueWatchingPreferences.blurNextUp,
-                                modifier = Modifier.padding(bottom = 12.dp),
                                 sectionPadding = homeSectionPadding,
                                 layout = continueWatchingLayout,
                                 onItemClick = onContinueWatchingClick,
                                 onItemLongPress = onContinueWatchingLongPress,
+                                onLivePosterClick = { onPosterClick?.invoke(it) },
                             )
                         }
                     }
@@ -760,18 +772,19 @@ fun HomeScreen(
                 }
 
                 homeUiState.isLoading && homeUiState.sections.isEmpty() && !hasRenderableCollectionRows -> {
-                    if (continueWatchingPreferences.isVisible && continueWatchingItems.isNotEmpty()) {
+                    if (continueWatchingPreferences.isVisible && (continueWatchingItems.isNotEmpty() || liveRecentPreviews.isNotEmpty())) {
                         item(key = HOME_CONTINUE_WATCHING_SECTION_KEY) {
-                            HomeContinueWatchingSection(
+                            HomeContinueWatchingSplit(
                                 items = continueWatchingItems,
+                                liveRecents = liveRecentPreviews,
                                 style = continueWatchingPreferences.style,
                                 useEpisodeThumbnails = continueWatchingPreferences.useEpisodeThumbnails,
                                 blurNextUp = continueWatchingPreferences.blurNextUp,
-                                modifier = Modifier.padding(bottom = 12.dp),
                                 sectionPadding = homeSectionPadding,
                                 layout = continueWatchingLayout,
                                 onItemClick = onContinueWatchingClick,
                                 onItemLongPress = onContinueWatchingLongPress,
+                                onLivePosterClick = { onPosterClick?.invoke(it) },
                             )
                         }
                     }
@@ -784,7 +797,7 @@ fun HomeScreen(
                 }
 
                 homeUiState.sections.isEmpty() && homeUiState.heroItems.isEmpty() &&
-                    (!continueWatchingPreferences.isVisible || continueWatchingItems.isEmpty()) &&
+                    (!continueWatchingPreferences.isVisible || (continueWatchingItems.isEmpty() && liveRecentPreviews.isEmpty())) &&
                     !hasRenderableCollectionRows -> {
                     item {
                         if (networkStatusUiState.isOfflineLike) {
@@ -808,18 +821,19 @@ fun HomeScreen(
                 }
 
                 else -> {
-                    if (continueWatchingPreferences.isVisible && continueWatchingItems.isNotEmpty()) {
+                    if (continueWatchingPreferences.isVisible && (continueWatchingItems.isNotEmpty() || liveRecentPreviews.isNotEmpty())) {
                         item(key = HOME_CONTINUE_WATCHING_SECTION_KEY) {
-                            HomeContinueWatchingSection(
+                            HomeContinueWatchingSplit(
                                 items = continueWatchingItems,
+                                liveRecents = liveRecentPreviews,
                                 style = continueWatchingPreferences.style,
                                 useEpisodeThumbnails = continueWatchingPreferences.useEpisodeThumbnails,
                                 blurNextUp = continueWatchingPreferences.blurNextUp,
-                                modifier = Modifier.padding(bottom = 12.dp),
                                 sectionPadding = homeSectionPadding,
                                 layout = continueWatchingLayout,
                                 onItemClick = onContinueWatchingClick,
                                 onItemLongPress = onContinueWatchingLongPress,
+                                onLivePosterClick = { onPosterClick?.invoke(it) },
                             )
                         }
                     }
@@ -1487,5 +1501,70 @@ private suspend fun remapTraktWatchedItems(
                 item
             }
         }
+    }
+}
+
+/**
+ * Continue Watching split into type-grouped rows: a Live TV row (recently-watched channels, since
+ * live records no resume position), then Movies and Series rows from the real watch-progress items.
+ * Each row hides itself when empty.
+ */
+@Composable
+private fun HomeContinueWatchingSplit(
+    items: List<ContinueWatchingItem>,
+    liveRecents: List<MetaPreview>,
+    style: ContinueWatchingSectionStyle,
+    useEpisodeThumbnails: Boolean,
+    blurNextUp: Boolean,
+    sectionPadding: Dp,
+    layout: ContinueWatchingLayout,
+    onItemClick: ((ContinueWatchingItem) -> Unit)?,
+    onItemLongPress: ((ContinueWatchingItem) -> Unit)?,
+    onLivePosterClick: (MetaPreview) -> Unit,
+) {
+    // Live channels belong only in the Live TV row above — keep any that leaked into watch-progress
+    // (a live id classifies as tv -> series) out of the Movies/Series rows.
+    val nonLive = items.filterNot { XtreamItemRegistry.isLiveId(it.parentMetaId) }
+    val movies = nonLive.filterNot { it.parentMetaType.isSeriesTypeForContinueWatching() }
+    val series = nonLive.filter { it.parentMetaType.isSeriesTypeForContinueWatching() }
+    Column(modifier = Modifier.padding(bottom = 12.dp)) {
+        if (liveRecents.isNotEmpty()) {
+            HomeCatalogRowSection(
+                section = HomeCatalogSection(
+                    key = "iptv_live_recents",
+                    title = "Live TV",
+                    subtitle = "",
+                    addonName = "",
+                    target = CatalogTarget.Library(contentType = "tv", sectionType = "xtream_recents"),
+                    items = liveRecents,
+                    availableItemCount = liveRecents.size,
+                    hasMore = false,
+                ),
+                sectionPadding = sectionPadding,
+                onPosterClick = onLivePosterClick,
+            )
+        }
+        HomeContinueWatchingSection(
+            items = movies,
+            style = style,
+            useEpisodeThumbnails = useEpisodeThumbnails,
+            blurNextUp = blurNextUp,
+            sectionPadding = sectionPadding,
+            layout = layout,
+            title = "Movies",
+            onItemClick = onItemClick,
+            onItemLongPress = onItemLongPress,
+        )
+        HomeContinueWatchingSection(
+            items = series,
+            style = style,
+            useEpisodeThumbnails = useEpisodeThumbnails,
+            blurNextUp = blurNextUp,
+            sectionPadding = sectionPadding,
+            layout = layout,
+            title = "Series",
+            onItemClick = onItemClick,
+            onItemLongPress = onItemLongPress,
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeContinueWatchingSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeContinueWatchingSection.kt
@@ -189,6 +189,7 @@ internal fun HomeContinueWatchingSection(
     modifier: Modifier = Modifier,
     sectionPadding: Dp? = null,
     layout: ContinueWatchingLayout? = null,
+    title: String? = null,
     onItemClick: ((ContinueWatchingItem) -> Unit)? = null,
     onItemLongPress: ((ContinueWatchingItem) -> Unit)? = null,
 ) {
@@ -203,6 +204,7 @@ internal fun HomeContinueWatchingSection(
             modifier = modifier.fillMaxWidth(),
             sectionPadding = sectionPadding,
             layout = layout,
+            title = title,
             onItemClick = onItemClick,
             onItemLongPress = onItemLongPress,
         )
@@ -216,6 +218,7 @@ internal fun HomeContinueWatchingSection(
                 modifier = Modifier.fillMaxWidth(),
                 sectionPadding = homeSectionHorizontalPaddingForWidth(maxWidth.value),
                 layout = rememberContinueWatchingLayout(maxWidth.value),
+                title = title,
                 onItemClick = onItemClick,
                 onItemLongPress = onItemLongPress,
             )
@@ -232,6 +235,7 @@ private fun HomeContinueWatchingSectionContent(
     modifier: Modifier,
     sectionPadding: Dp,
     layout: ContinueWatchingLayout,
+    title: String?,
     onItemClick: ((ContinueWatchingItem) -> Unit)?,
     onItemLongPress: ((ContinueWatchingItem) -> Unit)?,
 ) {
@@ -241,7 +245,7 @@ private fun HomeContinueWatchingSectionContent(
     }.collectAsStateWithLifecycle()
 
     NuvioShelfSection(
-        title = stringResource(Res.string.compose_settings_page_continue_watching),
+        title = title ?: stringResource(Res.string.compose_settings_page_continue_watching),
         entries = items,
         modifier = modifier,
         headerHorizontalPadding = sectionPadding,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamAccountStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamAccountStorage.kt
@@ -1,0 +1,15 @@
+package com.nuvio.app.features.iptv
+
+/**
+ * Local, profile-scoped persistence of the Xtream accounts list as a JSON string.
+ * Mirrors features/addons AddonStorage (SharedPreferences on Android, NSUserDefaults on iOS).
+ *
+ * ponytail: local only; Supabase cloud sync (like addons have) is the upgrade path.
+ */
+internal expect object XtreamAccountStorage {
+    fun loadAccountsJson(profileId: Int): String?
+    fun saveAccountsJson(profileId: Int, json: String)
+    /** Recently-watched live channels (JSON), profile-scoped — for the Live TV Continue-Watching row. */
+    fun loadRecentsJson(profileId: Int): String?
+    fun saveRecentsJson(profileId: Int, json: String)
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamClient.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamClient.kt
@@ -1,0 +1,210 @@
+package com.nuvio.app.features.iptv
+
+import com.nuvio.app.features.addons.httpGetText
+import io.ktor.http.encodeURLParameter
+import io.ktor.http.encodeURLPathPart
+import io.ktor.util.decodeBase64String
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonObject
+
+/**
+ * Talks to one Xtream panel: builds `player_api.php` + stream URLs, fetches via the
+ * shared [httpGetText], maps DTOs -> domain models. KMP twin of NuvioTV's XtreamClient.
+ *
+ * ponytail: stream URLs reuse the account's entered baseUrl; short_epg gives now+next
+ * cheaply. Full XMLTV grid and a per-host server_info override are the upgrade paths.
+ */
+object XtreamClient {
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Verifies credentials. Success only when the panel reports auth=1 and an active status. */
+    suspend fun verify(acc: XtreamAccount): Result<Unit> = call {
+        val info = json.decodeFromString<XtreamAccountDto>(httpGetText(playerApi(acc))).userInfo
+        check(info?.auth == 1) { "Authentication failed" }
+        val status = info.status?.lowercase() ?: ""
+        check(status.isEmpty() || status == "active") { "Account status: ${info.status}" }
+    }
+
+    /** Live account status: active/expired, trial flag, expiry, and current vs max connections. */
+    suspend fun accountInfo(acc: XtreamAccount): Result<XtreamAccountInfo?> = call {
+        val info = json.decodeFromString<XtreamAccountDto>(httpGetText(playerApi(acc))).userInfo ?: return@call null
+        XtreamAccountInfo(
+            status = info.status?.ifBlank { null },
+            isTrial = info.isTrial == "1",
+            expiresAtEpochSec = info.expDate?.trim()?.toLongOrNull(),
+            maxConnections = info.maxConnections?.trim()?.toIntOrNull(),
+            activeConnections = info.activeCons?.trim()?.toIntOrNull()
+        )
+    }
+
+    suspend fun liveCategories(acc: XtreamAccount) = categories(acc, "get_live_categories")
+    suspend fun vodCategories(acc: XtreamAccount) = categories(acc, "get_vod_categories")
+    suspend fun seriesCategories(acc: XtreamAccount) = categories(acc, "get_series_categories")
+
+    suspend fun liveChannels(acc: XtreamAccount, categoryId: String? = null): Result<List<XtreamChannel>> = call {
+        decode<List<XtreamLiveStreamDto>>(playerApi(acc, "get_live_streams", categoryId)).mapNotNull { dto ->
+            val id = dto.streamId ?: return@mapNotNull null
+            XtreamChannel(
+                streamId = id,
+                name = dto.name ?: "",
+                logo = dto.streamIcon?.ifBlank { null },
+                epgChannelId = dto.epgChannelId?.ifBlank { null },
+                categoryId = dto.categoryId,
+                hasArchive = (dto.tvArchive ?: 0) > 0,
+                streamUrl = streamUrl(acc, "live", id, "ts")
+            )
+        }
+    }
+
+    suspend fun vodMovies(acc: XtreamAccount, categoryId: String? = null): Result<List<XtreamMovie>> = call {
+        decode<List<XtreamVodStreamDto>>(playerApi(acc, "get_vod_streams", categoryId)).mapNotNull { dto ->
+            val id = dto.streamId ?: return@mapNotNull null
+            XtreamMovie(
+                streamId = id,
+                name = dto.name ?: "",
+                poster = dto.streamIcon?.ifBlank { null },
+                categoryId = dto.categoryId,
+                rating = dto.rating,
+                streamUrl = streamUrl(acc, "movie", id, dto.containerExtension?.ifBlank { null } ?: "mp4")
+            )
+        }
+    }
+
+    suspend fun series(acc: XtreamAccount, categoryId: String? = null): Result<List<XtreamSeriesItem>> = call {
+        decode<List<XtreamSeriesDto>>(playerApi(acc, "get_series", categoryId)).mapNotNull { dto ->
+            val id = dto.seriesId ?: return@mapNotNull null
+            XtreamSeriesItem(id, dto.name ?: "", dto.cover?.ifBlank { null }, dto.categoryId, dto.plot, dto.rating)
+        }
+    }
+
+    suspend fun shortEpg(acc: XtreamAccount, streamId: Int, limit: Int = 4): Result<List<XtreamProgram>> = call {
+        val url = playerApi(acc, "get_short_epg") + "&stream_id=$streamId&limit=$limit"
+        decode<XtreamShortEpgResponseDto>(url).listings.orEmpty().map { it.toProgram() }
+    }
+
+    /**
+     * VOD detail for synthetic-meta + TMDB enrichment. Returns null (not a failure) when the
+     * panel sends `info: []` — a known quirk — so callers fall back to bare Xtream metadata.
+     */
+    suspend fun vodInfo(acc: XtreamAccount, vodId: Int): Result<XtreamVodDetail?> = call {
+        val text = httpGetText(playerApi(acc, "get_vod_info") + "&vod_id=$vodId")
+        val root = runCatching { json.parseToJsonElement(text).jsonObject }.getOrNull() ?: return@call null
+        val info = root["info"] as? JsonObject   // null when the panel sends info: []
+        val movieData = root["movie_data"] as? JsonObject
+        XtreamVodDetail(
+            name = movieData?.get("name").asStringOrNull(),
+            plot = info?.get("plot").asStringOrNull(),
+            genres = info?.get("genre").asStringOrNull()?.splitCsv() ?: emptyList(),
+            rating = info?.get("rating").asStringOrNull(),
+            releaseDate = (info?.get("releasedate") ?: info?.get("release_date")).asStringOrNull(),
+            tmdbId = info?.get("tmdb_id").asIntOrNull(),
+            containerExtension = movieData?.get("container_extension").asStringOrNull()
+        )
+    }
+
+    /**
+     * Series detail incl. flattened episode list. Parsed leniently by hand because panels are
+     * wildly inconsistent: an episode's `info` is an object on some episodes and `[]` on others
+     * within the SAME series, and season/episode numbers arrive as int or quoted string. A strict
+     * decode throws on the first `info: []` and loses every episode — so we walk the JSON instead.
+     */
+    suspend fun seriesInfo(acc: XtreamAccount, seriesId: Int): Result<XtreamSeriesDetail?> = call {
+        val text = httpGetText(playerApi(acc, "get_series_info") + "&series_id=$seriesId")
+        val root = runCatching { json.parseToJsonElement(text).jsonObject }.getOrNull() ?: return@call null
+        val info = root["info"] as? JsonObject
+        val episodes = (root["episodes"] as? JsonObject).orEmptyEntries().flatMap { (seasonKey, seasonEps) ->
+            (seasonEps as? JsonArray).orEmpty().mapNotNull { element ->
+                val e = element as? JsonObject ?: return@mapNotNull null
+                val epId = e["id"].asStringOrNull() ?: return@mapNotNull null
+                val epInfo = e["info"] as? JsonObject   // null when the panel sends info: []
+                val num = e["episode_num"].asIntOrNull() ?: 0
+                XtreamEpisode(
+                    episodeId = epId,
+                    season = e["season"].asIntOrNull() ?: seasonKey.toIntOrNull() ?: 0,
+                    episodeNum = num,
+                    title = e["title"].asStringOrNull() ?: "Episode $num",
+                    plot = epInfo?.get("plot").asStringOrNull(),
+                    still = epInfo?.get("movie_image").asStringOrNull(),
+                    containerExtension = e["container_extension"].asStringOrNull()
+                )
+            }
+        }.sortedWith(compareBy({ it.season }, { it.episodeNum }))
+        XtreamSeriesDetail(
+            name = info?.get("name").asStringOrNull(),
+            poster = info?.get("cover").asStringOrNull(),
+            tmdbId = info?.get("tmdb_id").asIntOrNull(),
+            plot = info?.get("plot").asStringOrNull(),
+            genres = info?.get("genre").asStringOrNull()?.splitCsv() ?: emptyList(),
+            rating = info?.get("rating").asStringOrNull(),
+            episodes = episodes
+        )
+    }
+
+    // --- public stream-url builders (used by the registry / short-circuits) --
+
+    fun movieStreamUrl(acc: XtreamAccount, streamId: Int, ext: String = "mp4"): String = streamUrl(acc, "movie", streamId, ext.ifBlank { "mp4" })
+    fun liveStreamUrl(acc: XtreamAccount, streamId: Int): String = streamUrl(acc, "live", streamId, "ts")
+    fun episodeStreamUrl(acc: XtreamAccount, episodeId: String, ext: String = "mp4"): String {
+        val base = acc.baseUrl.trimEnd('/')
+        return "$base/series/${acc.username.encodeURLPathPart()}/${acc.password.encodeURLPathPart()}/$episodeId.${ext.ifBlank { "mp4" }}"
+    }
+
+    // --- internals -----------------------------------------------------------
+
+    private fun String.splitCsv(): List<String> = split(",").mapNotNull { it.trim().ifBlank { null } }
+
+    private suspend fun categories(acc: XtreamAccount, action: String): Result<List<XtreamCategory>> = call {
+        decode<List<XtreamCategoryDto>>(playerApi(acc, action)).mapNotNull { dto ->
+            val id = dto.categoryId ?: return@mapNotNull null
+            XtreamCategory(id, dto.categoryName ?: "")
+        }
+    }
+
+    private suspend inline fun <reified T> decode(url: String): T =
+        json.decodeFromString(httpGetText(url))
+
+    private fun playerApi(acc: XtreamAccount, action: String? = null, categoryId: String? = null): String {
+        val base = acc.baseUrl.trimEnd('/')
+        val sb = StringBuilder(base)
+            .append("/player_api.php?username=").append(acc.username.encodeURLParameter())
+            .append("&password=").append(acc.password.encodeURLParameter())
+        if (action != null) sb.append("&action=").append(action)
+        if (categoryId != null) sb.append("&category_id=").append(categoryId.encodeURLParameter())
+        return sb.toString()
+    }
+
+    private fun streamUrl(acc: XtreamAccount, kind: String, id: Int, ext: String): String {
+        val base = acc.baseUrl.trimEnd('/')
+        return "$base/$kind/${acc.username.encodeURLPathPart()}/${acc.password.encodeURLPathPart()}/$id.$ext"
+    }
+
+    private inline fun <T> call(block: () -> T): Result<T> = runCatching { block() }
+
+    private fun JsonObject?.orEmptyEntries(): Set<Map.Entry<String, JsonElement>> = this?.entries ?: emptySet()
+    private fun JsonElement?.asStringOrNull(): String? = (this as? JsonPrimitive)?.contentOrNull?.ifBlank { null }
+    private fun JsonElement?.asIntOrNull(): Int? {
+        val p = this as? JsonPrimitive ?: return null
+        return p.intOrNull ?: p.contentOrNull?.trim()?.toIntOrNull()
+    }
+}
+
+internal fun XtreamEpgEntryDto.toProgram(): XtreamProgram = XtreamProgram(
+    title = decodeXtreamBase64(title),
+    description = decodeXtreamBase64(description),
+    startMs = (startTimestamp?.toLongOrNull() ?: 0L) * 1000,
+    endMs = (stopTimestamp?.toLongOrNull() ?: 0L) * 1000,
+    nowPlaying = nowPlaying == 1
+)
+
+/** Xtream base64-encodes EPG title/description. Returns "" on null/garbage rather than throwing. */
+internal fun decodeXtreamBase64(s: String?): String {
+    if (s.isNullOrBlank()) return ""
+    return runCatching { s.trim().decodeBase64String() }.getOrDefault(s)
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamHubModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamHubModels.kt
@@ -1,0 +1,51 @@
+package com.nuvio.app.features.iptv
+
+import com.nuvio.app.features.home.MetaPreview
+import com.nuvio.app.features.home.PosterShape
+
+/** Top-level IPTV hub state. Live is handled by its own guide (P5); this covers VOD + Series browse. */
+data class XtreamHubUiState(
+    val accounts: List<XtreamAccount> = emptyList(),
+    val selectedAccountId: String? = null,
+    val section: XtreamHubSection = XtreamHubSection.LIVE,
+    val categories: List<XtreamHubCategory> = emptyList(),
+    val loadingCategories: Boolean = false,
+)
+
+enum class XtreamHubSection { LIVE, MOVIES, SERIES }
+
+/** Now/next program titles for a live channel (from get_short_epg). */
+data class ChannelEpg(val now: String?, val next: String?)
+
+data class XtreamHubCategory(
+    val id: String,
+    val name: String,
+    val items: List<MetaPreview> = emptyList(),
+    val loaded: Boolean = false,
+    val loading: Boolean = false,
+)
+
+fun XtreamMovie.toMetaPreview(accountId: String): MetaPreview = MetaPreview(
+    id = XtreamItemRegistry.vodId(accountId, streamId),
+    type = "movie",
+    name = name,
+    poster = poster,
+    posterShape = PosterShape.Poster,
+)
+
+fun XtreamSeriesItem.toMetaPreview(accountId: String): MetaPreview = MetaPreview(
+    id = XtreamItemRegistry.seriesId(accountId, seriesId),
+    type = "series",
+    name = name,
+    poster = poster,
+    posterShape = PosterShape.Poster,
+)
+
+fun XtreamChannel.toMetaPreview(accountId: String): MetaPreview = MetaPreview(
+    id = XtreamItemRegistry.liveId(accountId, streamId),
+    type = "tv",
+    name = name,
+    poster = logo,
+    logo = logo,
+    posterShape = PosterShape.Landscape,
+)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamHubRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamHubRepository.kt
@@ -1,0 +1,175 @@
+package com.nuvio.app.features.iptv
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
+
+/**
+ * Drives the IPTV hub. Category lists (per account + section) are cached in memory so switching
+ * sections/accounts is instant — no reload flash — and category items are fetched lazily, only
+ * for the rows actually scrolled into view. On launch it kicks a THROTTLED background prefetch of
+ * every section's category list so the first switch is already warm; the throttle (a monotonic
+ * mark) means rapidly re-foregrounding the app won't hammer the panel.
+ */
+object XtreamHubRepository {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val _uiState = MutableStateFlow(XtreamHubUiState())
+    val uiState: StateFlow<XtreamHubUiState> = _uiState.asStateFlow()
+
+    // Now/next EPG per live channel, kept separate from uiState so a per-channel fetch doesn't
+    // recompose the whole hub. Fetched lazily as channel tiles scroll into view.
+    private val _epg = MutableStateFlow<Map<String, ChannelEpg>>(emptyMap())
+    val epg: StateFlow<Map<String, ChannelEpg>> = _epg.asStateFlow()
+    private val epgFetched = mutableSetOf<String>()
+
+    // (accountId, section) -> category list, each carrying its own lazily-loaded items.
+    private val cache = mutableMapOf<Pair<String, XtreamHubSection>, List<XtreamHubCategory>>()
+    private var lastPrefetchMark: TimeMark? = null
+    private val REFRESH_TTL = 6.hours
+
+    /** Sync accounts, show the current section (from cache if warm), and prefetch the rest. */
+    fun ensureLoaded() {
+        XtreamRepository.ensureLoaded()
+        val accounts = XtreamRepository.uiState.value.accounts.filter { it.enabled }
+        val current = _uiState.value
+        val selected = current.selectedAccountId?.takeIf { id -> accounts.any { it.id == id } }
+            ?: accounts.firstOrNull()?.id
+        _uiState.update { it.copy(accounts = accounts, selectedAccountId = selected) }
+        if (selected != null) {
+            showSection(selected, current.section)
+            maybePrefetch(selected)
+        }
+    }
+
+    fun selectAccount(accountId: String) {
+        if (_uiState.value.selectedAccountId == accountId) return
+        _uiState.update { it.copy(selectedAccountId = accountId) }
+        showSection(accountId, _uiState.value.section)
+        maybePrefetch(accountId)
+    }
+
+    fun selectSection(section: XtreamHubSection) {
+        if (_uiState.value.section == section) return
+        val accountId = _uiState.value.selectedAccountId ?: return
+        _uiState.update { it.copy(section = section) }
+        showSection(accountId, section)
+    }
+
+    /** Show cached categories instantly, else fetch the (cheap) category list. */
+    private fun showSection(accountId: String, section: XtreamHubSection) {
+        val cached = cache[accountId to section]
+        if (cached != null) {
+            _uiState.update { it.copy(categories = cached, loadingCategories = false) }
+            return
+        }
+        _uiState.update { it.copy(categories = emptyList(), loadingCategories = true) }
+        scope.launch { fetchCategoryList(accountId, section) }
+    }
+
+    private suspend fun fetchCategoryList(accountId: String, section: XtreamHubSection) {
+        val account = XtreamRepository.uiState.value.accounts.firstOrNull { it.id == accountId } ?: return
+        val fresh = when (section) {
+            XtreamHubSection.LIVE -> XtreamClient.liveCategories(account)
+            XtreamHubSection.MOVIES -> XtreamClient.vodCategories(account)
+            XtreamHubSection.SERIES -> XtreamClient.seriesCategories(account)
+        }.getOrNull() ?: return  // keep any existing cache on a failed refresh
+        // Merge: carry over already-loaded items for categories that still exist.
+        val previous = cache[accountId to section].orEmpty().associateBy { it.id }
+        val merged = fresh.map { cat ->
+            val old = previous[cat.id]
+            XtreamHubCategory(cat.id, cat.name, items = old?.items ?: emptyList(), loaded = old?.loaded ?: false)
+        }
+        cache[accountId to section] = merged
+        if (isCurrent(accountId, section)) {
+            _uiState.update { it.copy(categories = merged, loadingCategories = false) }
+        }
+    }
+
+    /** Lazily fetch one category's items (called when its row first composes). */
+    fun loadCategory(categoryId: String) {
+        val state = _uiState.value
+        val accountId = state.selectedAccountId ?: return
+        val section = state.section
+        val category = cache[accountId to section]?.firstOrNull { it.id == categoryId } ?: return
+        if (category.loaded || category.loading) return
+        updateCategory(accountId, section, categoryId) { it.copy(loading = true) }
+        scope.launch {
+            val account = XtreamRepository.uiState.value.accounts.firstOrNull { it.id == accountId }
+            val items = if (account == null) emptyList() else when (section) {
+                XtreamHubSection.LIVE -> XtreamClient.liveChannels(account, categoryId).getOrDefault(emptyList()).map { ch ->
+                    XtreamItemRegistry.registerChannel(accountId, ch); ch.toMetaPreview(accountId)
+                }
+                XtreamHubSection.MOVIES -> XtreamClient.vodMovies(account, categoryId).getOrDefault(emptyList()).map { m ->
+                    XtreamItemRegistry.registerMovie(accountId, m); m.toMetaPreview(accountId)
+                }
+                XtreamHubSection.SERIES -> XtreamClient.series(account, categoryId).getOrDefault(emptyList()).map { s ->
+                    XtreamItemRegistry.registerSeries(accountId, s); s.toMetaPreview(accountId)
+                }
+            }
+            updateCategory(accountId, section, categoryId) { it.copy(items = items, loaded = true, loading = false) }
+        }
+    }
+
+    /** Background-refresh every section's category list on launch, throttled to once per TTL. */
+    private fun maybePrefetch(accountId: String) {
+        val mark = lastPrefetchMark
+        if (mark != null && mark.elapsedNow() < REFRESH_TTL) return
+        lastPrefetchMark = TimeSource.Monotonic.markNow()
+        scope.launch {
+            for (section in XtreamHubSection.entries) {
+                fetchCategoryList(accountId, section)
+            }
+        }
+    }
+
+    /** Lazily fetch now/next EPG for a live channel (called when its tile scrolls into view). */
+    fun ensureEpg(contentId: String) {
+        if (!epgFetched.add(contentId)) return
+        val parsed = XtreamItemRegistry.parseId(contentId) ?: return
+        if (parsed.kind != XtreamKind.LIVE) return
+        val streamId = parsed.id.toIntOrNull() ?: return
+        val account = XtreamRepository.uiState.value.accounts.firstOrNull { it.id == parsed.accountId } ?: return
+        scope.launch {
+            // get_short_epg returns current + upcoming, so the nowPlaying (or first) entry is "now".
+            val listings = XtreamClient.shortEpg(account, streamId).getOrDefault(emptyList())
+            if (listings.isEmpty()) return@launch
+            val nowIndex = listings.indexOfFirst { it.nowPlaying }.takeIf { it >= 0 } ?: 0
+            val now = listings.getOrNull(nowIndex)?.title?.ifBlank { null }
+            val next = listings.getOrNull(nowIndex + 1)?.title?.ifBlank { null }
+            if (now != null || next != null) {
+                _epg.update { it + (contentId to ChannelEpg(now = now, next = next)) }
+            }
+        }
+    }
+
+    fun resetForProfile() {
+        cache.clear()
+        lastPrefetchMark = null
+        epgFetched.clear()
+        _epg.value = emptyMap()
+        _uiState.value = XtreamHubUiState()
+    }
+
+    private fun isCurrent(accountId: String, section: XtreamHubSection): Boolean =
+        _uiState.value.selectedAccountId == accountId && _uiState.value.section == section
+
+    private fun updateCategory(
+        accountId: String,
+        section: XtreamHubSection,
+        categoryId: String,
+        transform: (XtreamHubCategory) -> XtreamHubCategory,
+    ) {
+        val key = accountId to section
+        val updated = cache[key]?.map { if (it.id == categoryId) transform(it) else it } ?: return
+        cache[key] = updated
+        if (isCurrent(accountId, section)) _uiState.update { it.copy(categories = updated) }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamHubScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamHubScreen.kt
@@ -1,0 +1,327 @@
+package com.nuvio.app.features.iptv
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.nuvio.app.core.ui.NuvioTokens
+import com.nuvio.app.features.home.MetaPreview
+import com.nuvio.app.features.home.components.HomePosterCard
+import androidx.compose.material.icons.Icons as MaterialIcons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material.icons.filled.LiveTv
+
+/**
+ * Top-level IPTV browse surface: an account selector, Movies/Series section chips, and lazily
+ * loaded category rows of posters. Posters open Nuvio's native detail (via the Xtream meta
+ * short-circuit) and play through the normal streams -> player pipeline. Live TV is its own
+ * guide (P5).
+ */
+@Composable
+fun XtreamHubScreen(
+    onPosterClick: (MetaPreview) -> Unit,
+    onPlayLiveChannel: (String) -> Unit,
+    onFavoriteLiveChannel: (String) -> Unit,
+    onAddProvider: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by XtreamHubRepository.uiState.collectAsStateWithLifecycle()
+    LaunchedEffect(Unit) { XtreamHubRepository.ensureLoaded() }
+
+    if (state.accounts.isEmpty()) {
+        XtreamHubEmptyState(onAddProvider = onAddProvider, modifier = modifier)
+        return
+    }
+
+    val isLive = state.section == XtreamHubSection.LIVE
+    val onTileClick: (MetaPreview) -> Unit = if (isLive) {
+        { meta -> onPlayLiveChannel(meta.id) }
+    } else {
+        onPosterClick
+    }
+    val onTileLongClick: ((MetaPreview) -> Unit)? = if (isLive) {
+        { meta -> onFavoriteLiveChannel(meta.id) }
+    } else {
+        null
+    }
+    val epgMap by XtreamHubRepository.epg.collectAsStateWithLifecycle()
+
+    BoxWithConstraints(modifier = modifier.fillMaxSize()) {
+        // In the wide/tablet layout the app's floating top nav bar overlays the top of the content,
+        // which would hide this fixed section-chip header — pad it down to clear the bar.
+        val tabletTopInset = if (maxWidth >= 768.dp) TABLET_TOP_BAR_INSET else 0.dp
+        Column(modifier = Modifier.fillMaxSize().statusBarsPadding().padding(top = tabletTopInset)) {
+        XtreamHubHeader(
+            accounts = state.accounts,
+            selectedAccountId = state.selectedAccountId,
+            section = state.section,
+            onSelectAccount = { XtreamHubRepository.selectAccount(it) },
+            onSelectSection = { XtreamHubRepository.selectSection(it) },
+            onAddProvider = onAddProvider,
+        )
+
+        when {
+            state.loadingCategories -> CenteredProgress()
+            state.categories.isEmpty() -> CenteredMessage("Nothing here yet")
+            else -> LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(bottom = NuvioTokens.Space.s24),
+            ) {
+                items(state.categories, key = { it.id }) { category ->
+                    LaunchedEffect(category.id) { XtreamHubRepository.loadCategory(category.id) }
+                    // Title always shows; only collapse a category once it's confirmed empty.
+                    if (!(category.loaded && category.items.isEmpty())) {
+                        XtreamHubCategoryRow(
+                            category = category,
+                            landscape = isLive,
+                            epg = if (isLive) epgMap else emptyMap(),
+                            onPosterClick = onTileClick,
+                            onPosterLongClick = onTileLongClick,
+                        )
+                    }
+                }
+            }
+        }
+        }
+    }
+}
+
+@Composable
+private fun XtreamHubHeader(
+    accounts: List<XtreamAccount>,
+    selectedAccountId: String?,
+    section: XtreamHubSection,
+    onSelectAccount: (String) -> Unit,
+    onSelectSection: (XtreamHubSection) -> Unit,
+    onAddProvider: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = NuvioTokens.Space.s16, vertical = NuvioTokens.Space.s10),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(NuvioTokens.Space.s8),
+    ) {
+        FilterChip(
+            selected = section == XtreamHubSection.LIVE,
+            onClick = { onSelectSection(XtreamHubSection.LIVE) },
+            label = { Text("Live TV") },
+        )
+        FilterChip(
+            selected = section == XtreamHubSection.MOVIES,
+            onClick = { onSelectSection(XtreamHubSection.MOVIES) },
+            label = { Text("Movies") },
+        )
+        FilterChip(
+            selected = section == XtreamHubSection.SERIES,
+            onClick = { onSelectSection(XtreamHubSection.SERIES) },
+            label = { Text("Series") },
+        )
+        Spacer(Modifier.weight(1f))
+        // Always a dropdown so it's obvious you can switch playlists (and it lists all of them,
+        // plus an "Add playlist" entry so a second provider is one tap away).
+        XtreamAccountDropdown(accounts, selectedAccountId, onSelectAccount, onAddProvider)
+    }
+}
+
+@Composable
+private fun XtreamAccountDropdown(
+    accounts: List<XtreamAccount>,
+    selectedAccountId: String?,
+    onSelectAccount: (String) -> Unit,
+    onAddPlaylist: () -> Unit,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val selectedName = accounts.firstOrNull { it.id == selectedAccountId }?.name ?: accounts.firstOrNull()?.name ?: "Playlist"
+    Box {
+        TextButton(onClick = { expanded = true }) {
+            Text(selectedName, maxLines = 1)
+            Icon(MaterialIcons.Filled.ArrowDropDown, contentDescription = null)
+        }
+        DropdownMenu(expanded = expanded, onDismissRequest = { expanded = false }) {
+            accounts.forEach { account ->
+                DropdownMenuItem(
+                    text = { Text(account.name) },
+                    onClick = {
+                        expanded = false
+                        onSelectAccount(account.id)
+                    },
+                )
+            }
+            HorizontalDivider()
+            DropdownMenuItem(
+                text = { Text("Add playlist") },
+                leadingIcon = { Icon(MaterialIcons.Filled.Add, contentDescription = null) },
+                onClick = {
+                    expanded = false
+                    onAddPlaylist()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun XtreamHubCategoryRow(
+    category: XtreamHubCategory,
+    landscape: Boolean,
+    epg: Map<String, ChannelEpg>,
+    onPosterClick: (MetaPreview) -> Unit,
+    onPosterLongClick: ((MetaPreview) -> Unit)? = null,
+) {
+    val tileWidth = if (landscape) CHANNEL_WIDTH else POSTER_WIDTH
+    val rowHeight = if (landscape) CHANNEL_ROW_HEIGHT else POSTER_HEIGHT
+    Column(modifier = Modifier.fillMaxWidth().padding(vertical = NuvioTokens.Space.s8)) {
+        Text(
+            text = category.name.ifBlank { "Other" },
+            style = MaterialTheme.typography.titleMedium,
+            fontWeight = FontWeight.SemiBold,
+            color = MaterialTheme.colorScheme.onSurface,
+            modifier = Modifier.padding(horizontal = NuvioTokens.Space.s16, vertical = NuvioTokens.Space.s6),
+        )
+        if (category.items.isEmpty()) {
+            // Loading or not-yet-loaded: hold the row height with a spinner so titles don't jump.
+            Box(Modifier.fillMaxWidth().height(rowHeight), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(strokeWidth = 2.dp)
+            }
+        } else {
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = NuvioTokens.Space.s16),
+                horizontalArrangement = Arrangement.spacedBy(NuvioTokens.Space.s10),
+            ) {
+                items(category.items, key = { it.id }) { item ->
+                    if (landscape) {
+                        // Live channel: card + now/next EPG line, fetched lazily as it appears.
+                        LaunchedEffect(item.id) { XtreamHubRepository.ensureEpg(item.id) }
+                        XtreamLiveChannelTile(
+                            item = item,
+                            epg = epg[item.id],
+                            width = tileWidth,
+                            onClick = { onPosterClick(item) },
+                            onLongClick = onPosterLongClick?.let { cb -> { cb(item) } },
+                        )
+                    } else {
+                        HomePosterCard(
+                            item = item,
+                            modifier = Modifier.width(tileWidth),
+                            onClick = { onPosterClick(item) },
+                            onLongClick = onPosterLongClick?.let { cb -> { cb(item) } },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun XtreamLiveChannelTile(
+    item: MetaPreview,
+    epg: ChannelEpg?,
+    width: androidx.compose.ui.unit.Dp,
+    onClick: () -> Unit,
+    onLongClick: (() -> Unit)?,
+) {
+    Column(modifier = Modifier.width(width)) {
+        HomePosterCard(
+            item = item,
+            modifier = Modifier.width(width),
+            useLandscapeBackdropMode = true,
+            onClick = onClick,
+            onLongClick = onLongClick,
+        )
+        Text(
+            text = epg?.now ?: "No information",
+            style = MaterialTheme.typography.labelSmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.padding(top = NuvioTokens.Space.s2, start = NuvioTokens.Space.s2, end = NuvioTokens.Space.s2),
+        )
+        epg?.next?.let { next ->
+            Text(
+                text = "Next: $next",
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(horizontal = NuvioTokens.Space.s2),
+            )
+        }
+    }
+}
+
+@Composable
+private fun XtreamHubEmptyState(onAddProvider: () -> Unit, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier.fillMaxSize().statusBarsPadding().padding(NuvioTokens.Space.s24),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Icon(MaterialIcons.Filled.LiveTv, contentDescription = null, modifier = Modifier.width(48.dp).height(48.dp))
+        Spacer(Modifier.height(NuvioTokens.Space.s12))
+        Text("No IPTV provider yet", style = MaterialTheme.typography.titleMedium, color = MaterialTheme.colorScheme.onSurface)
+        Spacer(Modifier.height(NuvioTokens.Space.s6))
+        Text(
+            "Add an Xtream Codes account to browse Live TV, Movies and Series.",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(Modifier.height(NuvioTokens.Space.s16))
+        TextButton(onClick = onAddProvider) { Text("Add IPTV provider") }
+    }
+}
+
+@Composable
+private fun CenteredProgress() {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun CenteredMessage(text: String) {
+    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+        Text(text, color = MaterialTheme.colorScheme.onSurfaceVariant)
+    }
+}
+
+private val TABLET_TOP_BAR_INSET = 72.dp
+private val POSTER_WIDTH = 120.dp
+private val POSTER_HEIGHT = 180.dp
+private val CHANNEL_WIDTH = 160.dp
+private val CHANNEL_ROW_HEIGHT = 120.dp

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamItemRegistry.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamItemRegistry.kt
@@ -1,0 +1,145 @@
+package com.nuvio.app.features.iptv
+
+import com.nuvio.app.features.home.MetaPreview
+import com.nuvio.app.features.home.PosterShape
+import com.nuvio.app.features.streams.StreamItem
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+
+/**
+ * Maps a namespaced `xtream:{accountId}:{kind}:{id}` content id back to a directly
+ * playable stream + display metadata, so Xtream VOD/series/live ride Nuvio's native
+ * meta -> streams -> player pipeline with zero addon/debrid involvement. KMP twin of
+ * NuvioTV's XtreamItemRegistry.
+ *
+ * ID SCHEME GOTCHA: accountId is "$baseUrl|$user" and baseUrl carries "://" and an
+ * optional ":port" — so the id is riddled with colons. Never naive-split on ':'. Parse
+ * by taking the LAST two colon-delimited fields as kind+id and the remainder as accountId.
+ */
+object XtreamItemRegistry {
+
+    private val _items = MutableStateFlow<Map<String, XtreamResolvedItem>>(emptyMap())
+
+    fun isXtreamId(id: String?): Boolean = id != null && id.startsWith("$PREFIX:")
+
+    fun buildId(accountId: String, kind: String, id: String): String = "$PREFIX:$accountId:$kind:$id"
+
+    fun vodId(accountId: String, streamId: Int): String = buildId(accountId, XtreamKind.VOD.slug, streamId.toString())
+    fun seriesId(accountId: String, seriesId: Int): String = buildId(accountId, XtreamKind.SERIES.slug, seriesId.toString())
+    fun liveId(accountId: String, streamId: Int): String = buildId(accountId, XtreamKind.LIVE.slug, streamId.toString())
+    fun episodeId(accountId: String, episodeId: String): String = buildId(accountId, XtreamKind.EPISODE.slug, episodeId)
+
+    /**
+     * Splits an xtream content id into (accountId, kind, id). The last two ':'-delimited
+     * fields are kind+id; everything before is the accountId (which itself contains colons).
+     */
+    fun parseId(contentId: String): ParsedXtreamId? {
+        if (!isXtreamId(contentId)) return null
+        val rest = contentId.substring(PREFIX.length + 1)
+        val lastColon = rest.lastIndexOf(':')
+        if (lastColon <= 0) return null
+        val id = rest.substring(lastColon + 1)
+        val beforeId = rest.substring(0, lastColon)
+        val kindColon = beforeId.lastIndexOf(':')
+        if (kindColon <= 0) return null
+        val kind = beforeId.substring(kindColon + 1)
+        val accountId = beforeId.substring(0, kindColon)
+        if (accountId.isBlank() || kind.isBlank() || id.isBlank()) return null
+        return ParsedXtreamId(accountId = accountId, kind = XtreamKind.fromSlug(kind) ?: return null, id = id)
+    }
+
+    fun register(item: XtreamResolvedItem) {
+        _items.update { it + (item.contentId to item) }
+    }
+
+    fun registerMovie(accountId: String, movie: XtreamMovie) = register(
+        XtreamResolvedItem(vodId(accountId, movie.streamId), accountId, XtreamKind.VOD, movie.name, movie.streamUrl, movie.poster)
+    )
+
+    fun registerChannel(accountId: String, channel: XtreamChannel) = register(
+        XtreamResolvedItem(liveId(accountId, channel.streamId), accountId, XtreamKind.LIVE, channel.name, channel.streamUrl, channel.logo, streamType = "live")
+    )
+
+    fun registerSeries(accountId: String, series: XtreamSeriesItem) = register(
+        XtreamResolvedItem(seriesId(accountId, series.seriesId), accountId, XtreamKind.SERIES, series.name, null, series.poster)
+    )
+
+    fun get(contentId: String): XtreamResolvedItem? = _items.value[contentId]
+
+    fun isLiveId(contentId: String): Boolean = parseId(contentId)?.kind == XtreamKind.LIVE
+
+    /**
+     * Rebuilds a live channel's stream URL straight from its id (accountId + streamId), so a
+     * favorited channel plays from the Library after a fresh launch even when the in-memory
+     * registry is empty. Returns null if the account is gone or the id isn't a live id.
+     */
+    fun liveStreamUrlFor(contentId: String): String? {
+        val parsed = parseId(contentId) ?: return null
+        if (parsed.kind != XtreamKind.LIVE) return null
+        val streamId = parsed.id.toIntOrNull() ?: return null
+        val account = XtreamRepository.uiState.value.accounts.firstOrNull { it.id == parsed.accountId } ?: return null
+        return XtreamClient.liveStreamUrl(account, streamId)
+    }
+
+    fun accountNameFor(contentId: String): String? {
+        val accountId = parseId(contentId)?.accountId ?: return null
+        return XtreamRepository.uiState.value.accounts.firstOrNull { it.id == accountId }?.name
+    }
+
+    /** The single direct StreamItem for a playable id, or null (series containers aren't directly playable). */
+    fun streamItemFor(contentId: String): StreamItem? {
+        val item = get(contentId) ?: return null
+        val accountName = XtreamRepository.uiState.value.accounts.firstOrNull { it.id == item.accountId }?.name
+        return item.toStreamItem(accountName ?: "Xtream")
+    }
+
+    /** Clears everything — call on profile switch so accounts don't leak across profiles. */
+    fun resetForProfile() {
+        _items.value = emptyMap()
+    }
+
+    private const val PREFIX = "xtream"
+}
+
+data class ParsedXtreamId(val accountId: String, val kind: XtreamKind, val id: String)
+
+enum class XtreamKind(val slug: String) {
+    LIVE("live"), VOD("vod"), SERIES("series"), EPISODE("episode");
+
+    companion object {
+        fun fromSlug(slug: String): XtreamKind? = entries.firstOrNull { it.slug == slug }
+    }
+}
+
+data class XtreamResolvedItem(
+    val contentId: String,
+    val accountId: String,
+    val kind: XtreamKind,
+    val name: String,
+    /** Direct playback URL. Null for SERIES containers (you play their episodes, not the series). */
+    val streamUrl: String?,
+    val poster: String? = null,
+    val logo: String? = null,
+    /** "live" for channels — drives the libmpv engine override in the player. */
+    val streamType: String? = null,
+)
+
+fun XtreamResolvedItem.toStreamItem(accountName: String): StreamItem? {
+    val url = streamUrl ?: return null
+    return StreamItem(
+        name = "Direct",
+        title = name,
+        url = url,
+        addonName = accountName,
+        addonId = "xtream",
+        streamType = streamType,
+    )
+}
+
+fun XtreamResolvedItem.toMetaPreview(): MetaPreview = MetaPreview(
+    id = contentId,
+    type = if (kind == XtreamKind.SERIES) "series" else "movie",
+    name = name,
+    poster = poster ?: logo,
+    posterShape = if (kind == XtreamKind.LIVE) PosterShape.Landscape else PosterShape.Poster,
+)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamLiveRecents.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamLiveRecents.kt
@@ -1,0 +1,68 @@
+package com.nuvio.app.features.iptv
+
+import com.nuvio.app.features.home.MetaPreview
+import com.nuvio.app.features.home.PosterShape
+import com.nuvio.app.features.profiles.ProfileRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+@Serializable
+data class XtreamLiveRecent(
+    val contentId: String,
+    val name: String,
+    val logo: String?,
+)
+
+/**
+ * Recently-watched live channels, profile-scoped + persisted. Live playback records no watch
+ * progress (no duration), so this backs the "Live TV" row of Continue Watching. LRU, newest first.
+ */
+object XtreamLiveRecents {
+    private const val CAP = 20
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    private val _recents = MutableStateFlow<List<XtreamLiveRecent>>(emptyList())
+    val recents: StateFlow<List<XtreamLiveRecent>> = _recents.asStateFlow()
+
+    private var loaded = false
+    private var currentProfileId = 1
+
+    fun ensureLoaded() {
+        if (loaded) return
+        loaded = true
+        currentProfileId = ProfileRepository.activeProfileId
+        _recents.value = parse(XtreamAccountStorage.loadRecentsJson(currentProfileId))
+    }
+
+    fun record(contentId: String, name: String, logo: String?) {
+        ensureLoaded()
+        val entry = XtreamLiveRecent(contentId, name, logo)
+        val updated = (listOf(entry) + _recents.value.filterNot { it.contentId == contentId }).take(CAP)
+        _recents.value = updated
+        XtreamAccountStorage.saveRecentsJson(currentProfileId, json.encodeToString(updated))
+    }
+
+    /** Reload this profile's recents on a profile switch (the Home Live TV row observes them live). */
+    fun onProfileChanged(profileId: Int) {
+        loaded = true
+        currentProfileId = profileId
+        _recents.value = parse(XtreamAccountStorage.loadRecentsJson(profileId))
+    }
+
+    private fun parse(stored: String?): List<XtreamLiveRecent> {
+        if (stored.isNullOrBlank()) return emptyList()
+        return runCatching { json.decodeFromString<List<XtreamLiveRecent>>(stored) }.getOrDefault(emptyList())
+    }
+}
+
+fun XtreamLiveRecent.toMetaPreview(): MetaPreview = MetaPreview(
+    id = contentId,
+    type = "tv",
+    name = name,
+    poster = logo,
+    logo = logo,
+    posterShape = PosterShape.Landscape,
+)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamModels.kt
@@ -1,0 +1,207 @@
+package com.nuvio.app.features.iptv
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.JsonDecoder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.intOrNull
+
+/**
+ * Tolerates the same field arriving as a JSON number, a quoted string, or a bool —
+ * real Xtream panels are inconsistent (verified live: tmdb_id is "936075" on one
+ * server, 24831 on another). Twin of NuvioTV's FlexIntAdapter.
+ */
+object FlexIntSerializer : KSerializer<Int?> {
+    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("FlexInt", PrimitiveKind.INT)
+    override fun deserialize(decoder: Decoder): Int? {
+        val jd = decoder as? JsonDecoder ?: return decoder.decodeInt()
+        val prim = jd.decodeJsonElement() as? JsonPrimitive ?: return null
+        return if (prim.isString) prim.content.trim().toIntOrNull()
+        else prim.booleanOrNull?.let { if (it) 1 else 0 } ?: prim.intOrNull
+    }
+    override fun serialize(encoder: Encoder, value: Int?) { encoder.encodeInt(value ?: 0) }
+}
+
+/**
+ * Xtream Codes `player_api.php` response shapes (only fields we use) plus the
+ * domain models the UI consumes. KMP twin of NuvioTV's XtreamDto/XtreamClient.
+ *
+ * ponytail: ids that panels reliably send as ints are Int; category_id is String
+ * because it comes back quoted. If a panel sends category_id as a bare int,
+ * decode will fail here — switch it to a JsonElement-tolerant type then.
+ */
+
+// --- Wire DTOs (kotlinx.serialization) --------------------------------------
+
+@Serializable
+data class XtreamAccountDto(
+    @SerialName("user_info") val userInfo: XtreamUserInfoDto? = null,
+    @SerialName("server_info") val serverInfo: XtreamServerInfoDto? = null
+)
+
+@Serializable
+data class XtreamUserInfoDto(
+    @Serializable(with = FlexIntSerializer::class) val auth: Int? = null,
+    val status: String? = null,
+    @SerialName("exp_date") val expDate: String? = null,
+    @SerialName("max_connections") val maxConnections: String? = null,
+    @SerialName("active_cons") val activeCons: String? = null,
+    @SerialName("is_trial") val isTrial: String? = null
+)
+
+@Serializable
+data class XtreamServerInfoDto(
+    val url: String? = null,
+    val port: String? = null,
+    @SerialName("server_protocol") val serverProtocol: String? = null
+)
+
+@Serializable
+data class XtreamCategoryDto(
+    @SerialName("category_id") val categoryId: String? = null,
+    @SerialName("category_name") val categoryName: String? = null
+)
+
+@Serializable
+data class XtreamLiveStreamDto(
+    val name: String? = null,
+    @Serializable(with = FlexIntSerializer::class) @SerialName("stream_id") val streamId: Int? = null,
+    @SerialName("stream_icon") val streamIcon: String? = null,
+    @SerialName("epg_channel_id") val epgChannelId: String? = null,
+    @SerialName("category_id") val categoryId: String? = null,
+    @Serializable(with = FlexIntSerializer::class) @SerialName("tv_archive") val tvArchive: Int? = null
+)
+
+@Serializable
+data class XtreamVodStreamDto(
+    val name: String? = null,
+    @Serializable(with = FlexIntSerializer::class) @SerialName("stream_id") val streamId: Int? = null,
+    @SerialName("stream_icon") val streamIcon: String? = null,
+    @SerialName("category_id") val categoryId: String? = null,
+    @SerialName("container_extension") val containerExtension: String? = null,
+    val rating: String? = null
+)
+
+@Serializable
+data class XtreamSeriesDto(
+    @Serializable(with = FlexIntSerializer::class) @SerialName("series_id") val seriesId: Int? = null,
+    val name: String? = null,
+    val cover: String? = null,
+    @SerialName("category_id") val categoryId: String? = null,
+    val plot: String? = null,
+    val rating: String? = null
+)
+
+@Serializable
+data class XtreamShortEpgResponseDto(
+    @SerialName("epg_listings") val listings: List<XtreamEpgEntryDto>? = null
+)
+
+@Serializable
+data class XtreamEpgEntryDto(
+    val title: String? = null,            // base64
+    val description: String? = null,      // base64
+    @SerialName("start_timestamp") val startTimestamp: String? = null,
+    @SerialName("stop_timestamp") val stopTimestamp: String? = null,
+    @Serializable(with = FlexIntSerializer::class) @SerialName("now_playing") val nowPlaying: Int? = null
+)
+
+// --- Domain models ----------------------------------------------------------
+
+@Serializable
+data class XtreamAccount(
+    val id: String,
+    val name: String,
+    val baseUrl: String,      // http://host:port (no trailing slash, no path)
+    val username: String,
+    val password: String,
+    val enabled: Boolean = true
+)
+
+data class XtreamCategory(val id: String, val name: String)
+
+data class XtreamChannel(
+    val streamId: Int,
+    val name: String,
+    val logo: String?,
+    val epgChannelId: String?,
+    val categoryId: String?,
+    val hasArchive: Boolean,
+    val streamUrl: String
+)
+
+data class XtreamMovie(
+    val streamId: Int,
+    val name: String,
+    val poster: String?,
+    val categoryId: String?,
+    val rating: String?,
+    val streamUrl: String
+)
+
+data class XtreamSeriesItem(
+    val seriesId: Int,
+    val name: String,
+    val poster: String?,
+    val categoryId: String?,
+    val plot: String?,
+    val rating: String?
+)
+
+data class XtreamProgram(
+    val title: String,
+    val description: String,
+    val startMs: Long,
+    val endMs: Long,
+    val nowPlaying: Boolean
+)
+
+data class XtreamAccountInfo(
+    val status: String?,
+    val isTrial: Boolean,
+    val expiresAtEpochSec: Long?,
+    val maxConnections: Int?,
+    val activeConnections: Int?
+)
+
+// get_vod_info + get_series_info are parsed by hand in XtreamClient (panels send `info` as
+// object-or-[] inconsistently), so no strict *_info DTOs live here.
+
+// --- detail domain models ---------------------------------------------------
+
+data class XtreamVodDetail(
+    val name: String?,
+    val plot: String?,
+    val genres: List<String>,
+    val rating: String?,
+    val releaseDate: String?,
+    val tmdbId: Int?,
+    val containerExtension: String?
+)
+
+data class XtreamSeriesDetail(
+    val name: String?,
+    val poster: String?,
+    val tmdbId: Int?,
+    val plot: String?,
+    val genres: List<String>,
+    val rating: String?,
+    val episodes: List<XtreamEpisode>
+)
+
+data class XtreamEpisode(
+    val episodeId: String,
+    val season: Int,
+    val episodeNum: Int,
+    val title: String,
+    val plot: String?,
+    val still: String?,
+    val containerExtension: String?
+)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamRepository.kt
@@ -1,0 +1,109 @@
+package com.nuvio.app.features.iptv
+
+import com.nuvio.app.features.profiles.ProfileRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+data class XtreamUiState(
+    val accounts: List<XtreamAccount> = emptyList(),
+    val isValidating: Boolean = false,
+    val error: String? = null
+)
+
+/**
+ * Xtream IPTV accounts, persisted locally per profile. Object-singleton with a
+ * MutableStateFlow, mirroring AddonRepository / DebridSettingsRepository. KMP twin of
+ * NuvioTV's XtreamAccountStore + XtreamSettingsViewModel.
+ */
+object XtreamRepository {
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    private val _uiState = MutableStateFlow(XtreamUiState())
+    val uiState: StateFlow<XtreamUiState> = _uiState.asStateFlow()
+
+    private var loaded = false
+    private var currentProfileId = 1
+
+    fun ensureLoaded() {
+        if (loaded) return
+        loaded = true
+        currentProfileId = ProfileRepository.activeProfileId
+        _uiState.update { it.copy(accounts = parse(XtreamAccountStorage.loadAccountsJson(currentProfileId))) }
+    }
+
+    /** Reload this profile's accounts on a profile switch so no data leaks across profiles. */
+    fun onProfileChanged(profileId: Int) {
+        loaded = true
+        currentProfileId = profileId
+        _uiState.value = XtreamUiState(accounts = parse(XtreamAccountStorage.loadAccountsJson(profileId)))
+    }
+
+    /** Parse a pasted portal/M3U URL, verify the credentials live, then persist. */
+    fun addFromUrl(input: String, name: String?, onResult: (Boolean) -> Unit) {
+        verifyAndSave(parseXtreamAccount(input, name), "Couldn't read a username & password from that URL", onResult)
+    }
+
+    /** Add from manually-entered server URL + username + password. */
+    fun addManual(serverUrl: String, username: String, password: String, name: String?, onResult: (Boolean) -> Unit) {
+        verifyAndSave(
+            xtreamAccountFromFields(serverUrl, username, password, name),
+            "Enter a server URL, username and password",
+            onResult
+        )
+    }
+
+    private fun verifyAndSave(account: XtreamAccount?, parseError: String, onResult: (Boolean) -> Unit) {
+        if (account == null) {
+            _uiState.update { it.copy(error = parseError) }
+            onResult(false)
+            return
+        }
+        scope.launch {
+            _uiState.update { it.copy(isValidating = true, error = null) }
+            XtreamClient.verify(account)
+                .onSuccess {
+                    val updated = _uiState.value.accounts.filterNot { it.id == account.id } + account
+                    _uiState.update { it.copy(accounts = updated, isValidating = false) }
+                    persist()
+                    onResult(true)
+                }
+                .onFailure { e ->
+                    _uiState.update { it.copy(isValidating = false, error = e.message ?: "Could not reach the panel") }
+                    onResult(false)
+                }
+        }
+    }
+
+    fun setEnabled(id: String, enabled: Boolean) {
+        _uiState.update { state ->
+            state.copy(accounts = state.accounts.map { if (it.id == id) it.copy(enabled = enabled) else it })
+        }
+        persist()
+    }
+
+    fun remove(id: String) {
+        _uiState.update { it.copy(accounts = it.accounts.filterNot { acc -> acc.id == id }) }
+        persist()
+    }
+
+    fun clearError() = _uiState.update { it.copy(error = null) }
+
+    private fun persist() {
+        XtreamAccountStorage.saveAccountsJson(currentProfileId, json.encodeToString(_uiState.value.accounts))
+    }
+
+    private fun parse(stored: String?): List<XtreamAccount> {
+        if (stored.isNullOrBlank()) return emptyList()
+        return runCatching { json.decodeFromString<List<XtreamAccount>>(stored) }.getOrDefault(emptyList())
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamSearchIndex.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamSearchIndex.kt
@@ -1,0 +1,116 @@
+package com.nuvio.app.features.iptv
+
+import com.nuvio.app.features.catalog.CatalogTarget
+import com.nuvio.app.features.home.HomeCatalogSection
+import com.nuvio.app.features.home.MetaPreview
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+/**
+ * Xtream has no search API, so we pull each enabled account's full live/series/VOD lists once,
+ * cache them, and substring-filter in memory. Live + series are fetched on the first search
+ * (smaller); the VOD list (often 50k+) loads in the BACKGROUND so channels/series results show
+ * immediately and movies fill in on a later keystroke — matching NuvioTV's index.
+ *
+ * ponytail: whole lists cached in RAM; fine for a handful of accounts. Cap/stream if it grows.
+ */
+object XtreamSearchIndex {
+    private data class AccountLists(
+        val channels: List<XtreamChannel> = emptyList(),
+        val series: List<XtreamSeriesItem> = emptyList(),
+        val movies: List<XtreamMovie> = emptyList(),
+    )
+
+    private val cache = mutableMapOf<String, AccountLists>()
+    private val coreJobs = mutableMapOf<String, Deferred<*>>()
+    private val mutex = Mutex()
+    private val bgScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private const val PER_TYPE_CAP = 30
+
+    suspend fun search(query: String): List<HomeCatalogSection> {
+        val q = query.trim()
+        if (q.length < 2) return emptyList()
+        XtreamRepository.ensureLoaded()
+        val accounts = XtreamRepository.uiState.value.accounts.filter { it.enabled }
+        if (accounts.isEmpty()) return emptyList()
+
+        val channels = mutableListOf<MetaPreview>()
+        val series = mutableListOf<MetaPreview>()
+        val movies = mutableListOf<MetaPreview>()
+        for (account in accounts) {
+            val lists = ensureLists(account)
+            lists.channels.asSequence().filter { it.name.contains(q, ignoreCase = true) }.take(PER_TYPE_CAP).forEach {
+                XtreamItemRegistry.registerChannel(account.id, it); channels += it.toMetaPreview(account.id)
+            }
+            lists.series.asSequence().filter { it.name.contains(q, ignoreCase = true) }.take(PER_TYPE_CAP).forEach {
+                XtreamItemRegistry.registerSeries(account.id, it); series += it.toMetaPreview(account.id)
+            }
+            lists.movies.asSequence().filter { it.name.contains(q, ignoreCase = true) }.take(PER_TYPE_CAP).forEach {
+                XtreamItemRegistry.registerMovie(account.id, it); movies += it.toMetaPreview(account.id)
+            }
+        }
+        return listOfNotNull(
+            section("xtream_channels", "IPTV Channels", "tv", channels),
+            section("xtream_movies", "IPTV Movies", "movie", movies),
+            section("xtream_series", "IPTV Series", "series", series),
+        )
+    }
+
+    private fun section(key: String, title: String, type: String, items: List<MetaPreview>): HomeCatalogSection? {
+        if (items.isEmpty()) return null
+        return HomeCatalogSection(
+            key = key,
+            title = title,
+            subtitle = "IPTV",
+            addonName = "IPTV",
+            target = CatalogTarget.Library(contentType = type, sectionType = "xtream"),
+            items = items,
+            availableItemCount = items.size,
+            hasMore = false,
+        )
+    }
+
+    /**
+     * Fetch channels + series (in parallel) once per account, in [bgScope] so a keystroke that
+     * cancels the search job can't abort the fetch — otherwise fast typing starves the huge live/
+     * series lists while VOD (already backgrounded) fills in, which looks like "only movies work".
+     */
+    private suspend fun ensureLists(account: XtreamAccount): AccountLists {
+        val job = mutex.withLock {
+            coreJobs.getOrPut(account.id) {
+                bgScope.async {
+                    val channelsD = async { XtreamClient.liveChannels(account) }
+                    val seriesD = async { XtreamClient.series(account) }
+                    val channelsResult = channelsD.await()
+                    val seriesResult = seriesD.await()
+                    mutex.withLock {
+                        cache[account.id] = AccountLists(
+                            channels = channelsResult.getOrDefault(emptyList()),
+                            series = seriesResult.getOrDefault(emptyList()),
+                            movies = cache[account.id]?.movies ?: emptyList(),
+                        )
+                    }
+                    bgScope.launch {
+                        val movies = XtreamClient.vodMovies(account).getOrDefault(emptyList())
+                        mutex.withLock {
+                            cache[account.id] = (cache[account.id] ?: AccountLists()).copy(movies = movies)
+                        }
+                    }
+                }
+            }
+        }
+        job.await()
+        return cache[account.id] ?: AccountLists()
+    }
+
+    fun resetForProfile() {
+        cache.clear()
+        coreJobs.clear()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamSettingsPage.kt
@@ -1,0 +1,266 @@
+package com.nuvio.app.features.iptv
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import com.nuvio.app.features.settings.SettingsGroup
+import com.nuvio.app.features.settings.SettingsGroupDivider
+import com.nuvio.app.features.settings.SettingsNavigationRow
+import com.nuvio.app.features.settings.SettingsSection
+
+/**
+ * Xtream IPTV accounts page. Single paste field: the user pastes a portal/M3U URL,
+ * we verify it live, then save. KMP twin of NuvioTV's XtreamSettingsScreen.
+ */
+internal fun LazyListScope.xtreamSettingsContent(
+    isTablet: Boolean,
+    state: XtreamUiState,
+) {
+    item {
+        var showAddDialog by remember { mutableStateOf(false) }
+        var actionsFor by remember { mutableStateOf<XtreamAccount?>(null) }
+
+        SettingsSection(title = "IPTV (Xtream Codes)", isTablet = isTablet) {
+            SettingsGroup(isTablet = isTablet) {
+                SettingsNavigationRow(
+                    title = "Add IPTV account",
+                    description = "Paste your portal or M3U URL",
+                    isTablet = isTablet,
+                    onClick = { showAddDialog = true },
+                )
+                state.accounts.forEach { account ->
+                    SettingsGroupDivider(isTablet = isTablet)
+                    SettingsNavigationRow(
+                        title = account.name,
+                        description = account.baseUrl + if (account.enabled) "" else "  •  disabled",
+                        isTablet = isTablet,
+                        onClick = { actionsFor = account },
+                    )
+                }
+            }
+        }
+
+        if (showAddDialog) {
+            XtreamAddDialog(
+                state = state,
+                onSubmitUrl = { url -> XtreamRepository.addFromUrl(url, name = null) { ok -> if (ok) showAddDialog = false } },
+                onSubmitManual = { server, user, pass, name ->
+                    XtreamRepository.addManual(server, user, pass, name) { ok -> if (ok) showAddDialog = false }
+                },
+                onDismiss = {
+                    XtreamRepository.clearError()
+                    showAddDialog = false
+                },
+            )
+        }
+
+        actionsFor?.let { account ->
+            AlertDialog(
+                onDismissRequest = { actionsFor = null },
+                title = { Text(account.name) },
+                text = { XtreamAccountDetails(account) },
+                confirmButton = {
+                    TextButton(onClick = {
+                        XtreamRepository.setEnabled(account.id, !account.enabled)
+                        actionsFor = null
+                    }) { Text(if (account.enabled) "Disable" else "Enable") }
+                },
+                dismissButton = {
+                    TextButton(onClick = {
+                        XtreamRepository.remove(account.id)
+                        actionsFor = null
+                    }) { Text("Remove") }
+                },
+            )
+        }
+    }
+}
+
+/** Live account status pulled from player_api user_info: state, connections, and expiry. */
+@Composable
+private fun XtreamAccountDetails(account: XtreamAccount) {
+    var info by remember(account.id) { mutableStateOf<XtreamAccountInfo?>(null) }
+    var loading by remember(account.id) { mutableStateOf(true) }
+    LaunchedEffect(account.id) {
+        loading = true
+        info = XtreamClient.accountInfo(account).getOrNull()
+        loading = false
+    }
+    Column {
+        Text(account.baseUrl, style = MaterialTheme.typography.bodyMedium)
+        Spacer(Modifier.height(8.dp))
+        val i = info
+        when {
+            loading -> Text("Loading account details…", style = MaterialTheme.typography.bodySmall)
+            i == null -> Text("Couldn't reach the panel for account details.", style = MaterialTheme.typography.bodySmall)
+            else -> {
+                val statusLabel = (i.status?.replaceFirstChar { it.uppercase() } ?: "Unknown") + if (i.isTrial) " · Trial" else ""
+                AccountDetailLine("Status", statusLabel)
+                if (i.maxConnections != null) {
+                    AccountDetailLine("Connections", "${i.activeConnections ?: 0} / ${i.maxConnections} active")
+                }
+                i.expiresAtEpochSec?.let { sec ->
+                    AccountDetailLine("Expires", if (sec == 0L) "Never" else formatEpochDate(sec))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AccountDetailLine(label: String, value: String) {
+    Spacer(Modifier.height(2.dp))
+    Text(
+        text = "$label: $value",
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurface,
+    )
+}
+
+/** Epoch seconds -> "YYYY-MM-DD" without a date library (Hinnant's days->civil algorithm). */
+private fun formatEpochDate(epochSec: Long): String {
+    val z = epochSec / 86400L + 719468L
+    val era = (if (z >= 0) z else z - 146096) / 146097
+    val doe = z - era * 146097
+    val yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365
+    val y = yoe + era * 400
+    val doy = doe - (365 * yoe + yoe / 4 - yoe / 100)
+    val mp = (5 * doy + 2) / 153
+    val d = doy - (153 * mp + 2) / 5 + 1
+    val m = if (mp < 10) mp + 3 else mp - 9
+    val year = if (m <= 2) y + 1 else y
+    return "$year-${m.toString().padStart(2, '0')}-${d.toString().padStart(2, '0')}"
+}
+
+@Composable
+private fun XtreamAddDialog(
+    state: XtreamUiState,
+    onSubmitUrl: (String) -> Unit,
+    onSubmitManual: (server: String, user: String, pass: String, name: String?) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var manualMode by remember { mutableStateOf(false) }
+    var url by remember { mutableStateOf("") }
+    var server by remember { mutableStateOf("") }
+    var user by remember { mutableStateOf("") }
+    var pass by remember { mutableStateOf("") }
+    var name by remember { mutableStateOf("") }
+
+    val canSubmit = if (manualMode) {
+        server.isNotBlank() && user.isNotBlank() && pass.isNotBlank()
+    } else {
+        url.isNotBlank()
+    }
+    val submit = {
+        if (canSubmit && !state.isValidating) {
+            if (manualMode) onSubmitManual(server.trim(), user.trim(), pass.trim(), name.trim().ifEmpty { null })
+            else onSubmitUrl(url.trim())
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Add IPTV account") },
+        text = {
+            Column {
+                // mode toggle
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                    FilterChip(
+                        selected = !manualMode,
+                        onClick = { manualMode = false },
+                        label = { Text("Paste link") },
+                    )
+                    FilterChip(
+                        selected = manualMode,
+                        onClick = { manualMode = true },
+                        label = { Text("Enter details") },
+                    )
+                }
+                Spacer(Modifier.height(12.dp))
+
+                if (manualMode) {
+                    OutlinedTextField(
+                        value = server, onValueChange = { server = it },
+                        modifier = Modifier.fillMaxWidth(), singleLine = true,
+                        label = { Text("Server URL") },
+                        placeholder = { Text("http://host:port") },
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = user, onValueChange = { user = it },
+                        modifier = Modifier.fillMaxWidth(), singleLine = true,
+                        label = { Text("Username") },
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = pass, onValueChange = { pass = it },
+                        modifier = Modifier.fillMaxWidth(), singleLine = true,
+                        label = { Text("Password") },
+                        visualTransformation = PasswordVisualTransformation(),
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = name, onValueChange = { name = it },
+                        modifier = Modifier.fillMaxWidth(), singleLine = true,
+                        label = { Text("Name (optional)") },
+                    )
+                } else {
+                    Text(
+                        text = "Paste your portal or M3U URL — it contains your username & password.",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                    Spacer(Modifier.height(8.dp))
+                    OutlinedTextField(
+                        value = url, onValueChange = { url = it },
+                        modifier = Modifier.fillMaxWidth(), singleLine = true,
+                        placeholder = { Text("http://host:port/get.php?username=…&password=…") },
+                    )
+                }
+
+                state.error?.let { err ->
+                    Spacer(Modifier.height(8.dp))
+                    Text(
+                        text = err,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.error,
+                    )
+                }
+            }
+        },
+        confirmButton = {
+            Button(onClick = submit, enabled = canSubmit && !state.isValidating) {
+                Text(if (state.isValidating) "Verifying…" else "Add")
+                if (state.isValidating) {
+                    Spacer(Modifier.width(8.dp))
+                    CircularProgressIndicator(modifier = Modifier.size(16.dp), strokeWidth = 2.dp)
+                }
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamUrlParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/iptv/XtreamUrlParser.kt
@@ -1,0 +1,63 @@
+package com.nuvio.app.features.iptv
+
+import io.ktor.http.Url
+
+/**
+ * Turns a pasted portal/M3U URL into an [XtreamAccount]. KMP twin of NuvioTV's
+ * XtreamUrlParser (uses Ktor's Url instead of okhttp HttpUrl). Accepts any of:
+ *   http://host:port/get.php?username=U&password=P&type=m3u_plus&output=ts
+ *   http://host:port/player_api.php?username=U&password=P
+ * The path is ignored; only scheme+host+port and the username/password query params matter.
+ */
+fun parseXtreamAccount(input: String, name: String? = null): XtreamAccount? {
+    val url = try {
+        Url(input.trim())
+    } catch (e: Exception) {
+        return null
+    }
+    if (url.host.isBlank()) return null
+    val user = url.parameters["username"]?.takeIf { it.isNotBlank() } ?: return null
+    val pass = url.parameters["password"]?.takeIf { it.isNotBlank() } ?: return null
+    val base = buildString {
+        append(url.protocol.name).append("://").append(url.host)
+        if (url.port != url.protocol.defaultPort) append(":").append(url.port)
+    }
+    return XtreamAccount(
+        id = "$base|$user",
+        name = name?.trim()?.takeIf { it.isNotEmpty() } ?: url.host,
+        baseUrl = base,
+        username = user,
+        password = pass
+    )
+}
+
+/**
+ * Builds an account from manually-entered fields. The server field may be "host", "host:port",
+ * or a full URL; only scheme+host+port are kept. Defaults to http when no scheme is given.
+ * KMP twin of NuvioTV's xtreamAccountFromFields.
+ */
+fun xtreamAccountFromFields(serverUrl: String, username: String, password: String, name: String? = null): XtreamAccount? {
+    val user = username.trim()
+    val pass = password.trim()
+    if (user.isEmpty() || pass.isEmpty()) return null
+    val raw = serverUrl.trim()
+    if (raw.isEmpty()) return null
+    val withScheme = if (raw.startsWith("http://") || raw.startsWith("https://")) raw else "http://$raw"
+    val url = try {
+        Url(withScheme)
+    } catch (e: Exception) {
+        return null
+    }
+    if (url.host.isBlank()) return null
+    val base = buildString {
+        append(url.protocol.name).append("://").append(url.host)
+        if (url.port != url.protocol.defaultPort) append(":").append(url.port)
+    }
+    return XtreamAccount(
+        id = "$base|$user",
+        name = name?.trim()?.takeIf { it.isNotEmpty() } ?: url.host,
+        baseUrl = base,
+        username = user,
+        password = pass
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSubtitleCueParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSubtitleCueParser.kt
@@ -129,7 +129,8 @@ object PlayerSubtitleCueParser {
     }
 
     private fun parseTtml(text: String): List<SubtitleSyncCue> =
-        Regex("""<p\b([^>]*)>(.*?)</p>""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+        // (?s) = dotall so . spans newlines; RegexOption.DOT_MATCHES_ALL is JVM-only (breaks Kotlin/Native/iOS).
+        Regex("""(?s)<p\b([^>]*)>(.*?)</p>""", RegexOption.IGNORE_CASE)
             .findAll(text)
             .mapNotNull { match ->
                 val attrs = match.groupValues[1]

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/profiles/ProfileRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/profiles/ProfileRepository.kt
@@ -159,6 +159,12 @@ object ProfileRepository {
         if (com.nuvio.app.core.build.AppFeaturePolicy.pluginsEnabled) {
             PluginRepository.onProfileChanged(profileIndex)
         }
+        // IPTV: reload accounts + recents for the new profile, drop cross-profile caches.
+        com.nuvio.app.features.iptv.XtreamRepository.onProfileChanged(profileIndex)
+        com.nuvio.app.features.iptv.XtreamLiveRecents.onProfileChanged(profileIndex)
+        com.nuvio.app.features.iptv.XtreamItemRegistry.resetForProfile()
+        com.nuvio.app.features.iptv.XtreamHubRepository.resetForProfile()
+        com.nuvio.app.features.iptv.XtreamSearchIndex.resetForProfile()
         ThemeSettingsRepository.onProfileChanged()
         PosterCardStyleRepository.onProfileChanged()
         PlayerSettingsRepository.onProfileChanged()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/search/SearchRepository.kt
@@ -20,7 +20,10 @@ import com.nuvio.app.features.home.MetaPreview
 import com.nuvio.app.features.home.filterReleasedItems
 import com.nuvio.app.features.watchprogress.CurrentDateProvider
 import kotlinx.coroutines.CancellationException
+import com.nuvio.app.features.iptv.XtreamRepository
+import com.nuvio.app.features.iptv.XtreamSearchIndex
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -54,25 +57,25 @@ object SearchRepository {
             return
         }
 
-        val activeAddons = addons.enabledAddons().filter { it.manifest != null }
-        if (activeAddons.isEmpty()) {
-            activeJob?.cancel()
-            lastRequestKey = null
-            _uiState.value = SearchUiState(
-                emptyStateReason = SearchEmptyStateReason.NoActiveAddons,
-            )
-            return
-        }
+        XtreamRepository.ensureLoaded()
+        val xtreamEnabled = XtreamRepository.uiState.value.accounts.any { it.enabled }
 
-        val requests = buildSearchRequests(
-            addons = activeAddons,
-            query = normalizedQuery,
-        )
-        if (requests.isEmpty()) {
+        val activeAddons = addons.enabledAddons().filter { it.manifest != null }
+        val requests = if (activeAddons.isEmpty()) {
+            emptyList()
+        } else {
+            buildSearchRequests(addons = activeAddons, query = normalizedQuery)
+        }
+        // Xtream can carry search on its own (the dev build often has no addons installed).
+        if (requests.isEmpty() && !xtreamEnabled) {
             activeJob?.cancel()
             lastRequestKey = null
             _uiState.value = SearchUiState(
-                emptyStateReason = SearchEmptyStateReason.NoSearchCatalogs,
+                emptyStateReason = if (activeAddons.isEmpty()) {
+                    SearchEmptyStateReason.NoActiveAddons
+                } else {
+                    SearchEmptyStateReason.NoSearchCatalogs
+                },
             )
             return
         }
@@ -81,6 +84,8 @@ object SearchRepository {
             append(normalizedQuery.lowercase())
             append('|')
             append(HomeCatalogSettingsRepository.snapshot().hideUnreleasedContent)
+            append('|')
+            append("xtream=$xtreamEnabled")
             append('|')
             append(
                 requests.joinToString(separator = "|") { request ->
@@ -95,6 +100,13 @@ object SearchRepository {
         _uiState.value = SearchUiState(isLoading = true)
 
         activeJob = scope.launch {
+            val xtreamDeferred = async {
+                if (xtreamEnabled) {
+                    runCatching { XtreamSearchIndex.search(normalizedQuery) }.getOrDefault(emptyList())
+                } else {
+                    emptyList()
+                }
+            }
             val resultChannel = Channel<IndexedSearchResult>(Channel.UNLIMITED)
             val jobs = requests.mapIndexed { index, request ->
                 launch {
@@ -143,19 +155,21 @@ object SearchRepository {
             }
 
             val completedResults = results.filterNotNull()
-            val sections = results.orderedSections()
+            val addonSections = results.orderedSections()
+            val xtreamSections = xtreamDeferred.await()
+            val sections = addonSections + xtreamSections
             val firstFailure = completedResults.firstNotNullOfOrNull { it.error?.message }
-            val allFailed = completedResults.isNotEmpty() && completedResults.all { it.error != null }
+            val allAddonsFailed = completedResults.isNotEmpty() && completedResults.all { it.error != null }
 
             _uiState.value = SearchUiState(
                 isLoading = false,
                 sections = sections,
                 emptyStateReason = when {
                     sections.isNotEmpty() -> null
-                    allFailed -> SearchEmptyStateReason.RequestFailed
+                    allAddonsFailed -> SearchEmptyStateReason.RequestFailed
                     else -> SearchEmptyStateReason.NoResults
                 },
-                errorMessage = if (allFailed) firstFailure else null,
+                errorMessage = if (allAddonsFailed && xtreamSections.isEmpty()) firstFailure else null,
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/IntegrationsSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/IntegrationsSettingsPage.kt
@@ -2,6 +2,7 @@ package com.nuvio.app.features.settings
 
 import androidx.compose.foundation.lazy.LazyListScope
 import nuvio.composeapp.generated.resources.compose_settings_page_debrid
+import nuvio.composeapp.generated.resources.compose_settings_page_iptv
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.compose_settings_page_mdblist_ratings
 import nuvio.composeapp.generated.resources.compose_settings_page_tmdb_enrichment
@@ -16,6 +17,7 @@ internal fun LazyListScope.integrationsContent(
     onTmdbClick: () -> Unit,
     onMdbListClick: () -> Unit,
     onDebridClick: () -> Unit,
+    onIptvClick: () -> Unit,
 ) {
     item {
         SettingsSection(
@@ -44,6 +46,13 @@ internal fun LazyListScope.integrationsContent(
                     description = stringResource(Res.string.settings_integrations_debrid_description),
                     isTablet = isTablet,
                     onClick = onDebridClick,
+                )
+                SettingsGroupDivider(isTablet = isTablet)
+                SettingsNavigationRow(
+                    title = stringResource(Res.string.compose_settings_page_iptv),
+                    description = "Live TV, movies & series from an Xtream provider",
+                    isTablet = isTablet,
+                    onClick = onIptvClick,
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsModels.kt
@@ -16,6 +16,7 @@ import nuvio.composeapp.generated.resources.compose_settings_page_advanced
 import nuvio.composeapp.generated.resources.compose_settings_page_appearance
 import nuvio.composeapp.generated.resources.compose_settings_page_content_discovery
 import nuvio.composeapp.generated.resources.compose_settings_page_debrid
+import nuvio.composeapp.generated.resources.compose_settings_page_iptv
 import nuvio.composeapp.generated.resources.compose_settings_page_continue_watching
 import nuvio.composeapp.generated.resources.compose_settings_page_homescreen
 import nuvio.composeapp.generated.resources.compose_settings_page_integrations
@@ -146,6 +147,11 @@ internal enum class SettingsPage(
     ),
     Debrid(
         titleRes = Res.string.compose_settings_page_debrid,
+        category = SettingsCategory.General,
+        parentPage = Integrations,
+    ),
+    Iptv(
+        titleRes = Res.string.compose_settings_page_iptv,
         category = SettingsCategory.General,
         parentPage = Integrations,
     ),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
@@ -46,6 +46,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.nuvio.app.features.iptv.XtreamRepository
+import com.nuvio.app.features.iptv.XtreamUiState
+import com.nuvio.app.features.iptv.xtreamSettingsContent
 import com.nuvio.app.core.ui.AppTheme
 import com.nuvio.app.core.ui.LocalNuvioBottomNavigationOverlayPadding
 import com.nuvio.app.core.ui.NuvioScreen
@@ -148,6 +151,10 @@ fun SettingsScreen(
         val debridSettings by remember {
             DebridSettingsRepository.ensureLoaded()
             DebridSettingsRepository.uiState
+        }.collectAsStateWithLifecycle()
+        val xtreamState by remember {
+            XtreamRepository.ensureLoaded()
+            XtreamRepository.uiState
         }.collectAsStateWithLifecycle()
         val traktAuthUiState by remember {
             TraktAuthRepository.ensureLoaded()
@@ -302,6 +309,7 @@ fun SettingsScreen(
                 tmdbSettings = tmdbSettings,
                 mdbListSettings = mdbListSettings,
                 debridSettings = debridSettings,
+                xtreamState = xtreamState,
                 traktAuthUiState = traktAuthUiState,
                 traktCommentsEnabled = traktCommentsEnabled,
                 traktSettingsUiState = traktSettingsUiState,
@@ -357,6 +365,7 @@ fun SettingsScreen(
                 tmdbSettings = tmdbSettings,
                 mdbListSettings = mdbListSettings,
                 debridSettings = debridSettings,
+                xtreamState = xtreamState,
                 traktAuthUiState = traktAuthUiState,
                 traktCommentsEnabled = traktCommentsEnabled,
                 traktSettingsUiState = traktSettingsUiState,
@@ -422,6 +431,7 @@ private fun MobileSettingsScreen(
     tmdbSettings: TmdbSettings,
     mdbListSettings: MdbListSettings,
     debridSettings: DebridSettings,
+    xtreamState: XtreamUiState,
     traktAuthUiState: TraktAuthUiState,
     traktCommentsEnabled: Boolean,
     traktSettingsUiState: TraktSettingsUiState,
@@ -661,6 +671,7 @@ private fun MobileSettingsScreen(
                     onTmdbClick = { onPageChange(SettingsPage.TmdbEnrichment) },
                     onMdbListClick = { onPageChange(SettingsPage.MdbListRatings) },
                     onDebridClick = { onPageChange(SettingsPage.Debrid) },
+                    onIptvClick = { onPageChange(SettingsPage.Iptv) },
                 )
                 SettingsPage.TmdbEnrichment -> tmdbSettingsContent(
                     isTablet = false,
@@ -673,6 +684,10 @@ private fun MobileSettingsScreen(
                 SettingsPage.Debrid -> debridSettingsContent(
                     isTablet = false,
                     settings = debridSettings,
+                )
+                SettingsPage.Iptv -> xtreamSettingsContent(
+                    isTablet = false,
+                    state = xtreamState,
                 )
                 SettingsPage.TraktAuthentication -> traktSettingsContent(
                     isTablet = false,
@@ -766,6 +781,7 @@ private fun TabletSettingsScreen(
     tmdbSettings: TmdbSettings,
     mdbListSettings: MdbListSettings,
     debridSettings: DebridSettings,
+    xtreamState: XtreamUiState,
     traktAuthUiState: TraktAuthUiState,
     traktCommentsEnabled: Boolean,
     traktSettingsUiState: TraktSettingsUiState,
@@ -1063,6 +1079,7 @@ private fun TabletSettingsScreen(
                         onTmdbClick = { onPageChange(SettingsPage.TmdbEnrichment) },
                         onMdbListClick = { onPageChange(SettingsPage.MdbListRatings) },
                         onDebridClick = { onPageChange(SettingsPage.Debrid) },
+                        onIptvClick = { onPageChange(SettingsPage.Iptv) },
                     )
                     SettingsPage.TmdbEnrichment -> tmdbSettingsContent(
                         isTablet = true,
@@ -1075,6 +1092,10 @@ private fun TabletSettingsScreen(
                     SettingsPage.Debrid -> debridSettingsContent(
                         isTablet = true,
                         settings = debridSettings,
+                    )
+                    SettingsPage.Iptv -> xtreamSettingsContent(
+                        isTablet = true,
+                        state = xtreamState,
                     )
                     SettingsPage.TraktAuthentication -> traktSettingsContent(
                         isTablet = true,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
@@ -11,6 +11,7 @@ import com.nuvio.app.features.debrid.DebridSettingsRepository
 import com.nuvio.app.features.debrid.DebridStreamPresentation
 import com.nuvio.app.features.debrid.LocalDebridAvailabilityService
 import com.nuvio.app.features.details.MetaDetailsRepository
+import com.nuvio.app.features.iptv.XtreamItemRegistry
 import com.nuvio.app.features.player.PlayerSettingsRepository
 import com.nuvio.app.features.plugins.PluginRepository
 import com.nuvio.app.features.plugins.pluginContentId
@@ -151,6 +152,39 @@ object StreamsRepository {
                 activeAddonIds = setOf("embedded"),
                 isAnyLoading = false,
             )
+            return
+        }
+
+        // Xtream IPTV: a namespaced id resolves to one direct stream — no addons/debrid.
+        // (Series episodes are already handled by embedded streams above; this covers VOD
+        // movies, which have no videos, and any registered live channel.)
+        if (XtreamItemRegistry.isXtreamId(videoId)) {
+            val xtreamStream = XtreamItemRegistry.streamItemFor(videoId)
+            if (xtreamStream != null) {
+                val group = AddonStreamGroup(
+                    addonName = xtreamStream.addonName,
+                    addonId = "xtream",
+                    streams = listOf(xtreamStream),
+                    isLoading = false,
+                )
+                val presentedGroup = StreamBadgePresentation.apply(
+                    groups = listOf(group),
+                    rules = streamBadgeRules,
+                ).firstOrNull() ?: group
+                _uiState.value = StreamsUiState(
+                    requestToken = requestToken,
+                    groups = listOf(presentedGroup),
+                    activeAddonIds = setOf("xtream"),
+                    isAnyLoading = false,
+                )
+            } else {
+                log.w { "Xtream stream short-circuit: no registered item for id=$videoId" }
+                _uiState.value = StreamsUiState(
+                    requestToken = requestToken,
+                    isAnyLoading = false,
+                    emptyStateReason = StreamsEmptyStateReason.NoStreamsFound,
+                )
+            }
             return
         }
 

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/iptv/XtreamClientTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/iptv/XtreamClientTest.kt
@@ -1,0 +1,82 @@
+package com.nuvio.app.features.iptv
+
+import io.ktor.util.encodeBase64
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class XtreamClientTest {
+
+    @Test
+    fun decodeBase64DecodesAndPassesThroughGarbage() {
+        val enc = "News at Ten".encodeToByteArray().encodeBase64()
+        assertEquals("News at Ten", decodeXtreamBase64(enc))
+        assertEquals("", decodeXtreamBase64(null))
+        assertEquals("", decodeXtreamBase64("   "))
+    }
+
+    @Test
+    fun flexIntToleratesIntStringAndBoolAcrossPanels() {
+        val json = Json { ignoreUnknownKeys = true }
+        // panel A: ints
+        val a = json.decodeFromString<XtreamLiveStreamDto>(
+            """{"name":"A","stream_id":42,"category_id":"3","tv_archive":1}"""
+        )
+        assertEquals(42, a.streamId)
+        assertEquals(1, a.tvArchive)
+        // panel B: quoted strings + bool
+        val b = json.decodeFromString<XtreamLiveStreamDto>(
+            """{"name":"B","stream_id":"42","category_id":"3","tv_archive":true}"""
+        )
+        assertEquals(42, b.streamId)
+        assertEquals(1, b.tvArchive)
+        // empty id -> null, no throw
+        val c = json.decodeFromString<XtreamLiveStreamDto>("""{"name":"C","stream_id":""}""")
+        assertNull(c.streamId)
+    }
+
+    @Test
+    fun parseXtreamAccountExtractsHostPortCreds() {
+        val a = parseXtreamAccount("http://provider.example.com:8080/get.php?username=user1&password=pass1&type=m3u_plus&output=mpegts")!!
+        assertEquals("http://provider.example.com:8080", a.baseUrl)
+        assertEquals("user1", a.username)
+        assertEquals("pass1", a.password)
+
+        val b = parseXtreamAccount("http://panel.example.net/get.php?username=u1&password=p1&type=m3u_plus&output=ts")!!
+        assertEquals("http://panel.example.net", b.baseUrl)   // default port omitted
+        assertEquals("panel.example.net", b.name)
+
+        assertNull(parseXtreamAccount("http://panel.example.net/get.php?type=m3u_plus"))  // no creds
+        assertNull(parseXtreamAccount("not a url"))
+    }
+
+    @Test
+    fun xtreamAccountFromFieldsNormalizesServerAndRequiresCreds() {
+        val a = xtreamAccountFromFields("host.example.org:8080", "demo", "secret", null)!!
+        assertEquals("http://host.example.org:8080", a.baseUrl)
+        assertEquals("demo", a.username)
+        val b = xtreamAccountFromFields("http://panel.example.net/c/", "u", "p", "Home")!!
+        assertEquals("http://panel.example.net", b.baseUrl)
+        assertEquals("Home", b.name)
+        assertNull(xtreamAccountFromFields("http://panel.example.net", "", "p", null))
+        assertNull(xtreamAccountFromFields("", "u", "p", null))
+    }
+
+    @Test
+    fun toProgramConvertsSecondsToMillisAndNowPlaying() {
+        val p = XtreamEpgEntryDto(
+            title = "VGl0bGU=",            // "Title"
+            description = "RGVzYw==",      // "Desc"
+            startTimestamp = "1700000000",
+            stopTimestamp = "1700003600",
+            nowPlaying = 1
+        ).toProgram()
+        assertEquals("Title", p.title)
+        assertEquals("Desc", p.description)
+        assertEquals(1700000000_000L, p.startMs)
+        assertEquals(1700003600_000L, p.endMs)
+        assertTrue(p.nowPlaying)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/iptv/XtreamItemRegistryTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/iptv/XtreamItemRegistryTest.kt
@@ -1,0 +1,76 @@
+package com.nuvio.app.features.iptv
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class XtreamItemRegistryTest {
+
+    // account.id = "$baseUrl|$user" and baseUrl carries "://" and an optional ":port",
+    // so the content id is full of colons — the parser must NOT naive-split on ':'.
+    @Test
+    fun parsesIdWhenAccountIdContainsSchemeAndPortColons() {
+        val accountId = "http://example.com:8080|user"
+        val id = XtreamItemRegistry.vodId(accountId, 12345)
+        assertEquals("xtream:http://example.com:8080|user:vod:12345", id)
+
+        val parsed = XtreamItemRegistry.parseId(id)
+        assertTrue(parsed != null)
+        assertEquals(accountId, parsed.accountId)
+        assertEquals(XtreamKind.VOD, parsed.kind)
+        assertEquals("12345", parsed.id)
+    }
+
+    @Test
+    fun parsesIdForDefaultPortAccount() {
+        val accountId = "http://example.com|user"   // no ":port" segment
+        val parsed = XtreamItemRegistry.parseId(XtreamItemRegistry.liveId(accountId, 7))
+        assertTrue(parsed != null)
+        assertEquals(accountId, parsed.accountId)
+        assertEquals(XtreamKind.LIVE, parsed.kind)
+        assertEquals("7", parsed.id)
+    }
+
+    @Test
+    fun roundTripsAllKinds() {
+        val accountId = "https://host:443|u"
+        val cases = listOf(
+            XtreamItemRegistry.vodId(accountId, 1) to XtreamKind.VOD,
+            XtreamItemRegistry.seriesId(accountId, 2) to XtreamKind.SERIES,
+            XtreamItemRegistry.liveId(accountId, 3) to XtreamKind.LIVE,
+            XtreamItemRegistry.episodeId(accountId, "99") to XtreamKind.EPISODE,
+        )
+        for ((cid, kind) in cases) {
+            val p = XtreamItemRegistry.parseId(cid)
+            assertTrue(p != null, "parse failed for $cid")
+            assertEquals(accountId, p.accountId)
+            assertEquals(kind, p.kind)
+        }
+    }
+
+    @Test
+    fun rejectsNonXtreamAndMalformedIds() {
+        assertNull(XtreamItemRegistry.parseId("tt1234567"))
+        assertNull(XtreamItemRegistry.parseId("tmdb:movie:550"))
+        assertNull(XtreamItemRegistry.parseId("xtream:onlyprefix"))
+        assertTrue(!XtreamItemRegistry.isXtreamId("tt1234567"))
+        assertTrue(XtreamItemRegistry.isXtreamId("xtream:a:vod:1"))
+    }
+
+    @Test
+    fun registerAndResolveStreamRoundTrips() {
+        val accountId = "http://h:8000|bob"
+        val cid = XtreamItemRegistry.vodId(accountId, 555)
+        XtreamItemRegistry.register(
+            XtreamResolvedItem(cid, accountId, XtreamKind.VOD, "The Movie", "http://h:8000/movie/bob/pw/555.mp4", poster = "p.jpg")
+        )
+        val item = XtreamItemRegistry.get(cid)
+        assertTrue(item != null)
+        assertEquals("The Movie", item.name)
+        assertEquals("http://h:8000/movie/bob/pw/555.mp4", item.toStreamItem("Acct")?.url)
+
+        XtreamItemRegistry.resetForProfile()
+        assertNull(XtreamItemRegistry.get(cid))
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/iptv/XtreamAccountStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/iptv/XtreamAccountStorage.ios.kt
@@ -1,0 +1,21 @@
+package com.nuvio.app.features.iptv
+
+import platform.Foundation.NSUserDefaults
+
+internal actual object XtreamAccountStorage {
+    private const val accountsKey = "xtream_accounts"
+
+    actual fun loadAccountsJson(profileId: Int): String? =
+        NSUserDefaults.standardUserDefaults.stringForKey("${accountsKey}_$profileId")
+
+    actual fun saveAccountsJson(profileId: Int, json: String) {
+        NSUserDefaults.standardUserDefaults.setObject(json, forKey = "${accountsKey}_$profileId")
+    }
+
+    actual fun loadRecentsJson(profileId: Int): String? =
+        NSUserDefaults.standardUserDefaults.stringForKey("xtream_live_recents_$profileId")
+
+    actual fun saveRecentsJson(profileId: Int, json: String) {
+        NSUserDefaults.standardUserDefaults.setObject(json, forKey = "xtream_live_recents_$profileId")
+    }
+}


### PR DESCRIPTION
## Xtream Codes IPTV (Live TV · VOD · Series)

Native Xtream Codes integration in shared KMP code (Android + iOS):

- Browse **Live TV / Movies / Series** — lazy per-row loading + in-memory cache (instant section/account switching), throttled background refresh
- **Now/next EPG** on live tiles (`get_short_epg`)
- **Multi-playlist accounts** with account details (status, expiry, active/max connections) and an "Add playlist" entry
- **Search** across channels, movies, and series
- **Continue Watching** split into Live TV / Movies / Series rows
- **Profile-scoped** state — switching profiles resets the IPTV singletons (no cross-profile leak)
- **libmpv-backed** live playback (ExoPlayer cannot sustain raw MPEG-TS)

Verified on the Android emulator and the iOS 26.5 simulator.

Notes:
- iOS keeps the non-GPL **MPVKit** product (LGPL) — no licensing change to the app.
- Unit tests use `example.*` placeholder hosts / credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)