### PR TITLE
Make Now Playing and Audio devices play/pause work in iOS

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -88,6 +88,7 @@ actual fun PlatformPlayerSurface(
     externalSubtitles: List<com.nuvio.app.features.streams.StreamSubtitle>,
     streamType: String?,
     useYoutubeChunkedPlayback: Boolean,
+    posterUrl: String?,
     modifier: Modifier,
     playWhenReady: Boolean,
     resizeMode: PlayerResizeMode,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
@@ -61,6 +61,7 @@ expect fun PlatformPlayerSurface(
     externalSubtitles: List<com.nuvio.app.features.streams.StreamSubtitle> = emptyList(),
     streamType: String? = null,
     useYoutubeChunkedPlayback: Boolean = false,
+    posterUrl: String? = null,
     modifier: Modifier = Modifier,
     playWhenReady: Boolean = true,
     resizeMode: PlayerResizeMode = PlayerResizeMode.Fit,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -296,6 +296,11 @@ private fun PlayerScreenRuntime.BindPlayerUiVisibilityEffects() {
         if (playbackSnapshot.isPlaying || playbackSnapshot.isLoading || playbackSnapshot.durationMs <= 0L || errorMessage != null) {
             return@LaunchedEffect
         }
+        // Check if this is an auto-pause (transition from playing to paused, not by user action)
+        if (previousIsPlaying && !playbackSnapshot.isPlaying) {
+            // Auto-pause detected (AirPods removed, phone call, etc.) - show controls immediately
+            controlsVisible = !playerControlsLocked
+        }
         delay(5000)
         pausedOverlayVisible = true
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -123,6 +123,7 @@ internal fun PlayerScreenRuntime.RenderPlayerRuntimeUi() {
                 sourceResponseHeaders = activeSourceResponseHeaders,
                 externalSubtitles = externalSubtitles,
                 streamType = activeStreamType,
+                posterUrl = poster,
                 modifier = Modifier.fillMaxSize(),
                 playWhenReady = shouldPlay,
                 resizeMode = resizeMode,

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerBridge.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerBridge.kt
@@ -13,7 +13,8 @@ interface NuvioPlayerBridge {
         videoUrl: String,
         audioUrl: String?,
         headersJson: String?,
-        subtitlesJson: String? = null
+        subtitlesJson: String? = null,
+        posterUrl: String? = null
     )
     fun play()
     fun pause()

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerEngine.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerEngine.ios.kt
@@ -44,6 +44,7 @@ actual fun PlatformPlayerSurface(
     externalSubtitles: List<com.nuvio.app.features.streams.StreamSubtitle>,
     streamType: String?,
     useYoutubeChunkedPlayback: Boolean,
+    posterUrl: String?,
     modifier: Modifier,
     playWhenReady: Boolean,
     resizeMode: PlayerResizeMode,
@@ -257,6 +258,7 @@ actual fun PlatformPlayerSurface(
             audioUrl = sourceAudioUrl,
             headersJson = encodePlaybackHeadersForBridge(sourceHeaders),
             subtitlesJson = encodeExternalSubtitlesForBridge(externalSubtitles),
+            posterUrl = posterUrl,
         )
         if (playWhenReady) {
             bridge.play()

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -17,11 +17,6 @@
 			</array>
 		</dict>
 	</array>
-	<key>NSAppTransportSecurity</key>
-	<dict>
-		<key>NSAllowsArbitraryLoads</key>
-		<true/>
-	</dict>
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>infuse</string>
@@ -29,9 +24,14 @@
 		<string>outplayer</string>
 		<string>open-vidhub</string>
 	</array>
-	<key>NSSupportsLiveActivities</key>
-	<true/>
-	<key>UIApplicationSupportsIndirectInputEvents</key>
-	<true/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/iosApp/iosApp/Player/AudioSessionManager.swift
+++ b/iosApp/iosApp/Player/AudioSessionManager.swift
@@ -1,0 +1,278 @@
+import AVFoundation
+import MediaPlayer
+import UIKit
+
+final class AudioSessionManager {
+    static let shared = AudioSessionManager()
+
+    private weak var activePlayer: MPVPlayerViewController?
+    private var pausedDueToRouteChange = false
+    private var commandsRegistered = false
+    private var nowPlayingUpdateTimer: Timer?
+
+    private init() {}
+
+    func registerActivePlayer(_ player: MPVPlayerViewController) {
+        activePlayer = player
+        pausedDueToRouteChange = false
+        configureAudioSession()
+        setupNotificationObservers()
+        UIApplication.shared.beginReceivingRemoteControlEvents()
+        registerRemoteCommands()
+        setupNowPlayingInfo()
+        startNowPlayingUpdateTimer()
+    }
+
+    func unregisterActivePlayer(_ player: MPVPlayerViewController) {
+        guard activePlayer === player else { return }
+        activePlayer = nil
+        pausedDueToRouteChange = false
+        stopNowPlayingUpdateTimer()
+        clearNowPlayingInfo()
+        UIApplication.shared.endReceivingRemoteControlEvents()
+        unregisterRemoteCommands()
+        removeNotificationObservers()
+        deactivateAudioSession()
+    }
+
+    func refreshSessionAndNowPlaying() {
+        guard activePlayer != nil else { return }
+        configureAudioSession()
+        updateNowPlayingInfo()
+    }
+
+    private func configureAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playback, mode: .moviePlayback)
+            try session.setActive(true)
+        } catch {}
+    }
+
+    private func deactivateAudioSession() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setActive(false, options: .notifyOthersOnDeactivation)
+        } catch {}
+    }
+
+    private func setupNowPlayingInfo() {
+        var info = [String: Any]()
+        info[MPNowPlayingInfoPropertyIsLiveStream] = false
+        info[MPNowPlayingInfoPropertyPlaybackRate] = 1.0
+        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = 0.0
+        info[MPMediaItemPropertyPlaybackDuration] = 0.0
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        MPNowPlayingInfoCenter.default().playbackState = .playing
+        updateNowPlayingInfo()
+    }
+
+    func updateNowPlayingInfo() {
+        guard let player = activePlayer else { return }
+
+        var info = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
+        let positionSeconds = Double(player.positionMs) / 1000.0
+        let durationSeconds = Double(player.durationMs) / 1000.0
+
+        info[MPMediaItemPropertyTitle] = player.mediaTitle()
+        info[MPMediaItemPropertyPlaybackDuration] = durationSeconds
+        info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = positionSeconds
+        info[MPNowPlayingInfoPropertyPlaybackRate] = player.isPlayerPlaying ? Double(player.currentSpeed) : 0.0
+        info[MPNowPlayingInfoPropertyIsLiveStream] = durationSeconds <= 0
+
+        if let image = player.getPosterImage() {
+            let artwork = MPMediaItemArtwork(boundsSize: image.size) { _ in image }
+            info[MPMediaItemPropertyArtwork] = artwork
+        }
+
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+        MPNowPlayingInfoCenter.default().playbackState = player.isPlayerPlaying ? .playing : .paused
+    }
+
+    private func clearNowPlayingInfo() {
+        MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
+        MPNowPlayingInfoCenter.default().playbackState = .stopped
+    }
+
+    private func startNowPlayingUpdateTimer() {
+        stopNowPlayingUpdateTimer()
+        nowPlayingUpdateTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.updateNowPlayingInfo()
+        }
+    }
+
+    private func stopNowPlayingUpdateTimer() {
+        nowPlayingUpdateTimer?.invalidate()
+        nowPlayingUpdateTimer = nil
+    }
+
+    private func setupNotificationObservers() {
+        let nc = NotificationCenter.default
+        nc.removeObserver(self, name: AVAudioSession.routeChangeNotification, object: nil)
+        nc.removeObserver(self, name: AVAudioSession.interruptionNotification, object: nil)
+
+        nc.addObserver(
+            self,
+            selector: #selector(handleRouteChange(_:)),
+            name: AVAudioSession.routeChangeNotification,
+            object: nil
+        )
+        nc.addObserver(
+            self,
+            selector: #selector(handleInterruption(_:)),
+            name: AVAudioSession.interruptionNotification,
+            object: nil
+        )
+    }
+
+    private func removeNotificationObservers() {
+        let nc = NotificationCenter.default
+        nc.removeObserver(self, name: AVAudioSession.routeChangeNotification, object: nil)
+        nc.removeObserver(self, name: AVAudioSession.interruptionNotification, object: nil)
+    }
+
+    @objc private func handleRouteChange(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let reasonValue = userInfo[AVAudioSessionRouteChangeReasonKey] as? UInt,
+              let reason = AVAudioSession.RouteChangeReason(rawValue: reasonValue)
+        else { return }
+
+        switch reason {
+        case .oldDeviceUnavailable:
+            handleAudioDeviceDisconnected(userInfo: userInfo)
+        case .newDeviceAvailable:
+            handleAudioDeviceConnected()
+        default:
+            break
+        }
+    }
+
+    private func handleAudioDeviceDisconnected(userInfo: [AnyHashable: Any]) {
+        guard activePlayer != nil else { return }
+
+        if let previousRoute = userInfo[AVAudioSessionRouteChangePreviousRouteKey] as? AVAudioSessionRouteDescription {
+            let hadExternalAudio = previousRoute.outputs.contains { output in
+                output.portType != .builtInSpeaker && output.portType != .builtInReceiver
+            }
+            guard hadExternalAudio else { return }
+        }
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self, let player = self.activePlayer else { return }
+            if !player.isMpvPaused() {
+                player.pausePlayback()
+                player.refreshPlaybackState()
+                self.pausedDueToRouteChange = true
+                self.updateNowPlayingInfo()
+            }
+        }
+    }
+
+    private func handleAudioDeviceConnected() {
+        pausedDueToRouteChange = false
+    }
+
+    @objc private func handleInterruption(_ notification: Notification) {
+        guard let userInfo = notification.userInfo,
+              let typeValue = userInfo[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: typeValue)
+        else { return }
+
+        switch type {
+        case .began:
+            DispatchQueue.main.async { [weak self] in
+                guard let self, let player = self.activePlayer else { return }
+                player.pausePlayback()
+                player.refreshPlaybackState()
+                self.updateNowPlayingInfo()
+            }
+        case .ended:
+            let optionsValue = userInfo[AVAudioSessionInterruptionOptionKey] as? UInt ?? 0
+            let options = AVAudioSession.InterruptionOptions(rawValue: optionsValue)
+            if options.contains(.shouldResume) {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self, let player = self.activePlayer else { return }
+                    player.playPlayback()
+                    player.refreshPlaybackState()
+                    self.updateNowPlayingInfo()
+                }
+            }
+        default:
+            break
+        }
+    }
+
+    private func registerRemoteCommands() {
+        guard !commandsRegistered else { return }
+        commandsRegistered = true
+
+        let center = MPRemoteCommandCenter.shared()
+
+        center.playCommand.isEnabled = true
+        center.playCommand.addTarget { [weak self] _ in
+            guard let self, let player = self.activePlayer else { return .noActionableNowPlayingItem }
+            DispatchQueue.main.async {
+                player.playPlayback()
+                player.refreshPlaybackState()
+                self.updateNowPlayingInfo()
+            }
+            return .success
+        }
+
+        center.pauseCommand.isEnabled = true
+        center.pauseCommand.addTarget { [weak self] _ in
+            guard let self, let player = self.activePlayer else { return .noActionableNowPlayingItem }
+            DispatchQueue.main.async {
+                player.pausePlayback()
+                player.refreshPlaybackState()
+                self.updateNowPlayingInfo()
+            }
+            return .success
+        }
+
+        center.togglePlayPauseCommand.isEnabled = true
+        center.togglePlayPauseCommand.addTarget { [weak self] _ in
+            guard let self, let player = self.activePlayer else { return .noActionableNowPlayingItem }
+            DispatchQueue.main.async {
+                if player.isMpvPaused() {
+                    player.playPlayback()
+                } else {
+                    player.pausePlayback()
+                }
+                player.refreshPlaybackState()
+                self.updateNowPlayingInfo()
+            }
+            return .success
+        }
+
+        center.stopCommand.isEnabled = true
+        center.stopCommand.addTarget { [weak self] _ in
+            guard let self, let player = self.activePlayer else { return .noActionableNowPlayingItem }
+            DispatchQueue.main.async {
+                player.pausePlayback()
+                player.refreshPlaybackState()
+                self.updateNowPlayingInfo()
+            }
+            return .success
+        }
+
+        center.nextTrackCommand.isEnabled = false
+        center.previousTrackCommand.isEnabled = false
+        center.skipForwardCommand.isEnabled = false
+        center.skipBackwardCommand.isEnabled = false
+        center.seekForwardCommand.isEnabled = false
+        center.seekBackwardCommand.isEnabled = false
+        center.changePlaybackRateCommand.isEnabled = false
+    }
+
+    private func unregisterRemoteCommands() {
+        guard commandsRegistered else { return }
+        commandsRegistered = false
+
+        let center = MPRemoteCommandCenter.shared()
+        center.playCommand.removeTarget(nil)
+        center.pauseCommand.removeTarget(nil)
+        center.togglePlayPauseCommand.removeTarget(nil)
+        center.stopCommand.removeTarget(nil)
+    }
+}

--- a/iosApp/iosApp/Player/MPVPlayerBridge.swift
+++ b/iosApp/iosApp/Player/MPVPlayerBridge.swift
@@ -16,10 +16,11 @@ final class MPVPlayerBridgeImpl: NSObject, NuvioPlayerBridge {
     }
 
     func loadFile(url: String) { playerVC?.loadFile(url) }
-    func loadFileWithAudio(videoUrl: String, audioUrl: String?, headersJson: String?, subtitlesJson: String?) {
+    func loadFileWithAudio(videoUrl: String, audioUrl: String?, headersJson: String?, subtitlesJson: String?, posterUrl: String?) {
         playerVC?.loadFile(
             videoUrl,
             audioUrl: audioUrl,
+            posterUrl: posterUrl,
             requestHeaders: parseRequestHeaders(headersJson),
             subtitles: parseSubtitles(subtitlesJson)
         )
@@ -215,6 +216,7 @@ struct TrackInfo {
 private struct PendingLoadRequest {
     let urlString: String
     let audioUrl: String?
+    let posterUrl: String?
     let requestHeaders: [String: String]
     let subtitles: [PluginSubtitle]
     let queuedAtUptime: TimeInterval
@@ -240,6 +242,11 @@ final class MPVPlayerViewController: UIViewController {
     var audioTracks: [TrackInfo] = []
     var subtitleTracks: [TrackInfo] = []
 
+    // Metadata for Now Playing
+    private var currentPosterUrl: String?
+    private var currentPosterImage: UIImage?
+    private static var posterImageCache: [String: UIImage] = [:]
+
     // State (polled from Kotlin every 250ms)
     var isPlayerLoading: Bool = true
     var isPlayerPlaying: Bool = false
@@ -257,6 +264,10 @@ final class MPVPlayerViewController: UIViewController {
 
     override var prefersHomeIndicatorAutoHidden: Bool {
         true
+    }
+
+    override var canBecomeFirstResponder: Bool {
+        return true
     }
 
     override var preferredScreenEdgesDeferringSystemGestures: UIRectEdge {
@@ -286,6 +297,9 @@ final class MPVPlayerViewController: UIViewController {
         view.layer.addSublayer(metalLayer)
         layoutMetalLayer()
 
+        // Set up audio session before MPV initializes
+        AudioSessionManager.shared.registerActivePlayer(self)
+        
         setupMpv()
         setupNotifications()
         refreshImmersiveSystemUI()
@@ -304,6 +318,7 @@ final class MPVPlayerViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
+        becomeFirstResponder()
         refreshImmersiveSystemUI()
         attemptStartPendingLoad()
     }
@@ -313,6 +328,37 @@ final class MPVPlayerViewController: UIViewController {
         layoutMetalLayer()
         refreshImmersiveSystemUI()
         attemptStartPendingLoad()
+    }
+
+    // MARK: - Remote Control Events
+
+    override func remoteControlReceived(with event: UIEvent?) {
+        guard let event = event, event.type == .remoteControl else { return }
+
+        switch event.subtype {
+        case .remoteControlTogglePlayPause:
+            let paused = isMpvPaused()
+            if paused {
+                playPlayback()
+            } else {
+                pausePlayback()
+            }
+            refreshPlaybackState()
+            AudioSessionManager.shared.updateNowPlayingInfo()
+
+        case .remoteControlPlay:
+            playPlayback()
+            refreshPlaybackState()
+            AudioSessionManager.shared.updateNowPlayingInfo()
+
+        case .remoteControlPause:
+            pausePlayback()
+            refreshPlaybackState()
+            AudioSessionManager.shared.updateNowPlayingInfo()
+
+        default:
+            break
+        }
     }
 
     private func layoutMetalLayer() {
@@ -405,10 +451,15 @@ final class MPVPlayerViewController: UIViewController {
 
     // MARK: - Playback API
 
-    func loadFile(_ urlString: String, audioUrl: String? = nil, requestHeaders: [String: String] = [:], subtitles: [PluginSubtitle] = []) {
+    func loadFile(_ urlString: String, audioUrl: String? = nil, posterUrl: String? = nil, requestHeaders: [String: String] = [:], subtitles: [PluginSubtitle] = []) {
+        currentPosterUrl = posterUrl
+        currentPosterImage = nil
+        downloadPosterImageIfNeeded()
+        
         let request = PendingLoadRequest(
             urlString: urlString,
             audioUrl: audioUrl,
+            posterUrl: posterUrl,
             requestHeaders: requestHeaders,
             subtitles: subtitles,
             queuedAtUptime: ProcessInfo.processInfo.systemUptime
@@ -490,11 +541,56 @@ final class MPVPlayerViewController: UIViewController {
     func playPlayback() {
         guard mpv != nil else { return }
         setFlag("pause", false)
+        DispatchQueue.main.async {
+            AudioSessionManager.shared.refreshSessionAndNowPlaying()
+        }
     }
 
     func pausePlayback() {
         guard mpv != nil else { return }
         setFlag("pause", true)
+    }
+
+    /// Reads mpv pause flag directly (real-time) vs cached value (250ms polling)
+    func isMpvPaused() -> Bool {
+        return getFlag("pause")
+    }
+
+    func mediaTitle() -> String {
+        return getString("media-title") ?? "Nuvio"
+    }
+
+    func getPosterImage() -> UIImage? {
+        return currentPosterImage
+    }
+
+    private func downloadPosterImageIfNeeded() {
+        guard let posterUrl = currentPosterUrl, !posterUrl.isEmpty else {
+            currentPosterImage = nil
+            return
+        }
+
+        if let cachedImage = Self.posterImageCache[posterUrl] {
+            currentPosterImage = cachedImage
+            return
+        }
+
+        guard let url = URL(string: posterUrl) else {
+            currentPosterImage = nil
+            return
+        }
+
+        URLSession.shared.dataTask(with: url) { [weak self] data, response, error in
+            guard let self = self, let data = data, error == nil else { return }
+            guard let image = UIImage(data: data) else { return }
+            
+            Self.posterImageCache[posterUrl] = image
+            
+            DispatchQueue.main.async {
+                self.currentPosterImage = image
+                AudioSessionManager.shared.updateNowPlayingInfo()
+            }
+        }.resume()
     }
 
     func seekToMs(_ ms: Int64) {
@@ -701,13 +797,16 @@ final class MPVPlayerViewController: UIViewController {
     }
 
     func destroyPlayer() {
+        AudioSessionManager.shared.unregisterActivePlayer(self)
         NotificationCenter.default.removeObserver(self)
         pendingLoadRetryWorkItem?.cancel()
         pendingLoadRetryWorkItem = nil
         pendingLoadRequest = nil
         clearPlaybackError()
+        currentPosterUrl = nil
+        currentPosterImage = nil
         guard let ctx = mpv else { return }
-        mpv = nil  // nil first so event loop stops reading
+        mpv = nil
         mpv_terminate_destroy(ctx)
     }
 
@@ -927,6 +1026,7 @@ final class MPVPlayerViewController: UIViewController {
                         self.isPlayerLoading = false
                         self.updateState()
                         self.logCurrentAudioOutput()
+                        AudioSessionManager.shared.refreshSessionAndNowPlaying()
                     }
                 case MPV_EVENT_END_FILE:
                     if let data = eventPtr.pointee.data {


### PR DESCRIPTION
## Summary

This PR fixes Now Playing on iOS not showing what's currently playing in the Nuvio app, and fixes play/pause functionality for external audio devices using their buttons. This includes in-ear detection for AirPods as well.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

- On iOS, the Now Playing interface isn't updated when playing media in Nuvio. 
- External audio devices(like earphones, bluetooth speakers, AirPods, etc don't pause/resume the media on button press.
- The AirPods in-ear detection does not work. Removing one AirPod does not pause the media, and re-inserting the AirPod does not resume it.

## Issue or approval

- Fixes #1188 on iOS
- Open bug reported on [Discord](https://discord.com/channels/1379902184207941732/1505733536970178701)


## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

UI is not touched at all. The changes are fixes for iOS specific things and limited to iOS only. The Android part of the codebase is untouched.

## Testing

- Tested on iPad Air M2 with iPadOS 26.5
- Used AirPods Pro 2 for testing in-ear detection
- Used External bluetooth speaker and also AirPods Pro 2 stem press to test play/pause behavior.

## Screenshots / Video (UI changes only)

Not a UI change but will attach Now Playing screenshot
<img width="2360" height="1640" alt="image" src="https://github.com/user-attachments/assets/9fec86d5-b94a-4217-b34e-9cff7a2d7276" />


## Breaking changes

None

## Linked issues

#1188 
