### PR TITLE
bypassing unnecessary P2P prompts

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/plugins/PluginModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/plugins/PluginModels.kt
@@ -79,6 +79,7 @@ data class PluginRuntimeResult(
     val infoHash: String? = null,
     val headers: Map<String, String>? = null,
     val subtitles: List<PluginSubtitleResult>? = null,
+    val clientResolve: com.nuvio.app.features.streams.StreamClientResolve? = null,
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamFetchSupport.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamFetchSupport.kt
@@ -116,6 +116,7 @@ internal fun PluginRuntimeResult.toStreamItem(
         addonName = addonName,
         addonId = addonId,
         streamType = normalizeStreamType(type),
+        clientResolve = clientResolve,
         behaviorHints = if (requestHeaders.isEmpty()) {
             StreamBehaviorHints()
         } else {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamModels.kt
@@ -64,7 +64,7 @@ data class StreamItem(
         get() = clientResolve?.isDirectDebridCandidate == true
 
     val isInstalledAddonStream: Boolean
-        get() = addonId.startsWith("addon:")
+        get() = addonId.startsWith("addon:") || addonId.startsWith("plugin:")
 
     val isTorrentStream: Boolean
         get() = !isDirectDebridStream && (

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/PluginRuntime.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/PluginRuntime.kt
@@ -229,10 +229,19 @@ internal object PluginRuntime {
                     )
                 }?.takeIf { it.isNotEmpty() }
 
+                val clientResolve = (item["clientResolve"] as? JsonObject)?.let { resolveObj ->
+                    com.nuvio.app.features.streams.StreamClientResolve(
+                        type = resolveObj["type"]?.jsonPrimitive?.contentOrNull,
+                        infoHash = resolveObj["infoHash"]?.jsonPrimitive?.contentOrNull,
+                        service = resolveObj["service"]?.jsonPrimitive?.contentOrNull,
+                        isCached = resolveObj["isCached"]?.jsonPrimitive?.contentOrNull?.toBoolean() ?: resolveObj["isCached"]?.jsonPrimitive?.booleanOrNull
+                    )
+                }
+
                 PluginRuntimeResult(
                     title = item.stringOrNull("title") ?: item.stringOrNull("name") ?: runBlocking { getString(Res.string.generic_unknown) },
                     name = item.stringOrNull("name"),
-                    url = url,
+                    url = url ?: "", // Default to empty if missing but clientResolve is present
                     quality = item.stringOrNull("quality"),
                     size = item.stringOrNull("size"),
                     language = item.stringOrNull("language"),
@@ -243,8 +252,9 @@ internal object PluginRuntime {
                     infoHash = item.stringOrNull("infoHash"),
                     headers = headers,
                     subtitles = subtitles,
+                    clientResolve = clientResolve,
                 )
-            }.filter { it.url.isNotBlank() }
+            }.filter { it.url.isNotBlank() || it.clientResolve != null }
         }.getOrElse { emptyList() }
     }
 


### PR DESCRIPTION
## Summary
Fixed an issue where JavaScript plugins could not pass Debrid `clientResolve` data to Nuvio, causing their cached Debrid streams to trigger P2P prompts. Plugins are now correctly evaluated as Debrid candidates, and their `clientResolve` metadata is successfully extracted and mapped to the stream.

## PR type
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why
So plugins that implement their own Debrid cache checks (e.g., verifying TorBox/Real-Debrid cache) can instantly trigger Nuvio's internal Debrid playback flow without interrupting the user with unnecessary P2P prompts.

## Issue or approval
N/A

## UI / behavior impact
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
This change is strictly limited to allowing JavaScript plugins to be treated as proper Debrid candidates. It modifies `StreamModels.kt` to allow `plugin:` prefixes in `isInstalledAddonStream`. It also adds `clientResolve` to `PluginRuntimeResult`, updates the JSON parser in `PluginRuntime.kt` to extract it, and maps it to `StreamItem` in `StreamFetchSupport.kt`. It does not change how standard addons behave, nor does it alter any UI.

## Testing
I am not able to test.

## Screenshots / Video
Not a UI change.

## Breaking changes
None.

## Linked issues
[Issue 1428](https://github.com/NuvioMedia/NuvioMobile/issues/1428)