### PR TITLE
feat(details): support behaviorHints.defaultVideoId for series initial play

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsModels.kt
@@ -30,6 +30,7 @@ data class MetaDetails(
     val language: String? = null,
     val website: String? = null,
     val hasScheduledVideos: Boolean = false,
+    val defaultVideoId: String? = null,
     val moreLikeThis: List<MetaPreview> = emptyList(),
     val moreLikeThisSource: MoreLikeThisSource? = null,
     val collectionName: String? = null,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
@@ -51,6 +51,7 @@ internal object MetaDetailsParser {
             language = meta.string("language"),
             website = meta.string("website"),
             hasScheduledVideos = meta.behaviorHints().boolean("hasScheduledVideos") == true,
+            defaultVideoId = meta.behaviorHints().string("defaultVideoId"),
             trailers = meta.trailers(),
             links = links,
             videos = meta.videos(),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/SeriesPlaybackResolver.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/SeriesPlaybackResolver.kt
@@ -170,6 +170,7 @@ internal fun MetaDetails.seriesPrimaryAction(
         todayIsoDate = todayIsoDate,
         preferFurthestEpisode = preferFurthestEpisode,
         showUnairedNextUp = showUnairedNextUp,
+        defaultVideoId = defaultVideoId,
     )?.toLegacySeriesPrimaryAction()
 
 internal fun MetaVideo.playLabel(): String =

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watching/domain/SeriesContinuity.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watching/domain/SeriesContinuity.kt
@@ -92,6 +92,7 @@ fun decideSeriesPrimaryAction(
     todayIsoDate: String,
     preferFurthestEpisode: Boolean = true,
     showUnairedNextUp: Boolean = false,
+    defaultVideoId: String? = null,
 ): WatchingSeriesPrimaryAction? {
     val resumeRecord = resumeProgressForSeries(
         content = content,
@@ -127,7 +128,9 @@ fun decideSeriesPrimaryAction(
                 available = episode.available,
             )
         }
-        released.firstOrNull { normalizeSeasonNumber(it.seasonNumber) > 0 } ?: released.firstOrNull()
+        defaultVideoId?.let { videoId -> released.firstOrNull { it.videoId == videoId } }
+            ?: released.firstOrNull { normalizeSeasonNumber(it.seasonNumber) > 0 }
+            ?: released.firstOrNull()
     }
 
     return nextEpisode?.let { episode ->

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/MetaDetailsParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/MetaDetailsParserTest.kt
@@ -65,4 +65,24 @@ class MetaDetailsParserTest {
         assertFalse(result.videos[0].available)
         assertTrue(result.videos[1].available)
     }
+
+    @Test
+    fun `parse reads defaultVideoId from behavior hints`() {
+        val result = MetaDetailsParser.parse(
+            """
+            {
+              "meta": {
+                "id": "show",
+                "type": "series",
+                "name": "Show",
+                "behaviorHints": {
+                  "defaultVideoId": "show:1:2"
+                }
+              }
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals("show:1:2", result.defaultVideoId)
+    }
 }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/SeriesPlaybackResolverTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/SeriesPlaybackResolverTest.kt
@@ -131,6 +131,72 @@ class SeriesPlaybackResolverTest {
     }
 
     @Test
+    fun seriesPrimaryAction_prefers_default_video_id_when_nothing_watched() {
+        val meta = MetaDetails(
+            id = "show",
+            type = "series",
+            name = "Show",
+            defaultVideoId = "show:1:2",
+            videos = listOf(
+                MetaVideo(id = "show:1:1", title = "Episode 1", season = 1, episode = 1, released = "2026-03-01"),
+                MetaVideo(id = "show:1:2", title = "Episode 2", season = 1, episode = 2, released = "2026-03-08"),
+                MetaVideo(id = "show:1:3", title = "Episode 3", season = 1, episode = 3, released = "2026-03-15"),
+            ),
+        )
+
+        val action = meta.seriesPrimaryAction(
+            entries = emptyList(),
+            watchedItems = emptyList(),
+            todayIsoDate = "2026-03-30",
+        )
+
+        assertNotNull(action)
+        assertEquals("Play S1E2", action.label)
+        assertEquals("show:1:2", action.videoId)
+        assertEquals(1, action.seasonNumber)
+        assertEquals(2, action.episodeNumber)
+    }
+
+    @Test
+    fun seriesPrimaryAction_ignores_default_video_id_when_progress_exists() {
+        val meta = MetaDetails(
+            id = "show",
+            type = "series",
+            name = "Show",
+            defaultVideoId = "show:1:2",
+            videos = listOf(
+                MetaVideo(id = "show:1:1", title = "Episode 1", season = 1, episode = 1, released = "2026-03-01"),
+                MetaVideo(id = "show:1:2", title = "Episode 2", season = 1, episode = 2, released = "2026-03-08"),
+                MetaVideo(id = "show:1:3", title = "Episode 3", season = 1, episode = 3, released = "2026-03-15"),
+            ),
+        )
+
+        val action = meta.seriesPrimaryAction(
+            entries = listOf(
+                WatchProgressEntry(
+                    contentType = "series",
+                    parentMetaId = "show",
+                    parentMetaType = "series",
+                    videoId = "show:1:1",
+                    title = "Show",
+                    seasonNumber = 1,
+                    episodeNumber = 1,
+                    lastPositionMs = 1_000L,
+                    durationMs = 10_000L,
+                    lastUpdatedEpochMs = 100L,
+                    isCompleted = false,
+                ),
+            ),
+            watchedItems = emptyList(),
+            todayIsoDate = "2026-03-30",
+        )
+
+        assertNotNull(action)
+        assertEquals("Resume S1E1", action.label)
+        assertEquals("show:1:1", action.videoId)
+    }
+
+    @Test
     fun nextReleasedEpisodeAfter_global_index_fallback_ignores_specials() {
         val meta = MetaDetails(
             id = "show",


### PR DESCRIPTION
## What

Adds support for the Stremio addon protocol's meta-level `behaviorHints.defaultVideoId` on series detail pages. When a user opens a series they have **no watch progress and no watched history** for, the primary play action (and the episode pre-selection driven by it) now targets the episode the addon pointed at, instead of always falling back to the first released episode. Existing resume / next-episode logic always wins — the hint is a cold-start fallback only.

## Why

Catalog addons use `defaultVideoId` to deep-link "up next"-style rows, where each series tile points at the user's next unwatched episode computed server-side. Stremio honors the hint, and **NuvioTV already parses and applies it** (`MetaResponseDto.defaultVideoId` → `MetaDetailsViewModel.findPreferredDefaultEpisode`), but NuvioMobile currently ignores it — so those tiles land on S1E1 for users without local progress. This brings mobile to parity with NuvioTV.

## How

- `MetaDetails` gains `defaultVideoId`, parsed from meta `behaviorHints` alongside the existing `hasScheduledVideos` field.
- `decideSeriesPrimaryAction` takes an optional `defaultVideoId`; in the cold-start branch (no resume record, no watched record) it prefers the matching **released** episode — availability and release-date rules unchanged — before the usual first-main-season-episode fallback.
- The detail screen picks this up through the existing `MetaDetails.seriesPrimaryAction` extension, so there are no call-site changes; episode pre-selection follows the primary action as before. The home continue-watching path shares the extension but always has progress records, so its behavior is unchanged.

## Testing

- `:composeApp:compileCommonMainKotlinMetadata` passes.
- Added `commonTest` coverage: hint respected on cold start, ignored when progress exists, and a parser test for the new behaviorHints field.
- I could not execute the iOS test targets on a Windows host — would appreciate a CI/macOS run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)