### PR TITLE
Update upstream for Parental Guidance api

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ParentalGuideRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ParentalGuideRepository.kt
@@ -8,7 +8,7 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 
-private const val PARENTAL_GUIDE_BASE_URL = "https://api.imdbapi.dev"
+private const val PARENTAL_GUIDE_BASE_URL = "https://api.tiffara.com"
 private val imdbIdPattern = Regex("tt\\d+")
 
 data class ParentalGuideResult(


### PR DESCRIPTION
## Summary

Updated Parental Guidance upstream due to domain change.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Due to a change in the upstream domain for the Parental Guidance api, this information was no longer being fetched and returned

## Issue or approval

Fixes #1523 

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This fix ix limited to the baseUrl for the Parental Guidance api

## Testing

Created a debug build with the fix applied and tested an item known to have parental guidance information (Shawshank Redemption as a test).

## Screenshots / Video

<img width="1871" height="931" alt="Screenshot 2026-07-12 164735" src="https://github.com/user-attachments/assets/6e0fc8ef-f006-4878-9673-f65687abf365" />


## Breaking changes

None

## Linked issues

https://github.com/NuvioMedia/NuvioMobile/issues/1523
