### PR TITLE
Add dynamic hero-based background to Home screen

### DIFF
--- a/.github/workflows/ios-compile.yml
+++ b/.github/workflows/ios-compile.yml
@@ -19,8 +19,6 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Set up Java
         uses: actions/setup-java@v4

--- a/.github/workflows/ios-compile.yml
+++ b/.github/workflows/ios-compile.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   compile-ios:
     name: Compile iOS simulator target
-    runs-on: macos-15
+    runs-on: macos-latest
     timeout-minutes: 45
 
     steps:

--- a/.github/workflows/ios-compile.yml
+++ b/.github/workflows/ios-compile.yml
@@ -1,0 +1,44 @@
+name: iOS Compile Check
+
+on:
+  push:
+    branches:
+      - feature/dynamic-home-background
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  compile-ios:
+    name: Compile iOS simulator target
+    runs-on: macos-15
+    timeout-minutes: 45
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Create local properties
+        run: touch local.properties
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x gradlew
+
+      - name: Compile common Kotlin metadata
+        run: ./gradlew compileCommonMainKotlinMetadata --stacktrace
+
+      - name: Compile iOS simulator target
+        run: ./gradlew :composeApp:compileKotlinIosSimulatorArm64 --stacktrace

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/Components.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/Components.kt
@@ -53,6 +53,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -81,18 +82,31 @@ fun NuvioScreen(
     horizontalPadding: Dp = MaterialTheme.nuvio.spacing.screenHorizontal,
     topPadding: Dp? = null,
     listState: LazyListState = rememberLazyListState(),
+    backgroundBrush: Brush? = null,
     content: LazyListScope.() -> Unit,
 ) {
     val tokens = MaterialTheme.nuvio
-    val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
+    val statusBarTop = WindowInsets.statusBars
+        .asPaddingValues()
+        .calculateTopPadding()
+
+    val backgroundModifier = if (backgroundBrush != null) {
+        Modifier.background(backgroundBrush)
+    } else {
+        Modifier.background(tokens.colors.background)
+    }
+
     LazyColumn(
         state = listState,
         modifier = modifier
             .fillMaxSize()
-            .background(tokens.colors.background),
+            .then(backgroundModifier),
         contentPadding = PaddingValues(
             start = horizontalPadding,
-            top = topPadding ?: tokens.spacing.screenTop + statusBarTop + nuvioPlatformExtraTopPadding,
+            top = topPadding
+                ?: tokens.spacing.screenTop +
+                statusBarTop +
+                nuvioPlatformExtraTopPadding,
             end = horizontalPadding,
             bottom = nuvioSafeBottomPadding(tokens.spacing.screenBottom),
         ),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -1,9 +1,12 @@
 package com.nuvio.app.features.home
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -11,6 +14,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nuvio.app.core.auth.AuthRepository
@@ -18,6 +23,7 @@ import com.nuvio.app.core.auth.AuthState
 import com.nuvio.app.core.network.NetworkCondition
 import com.nuvio.app.core.network.NetworkStatusRepository
 import com.nuvio.app.core.ui.LocalNuvioBottomNavigationOverlayPadding
+import com.nuvio.app.core.ui.nuvio
 import com.nuvio.app.core.ui.NuvioScreen
 import com.nuvio.app.core.ui.NuvioNetworkOfflineCard
 import com.nuvio.app.core.ui.nuvioSafeBottomPadding
@@ -138,6 +144,16 @@ fun HomeScreen(
         TraktSettingsRepository.uiState
     }.collectAsStateWithLifecycle()
     var observedOfflineState by remember { mutableStateOf(false) }
+
+    var heroBackgroundColor by remember {
+        mutableStateOf<Color?>(null)
+    }
+
+    val animatedHeroBackgroundColor by animateColorAsState(
+        targetValue = heroBackgroundColor
+            ?: MaterialTheme.nuvio.colors.background,
+        label = "home_hero_background_color",
+    )
 
     LaunchedEffect(scrollToTopRequests) {
         scrollToTopRequests.collect {
@@ -741,6 +757,15 @@ fun HomeScreen(
             }
         }
 
+        val homeBackgroundBrush = Brush.verticalGradient(
+            colors = listOf(
+                animatedHeroBackgroundColor,
+                animatedHeroBackgroundColor.copy(alpha = 0.88f),
+                animatedHeroBackgroundColor.copy(alpha = 0.62f),
+                MaterialTheme.nuvio.colors.background,
+            ),
+        )
+
         NuvioScreen(
             modifier = Modifier.fillMaxSize(),
             horizontalPadding = 0.dp,
@@ -763,6 +788,9 @@ fun HomeScreen(
                             mobileBelowSectionHeightHint = mobileHeroBelowSectionHeightHint,
                             listState = homeListState,
                             onItemClick = onPosterClick,
+                            onBackgroundColorChanged = { color ->
+                                heroBackgroundColor = color
+                            },
                         )
 
                         else -> HomeHeroReservedSpace(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeHeroSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeHeroSection.kt
@@ -30,15 +30,21 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.lerp
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.input.pointer.util.VelocityTracker
@@ -52,6 +58,9 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.nuvio.app.core.format.formatReleaseDateForDisplay
 import com.nuvio.app.features.home.MetaPreview
+import com.nuvio.app.features.details.components.loadedBackdropImageBitmap
+import com.kmpalette.rememberDominantColorState
+import com.kmpalette.extensions.painter.rememberPainterDominantColorState
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import nuvio.composeapp.generated.resources.*
@@ -90,6 +99,7 @@ fun HomeHeroSection(
     mobileBelowSectionHeightHint: Dp? = null,
     listState: LazyListState? = null,
     onItemClick: ((MetaPreview) -> Unit)? = null,
+    onBackgroundColorChanged: (Color) -> Unit = {},
 ) {
     if (items.isEmpty()) return
 
@@ -149,7 +159,63 @@ fun HomeHeroSection(
             ?.page
             ?.let(items::get)
             ?: items[currentPage]
+        
+        var dominantPainter by remember(currentItem.type, currentItem.id) {
+            mutableStateOf<Painter?>(null)
+        }
+        
+        var dominantBitmap by remember(currentItem.type, currentItem.id) {
+            mutableStateOf<ImageBitmap?>(null)
+        }
 
+        val bitmapColorState = key(currentItem.type, currentItem.id) {
+            rememberDominantColorState(
+                defaultColor = MaterialTheme.colorScheme.background,
+            )
+        }
+
+        val painterColorState = key(currentItem.type, currentItem.id) {
+            rememberPainterDominantColorState(
+                defaultColor = MaterialTheme.colorScheme.background,
+                defaultOnColor = MaterialTheme.colorScheme.onBackground,
+            )
+        }
+        
+        LaunchedEffect(
+            currentItem.type,
+            currentItem.id,
+            dominantBitmap,
+            dominantPainter,
+        ) {
+            val bitmap = dominantBitmap
+            val painter = dominantPainter
+        
+            when {
+                bitmap != null -> bitmapColorState.updateFrom(bitmap)
+                painter != null -> painterColorState.updateFrom(painter)
+            }
+        }
+        
+        val extractedDominantColor = if (dominantBitmap != null) {
+            bitmapColorState.color
+        } else {
+            painterColorState.color
+        }
+        
+        val homeBackgroundColor = lerp(
+            start = MaterialTheme.colorScheme.background,
+            stop = extractedDominantColor,
+            fraction = 0.42f,
+        )
+        
+        LaunchedEffect(
+            currentItem.type,
+            currentItem.id,
+            homeBackgroundColor,
+        ) {
+            onBackgroundColorChanged(homeBackgroundColor)
+        }
+        
         Box(
             modifier = Modifier
                 .fillMaxWidth()
@@ -164,6 +230,20 @@ fun HomeHeroSection(
             ) {
                 Box(modifier = Modifier.fillMaxSize())
             }
+
+            AsyncImage(
+                model = currentItem.banner ?: currentItem.poster,
+                contentDescription = null,
+                modifier = Modifier
+                    .size(64.dp)
+                    .graphicsLayer {
+                        alpha = 0.01f
+                    },
+                onSuccess = { state ->
+                    dominantPainter = state.painter
+                    dominantBitmap = loadedBackdropImageBitmap(state.result)
+                },
+            )
 
             Box(
                 modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
## Summary

Adds a dynamic Home screen background based on the dominant color of the currently selected hero artwork.

## Changes

- extracts the dominant hero color with KMPalette
- falls back to painter-based extraction on iOS
- animates background color changes when switching heroes
- adds optional background brush support to NuvioScreen
- keeps existing screens unchanged

## Validation

- compileCommonMainKotlinMetadata succeeds on Linux
- iOS targets remain untested locally because they require macOS/Xcode