### PR TITLE
fix(ios): fix profile switcher navigation, layout, and localization

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -417,7 +417,7 @@ fun App(
     onReplace: ((AppRoute) -> Unit)? = null,
     onActivate: ((AppScreenTab) -> Unit)? = null,
     onAppReady: ((Boolean) -> Unit)? = null,
-    onTabTitles: ((home: String, search: String, library: String, profile: String) -> Unit)? = null,
+    onTabTitles: ((home: String, search: String, library: String, profile: String, switchProfile: String, addProfile: String) -> Unit)? = null,
     nativeProfileSwitcherController: NativeProfileSwitcherController? = null,
 ) {
     setSingletonImageLoaderFactory { context ->
@@ -746,7 +746,7 @@ private fun MainAppContent(
     onGoBack: (() -> Unit)? = null,
     onReplace: ((AppRoute) -> Unit)? = null,
     onActivate: ((AppScreenTab) -> Unit)? = null,
-    onTabTitles: ((home: String, search: String, library: String, profile: String) -> Unit)? = null,
+    onTabTitles: ((home: String, search: String, library: String, profile: String, switchProfile: String, addProfile: String) -> Unit)? = null,
     nativeProfileSwitcherController: NativeProfileSwitcherController? = null,
     onRootContentReady: ((Boolean) -> Unit)? = null,
     onSwitchProfile: () -> Unit = {},
@@ -856,6 +856,8 @@ private fun MainAppContent(
     val nativeTabSearchTitle = stringResource(Res.string.compose_nav_search)
     val nativeTabLibraryTitle = stringResource(Res.string.compose_nav_library)
     val nativeTabProfileTitle = stringResource(Res.string.compose_nav_profile)
+    val nativeSwitchProfileTitle = stringResource(Res.string.compose_settings_root_switch_profile_title)
+    val nativeAddProfileTitle = stringResource(Res.string.compose_profile_add_profile)
     val homescreenSettingsTitle = stringResource(Res.string.compose_settings_page_homescreen)
     val metaScreenSettingsTitle = stringResource(Res.string.compose_settings_page_meta_screen)
     val continueWatchingSettingsTitle = stringResource(Res.string.compose_settings_page_continue_watching)
@@ -933,6 +935,8 @@ private fun MainAppContent(
         nativeTabSearchTitle,
         nativeTabLibraryTitle,
         nativeTabProfileTitle,
+        nativeSwitchProfileTitle,
+        nativeAddProfileTitle,
         onTabTitles,
     ) {
         NativeTabBridge.publishTabTitles(
@@ -946,6 +950,8 @@ private fun MainAppContent(
             nativeTabSearchTitle,
             nativeTabLibraryTitle,
             nativeTabProfileTitle,
+            nativeSwitchProfileTitle,
+            nativeAddProfileTitle,
         )
     }
 

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/MainViewController.kt
@@ -24,7 +24,7 @@ fun MainViewController(
     onReplace: (AppRoute) -> Unit,
     onActivate: (String) -> Unit,
     onAppReady: (Boolean) -> Unit,
-    onTabTitles: (String, String, String, String) -> Unit,
+    onTabTitles: (String, String, String, String, String, String) -> Unit,
     nativeProfileSwitcherController: NativeProfileSwitcherController,
 ): UIViewController {
     val initialTab = AppScreenTab.fromName(initialTabName)

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -18,14 +18,14 @@ private enum NuvioComposeHost {
     static func wrap(
         _ contentController: UIViewController,
         disablesInteractiveContentPopGesture: Bool = false,
-        onTabBarAvailable: ((UITabBar) -> Void)? = nil
+        onTabBarControllerAvailable: ((UITabBarController) -> Void)? = nil
     ) -> RootComposeViewController {
         _ = registerPlayerBridge
         contentController.view.backgroundColor = nuvioBackgroundColor
         return RootComposeViewController(
             contentController: contentController,
             disablesInteractiveContentPopGesture: disablesInteractiveContentPopGesture,
-            onTabBarAvailable: onTabBarAvailable
+            onTabBarControllerAvailable: onTabBarControllerAvailable
         )
     }
 }
@@ -36,16 +36,16 @@ private enum NuvioComposeHost {
 final class RootComposeViewController: UIViewController {
     private let contentController: UIViewController
     private let disablesInteractiveContentPopGesture: Bool
-    private let onTabBarAvailable: ((UITabBar) -> Void)?
+    private let onTabBarControllerAvailable: ((UITabBarController) -> Void)?
 
     init(
         contentController: UIViewController,
         disablesInteractiveContentPopGesture: Bool,
-        onTabBarAvailable: ((UITabBar) -> Void)?
+        onTabBarControllerAvailable: ((UITabBarController) -> Void)?
     ) {
         self.contentController = contentController
         self.disablesInteractiveContentPopGesture = disablesInteractiveContentPopGesture
-        self.onTabBarAvailable = onTabBarAvailable
+        self.onTabBarControllerAvailable = onTabBarControllerAvailable
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -108,8 +108,8 @@ final class RootComposeViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         setInteractiveContentPopGestureEnabled(false)
-        if let tabBar = tabBarController?.tabBar {
-            onTabBarAvailable?(tabBar)
+        if let tabBarController {
+            onTabBarControllerAvailable?(tabBarController)
         }
     }
 
@@ -454,8 +454,9 @@ final class NativeProfileTabInteractionCoordinator: NSObject, UIGestureRecognize
     var onLongPress: (() -> Void)?
     private(set) var isHandlingLongPress = false
     private(set) var suppressesProfileSelection = false
-    private weak var tabBar: UITabBar?
-    private var resetWorkItem: DispatchWorkItem?
+    private weak var tabBarController: UITabBarController?
+    private var selectedIndexBeforeLongPress: Int?
+    private let competingRecognizers = NSHashTable<UIGestureRecognizer>.weakObjects()
     private lazy var recognizer: UILongPressGestureRecognizer = {
         let recognizer = UILongPressGestureRecognizer(
             target: self,
@@ -467,11 +468,11 @@ final class NativeProfileTabInteractionCoordinator: NSObject, UIGestureRecognize
         return recognizer
     }()
 
-    func attach(to tabBar: UITabBar) {
-        guard self.tabBar !== tabBar else { return }
-        self.tabBar?.removeGestureRecognizer(recognizer)
-        tabBar.addGestureRecognizer(recognizer)
-        self.tabBar = tabBar
+    func attach(to tabBarController: UITabBarController) {
+        guard self.tabBarController !== tabBarController else { return }
+        self.tabBarController?.tabBar.removeGestureRecognizer(recognizer)
+        tabBarController.tabBar.addGestureRecognizer(recognizer)
+        self.tabBarController = tabBarController
     }
 
     func gestureRecognizer(
@@ -479,10 +480,11 @@ final class NativeProfileTabInteractionCoordinator: NSObject, UIGestureRecognize
         shouldReceive touch: UITouch
     ) -> Bool {
         guard gestureRecognizer === recognizer,
-              let tabBar,
+              let tabBar = tabBarController?.tabBar,
               let profileItem = tabBar.items?.last else {
             return false
         }
+        competingRecognizers.removeAllObjects()
         guard #available(iOS 17.0, *),
               let profileFrame = profileItem.frame(in: tabBar) else { return false }
         return profileFrame.contains(touch.location(in: tabBar))
@@ -492,24 +494,41 @@ final class NativeProfileTabInteractionCoordinator: NSObject, UIGestureRecognize
         _ gestureRecognizer: UIGestureRecognizer,
         shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
     ) -> Bool {
-        gestureRecognizer === recognizer || otherGestureRecognizer === recognizer
+        guard gestureRecognizer === recognizer || otherGestureRecognizer === recognizer else {
+            return false
+        }
+        competingRecognizers.add(
+            gestureRecognizer === recognizer ? otherGestureRecognizer : gestureRecognizer
+        )
+        return true
     }
 
     @objc private func handleLongPress(_ recognizer: UILongPressGestureRecognizer) {
         switch recognizer.state {
         case .began:
-            resetWorkItem?.cancel()
+            selectedIndexBeforeLongPress = tabBarController?.selectedIndex
             isHandlingLongPress = true
             suppressesProfileSelection = true
             UIImpactFeedbackGenerator(style: .medium).impactOccurred()
             onLongPress?()
-        case .ended, .cancelled, .failed:
-            let workItem = DispatchWorkItem { [weak self] in
-                self?.isHandlingLongPress = false
-                self?.suppressesProfileSelection = false
+            competingRecognizers.allObjects.forEach { competingRecognizer in
+                competingRecognizer.isEnabled = false
+                competingRecognizer.isEnabled = true
             }
-            resetWorkItem = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.75, execute: workItem)
+            if let selectedIndexBeforeLongPress {
+                tabBarController?.selectedIndex = selectedIndexBeforeLongPress
+            }
+        case .ended, .cancelled, .failed:
+            let selectedIndex = selectedIndexBeforeLongPress
+            isHandlingLongPress = false
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                if let selectedIndex {
+                    self.tabBarController?.selectedIndex = selectedIndex
+                }
+                self.selectedIndexBeforeLongPress = nil
+                self.suppressesProfileSelection = false
+            }
         default:
             break
         }
@@ -522,6 +541,8 @@ final class AppNavigationCoordinator: ObservableObject {
     @Published var selectedTab: NuvioAppTab = .home
     @Published private(set) var isAppReady = false
     @Published private var localizedTabTitles: [NuvioAppTab: String] = [:]
+    @Published private(set) var localizedSwitchProfileTitle = ""
+    @Published private(set) var localizedAddProfileTitle = ""
     @Published var isProfileSwitcherPresented = false
 
     let homeCoordinator = TabNavigationCoordinator()
@@ -562,13 +583,22 @@ final class AppNavigationCoordinator: ObservableObject {
         localizedTabTitles[tab] ?? tab.fallbackTitle
     }
 
-    func updateTabTitles(home: String, search: String, library: String, profile: String) {
+    func updateTabTitles(
+        home: String,
+        search: String,
+        library: String,
+        profile: String,
+        switchProfile: String,
+        addProfile: String
+    ) {
         localizedTabTitles = [
             .home: home,
             .search: search,
             .library: library,
             .settings: profile,
         ]
+        localizedSwitchProfileTitle = switchProfile
+        localizedAddProfileTitle = addProfile
     }
 
     func updateAppReady(_ ready: Bool) {
@@ -651,20 +681,22 @@ struct NativeNavComposeView: UIViewControllerRepresentable {
             onAppReady: { ready in
                 appCoordinator.updateAppReady(ready.boolValue)
             },
-            onTabTitles: { home, search, library, profile in
+            onTabTitles: { home, search, library, profile, switchProfile, addProfile in
                 appCoordinator.updateTabTitles(
                     home: home,
                     search: search,
                     library: library,
-                    profile: profile
+                    profile: profile,
+                    switchProfile: switchProfile,
+                    addProfile: addProfile
                 )
             },
             nativeProfileSwitcherController: appCoordinator.profileSwitcherController
         )
         return NuvioComposeHost.wrap(
             controller,
-            onTabBarAvailable: { tabBar in
-                appCoordinator.profileTabInteraction.attach(to: tabBar)
+            onTabBarControllerAvailable: { tabBarController in
+                appCoordinator.profileTabInteraction.attach(to: tabBarController)
             }
         )
     }
@@ -969,7 +1001,7 @@ private struct NativeProfileAvatarView: View {
         }
         .clipShape(Circle())
         .overlay {
-            Circle().stroke(
+            Circle().strokeBorder(
                 Color(uiColor: profile.avatarColor).opacity(profile.active ? 1 : 0.45),
                 lineWidth: profile.active ? 2.5 : 1.5
             )
@@ -987,21 +1019,27 @@ private struct NativeProfileAvatarView: View {
 private struct NativeProfileSwitcherView: View {
     @Environment(\.dismiss) private var dismiss
     @StateObject private var model: NativeProfileSwitcherViewModel
+    let title: String
+    let addProfileTitle: String
     let onManageProfiles: () -> Void
 
     init(
         controller: NativeProfileSwitcherController,
+        title: String,
+        addProfileTitle: String,
         onManageProfiles: @escaping () -> Void
     ) {
         _model = StateObject(
             wrappedValue: NativeProfileSwitcherViewModel(controller: controller)
         )
+        self.title = title
+        self.addProfileTitle = addProfileTitle
         self.onManageProfiles = onManageProfiles
     }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
-            Text("Switch Profile")
+            Text(title)
                 .font(.headline)
 
             if model.isLoaded {
@@ -1043,8 +1081,9 @@ private struct NativeProfileSwitcherView: View {
                                         .font(.system(size: 19, weight: .semibold))
                                         .frame(width: 52, height: 52)
                                         .background(.secondary.opacity(0.12), in: Circle())
-                                    Text("Add")
+                                    Text(addProfileTitle)
                                         .font(.caption)
+                                        .multilineTextAlignment(.center)
                                         .frame(width: 64)
                                 }
                             }
@@ -1124,10 +1163,7 @@ struct NativeNavContentView: View {
             get: { appCoordinator.selectedTab },
             set: { newTab in
                 if newTab == .settings &&
-                    (
-                        appCoordinator.profileTabInteraction.suppressesProfileSelection ||
-                            appCoordinator.isProfileSwitcherPresented
-                    ) {
+                    appCoordinator.profileTabInteraction.suppressesProfileSelection {
                     return
                 }
                 if newTab == appCoordinator.selectedTab {
@@ -1209,6 +1245,8 @@ struct NativeNavContentView: View {
                     ) {
                         NativeProfileSwitcherView(
                             controller: appCoordinator.profileSwitcherController,
+                            title: appCoordinator.localizedSwitchProfileTitle,
+                            addProfileTitle: appCoordinator.localizedAddProfileTitle,
                             onManageProfiles: appCoordinator.openProfileManagement
                         )
                     }


### PR DESCRIPTION
## Summary

- Stabilizes the native iOS profile switcher opened by long-pressing the Profile tab.
- Restores the previously selected tab as soon as the profile switcher opens.
- Prevents the long-press release from briefly navigating to the Profile screen.
- Ensures the Profile tab immediately resumes its standard behavior after the popup is dismissed.
- Prevents the selected profile border from being clipped.
- Replaces the hardcoded “Switch Profile” and “Add” labels with existing localized resources available in all supported languages.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On iOS, the native Profile tab long-press gesture interfered with the standard tab-selection behavior.

After opening and dismissing the profile switcher, quickly tapping Profile could incorrectly return to Home. Releasing the long press could also briefly display the Profile screen before restoring the previous screen.

The selection indicator did not reliably return to the previously active tab when the popup opened, and directly manipulating the managed tab bar could cause a runtime exception.

The same popup also contained hardcoded English labels, and the selected profile border could be clipped at the top.

## Issue or approval

Fixes #1543

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR is limited to the native iOS Profile tab long-press menu and its related presentation state.

It does not change the shared profile-management flow, navigation structure, tab bar appearance, or profile data handling. It includes no unrelated refactoring, cleanup, or additional UI polish.

## Testing

- Built the iOS application successfully with:

  `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Debug -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/NuvioMobile-profile-derived CODE_SIGNING_ALLOWED=NO build`

- Repeatedly long-pressed Profile from Home and other tabs.
- Verified that the selection indicator returns to the previous tab when the popup opens.
- Verified that releasing the long press does not briefly display the Profile screen.
- Dismissed the popup and immediately tapped Profile without waiting.
- Verified that the immediate tap correctly navigates to Profile.
- Repeated the open, dismiss, and tap flow multiple times.
- Verified that opening the popup does not cause the managed-tab-bar runtime exception.
- Verified that the selected profile border is not clipped.
- Verified that “Switch Profile” and “Add” use localized Compose resources.
- Confirmed that the “Add” resource exists in all 21 supported localization files.

## Screenshots / Video

Not a UI change

## Breaking changes

None.

## Linked issues

Fixes #1543