### PR TITLE
Show watched checkmarks in player episode switcher

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEpisodesPanel.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEpisodesPanel.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
+import com.nuvio.app.core.ui.NuvioAnimatedWatchedBadge
 import com.nuvio.app.core.ui.NuvioTokens
 import com.nuvio.app.core.ui.nuvio
 import com.nuvio.app.features.debrid.DebridSettingsRepository
@@ -376,16 +377,27 @@ private fun EpisodeRow(
     ) {
         // Thumbnail
         if (episode.thumbnail != null) {
-            AsyncImage(
-                model = episode.thumbnail,
-                contentDescription = null,
+            Box(
                 modifier = Modifier
                     .width(NuvioTokens.Space.s80)
-                    .height(NuvioTokens.Space.s48)
-                    .clip(tokens.shapes.compactCard)
-                    .then(if (shouldBlurArtwork) Modifier.blur(NuvioTokens.Space.s18) else Modifier),
-                contentScale = ContentScale.Crop,
-            )
+                    .height(NuvioTokens.Space.s48),
+            ) {
+                AsyncImage(
+                    model = episode.thumbnail,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .clip(tokens.shapes.compactCard)
+                        .then(if (shouldBlurArtwork) Modifier.blur(NuvioTokens.Space.s18) else Modifier),
+                    contentScale = ContentScale.Crop,
+                )
+                NuvioAnimatedWatchedBadge(
+                    isVisible = isWatched,
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .padding(NuvioTokens.Space.s4),
+                )
+            }
         }
 
         Column(modifier = Modifier.weight(1f)) {
@@ -413,6 +425,9 @@ private fun EpisodeRow(
                         fontSize = NuvioTokens.Type.labelXs,
                         fontWeight = FontWeight.SemiBold,
                     )
+                }
+                if (episode.thumbnail == null) {
+                    NuvioAnimatedWatchedBadge(isVisible = isWatched)
                 }
                 if (isCurrent) {
                     Box(


### PR DESCRIPTION
﻿## Summary

Fix the player episode switcher so completed episodes show the same watched checkmark already shown on the series detail page. Watched state was already computed in `PlayerEpisodesPanel` / `EpisodeRow`; the row UI simply never rendered `NuvioAnimatedWatchedBadge`.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Users can already see watched/completed episode status on the series details page, but when the Episodes panel is opened inside the player, completed episode indicators are missing. That is an inconsistent visual state: `isWatched` was already available and only used for blur.

## Issue or approval

Fixes #1546

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Only `PlayerEpisodesPanel.kt` changed. Reuses existing `NuvioAnimatedWatchedBadge`. No watched/progress logic changes, no detail-page changes, no desktop HTML player changes.

## Testing

- Open a series with completed episodes; confirm detail page shows ticks.
- Play an episode; open the player episode switcher.
- Confirm completed episodes show the watched badge; unwatched do not.
- Confirm current episode still shows Playing.

## Screenshots / Video (UI changes only)

### Before

<img width="1600" height="720" alt="image" src="https://github.com/user-attachments/assets/608a0f7c-9f75-4058-8b08-a84944cbb7c6" />



### After

<img width="1600" height="720" alt="image" src="https://github.com/user-attachments/assets/6079a788-eb48-4977-ab41-381f4e8b205b" />



## Breaking changes

None

## Linked issues

Fixes #1546
