### PR TITLE
Fix(iOS): Collection Folder catalog filters being obstructed by the native iOS navigation bar

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/collection/FolderDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/collection/FolderDetailScreen.kt
@@ -63,6 +63,7 @@ import com.nuvio.app.features.home.stableKey
 import com.nuvio.app.features.home.components.HomeCatalogRowSection
 import com.nuvio.app.features.watched.WatchedRepository
 import com.nuvio.app.features.watching.application.WatchingState
+import com.nuvio.app.navigation.LocalUseNativeNavigation
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
@@ -86,6 +87,7 @@ fun FolderDetailScreen(
         WatchedRepository.uiState
     }.collectAsState()
     val folder = uiState.folder
+    val useNativeNavigation = LocalUseNativeNavigation.current
     val coverImageUrl = folder?.coverImageUrl?.takeIf { it.isNotBlank() }
     val density = LocalDensity.current
     val statusBarTop = WindowInsets.statusBars.asPaddingValues().calculateTopPadding()
@@ -141,13 +143,15 @@ fun FolderDetailScreen(
             )
         }
 
-        NuvioScreenHeader(
-            title = folder?.title ?: uiState.collectionTitle,
-            modifier = Modifier.padding(horizontal = 16.dp),
-            includeStatusBarPadding = coverImageUrl == null,
-            topPadding = if (coverImageUrl != null) statusBarTop * heroCollapseFraction else null,
-            onBack = onBack,
-        )
+        if (!useNativeNavigation) {
+            NuvioScreenHeader(
+                title = folder?.title ?: uiState.collectionTitle,
+                modifier = Modifier.padding(horizontal = 16.dp),
+                includeStatusBarPadding = coverImageUrl == null,
+                topPadding = if (coverImageUrl != null) statusBarTop * heroCollapseFraction else null,
+                onBack = onBack,
+            )
+        }
 
         if (folder == null && !uiState.isLoading) {
             Box(

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -790,11 +790,17 @@ private struct DetailDestinationView: View {
     @ObservedObject var appCoordinator: AppNavigationCoordinator
 
     private var usesComposeNavigationHeader: Bool {
-        wrapper.route is DetailRoute || wrapper.route is StreamRoute
+        wrapper.route is DetailRoute ||
+            wrapper.route is StreamRoute ||
+            wrapper.route is FolderDetailRoute
+    }
+
+    private var hidesNativeNavigationBar: Bool {
+        wrapper.route.hidesNavigationBar || usesComposeNavigationHeader
     }
 
     private var showsReadabilityFade: Bool {
-        !wrapper.route.hidesNavigationBar && !usesComposeNavigationHeader
+        !hidesNativeNavigationBar
     }
 
     private var content: some View {
@@ -822,7 +828,7 @@ private struct DetailDestinationView: View {
         }
         .toolbar(.hidden, for: .tabBar)
         .toolbar(
-            wrapper.route.hidesNavigationBar ? Visibility.hidden : Visibility.visible,
+            hidesNativeNavigationBar ? Visibility.hidden : Visibility.visible,
             for: .navigationBar
         )
     }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -102,19 +102,19 @@ final class RootComposeViewController: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        setInteractiveContentPopGestureEnabled(false)
+        configureBackGestures(isVisible: true)
     }
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        setInteractiveContentPopGestureEnabled(false)
+        configureBackGestures(isVisible: true)
         if let tabBar = tabBarController?.tabBar {
             onTabBarAvailable?(tabBar)
         }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
-        setInteractiveContentPopGestureEnabled(true)
+        configureBackGestures(isVisible: false)
         super.viewWillDisappear(animated)
     }
 
@@ -124,11 +124,12 @@ final class RootComposeViewController: UIViewController {
         setNeedsStatusBarAppearanceUpdate()
     }
 
-    private func setInteractiveContentPopGestureEnabled(_ enabled: Bool) {
-        guard disablesInteractiveContentPopGesture else { return }
+    private func configureBackGestures(isVisible: Bool) {
         if #available(iOS 26.0, *) {
-            navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = enabled
+            navigationController?.interactiveContentPopGestureRecognizer?.isEnabled = false
         }
+        navigationController?.interactivePopGestureRecognizer?.isEnabled =
+            isVisible ? !disablesInteractiveContentPopGesture : true
     }
 
     private func immersiveController(in controller: UIViewController?) -> UIViewController? {
@@ -700,7 +701,7 @@ struct DetailComposeView: UIViewControllerRepresentable {
         )
         return NuvioComposeHost.wrap(
             controller,
-            disablesInteractiveContentPopGesture: true
+            disablesInteractiveContentPopGesture: route is PlayerRoute
         )
     }
 
@@ -790,27 +791,38 @@ private struct DetailDestinationView: View {
     @ObservedObject var appCoordinator: AppNavigationCoordinator
 
     private var usesComposeNavigationHeader: Bool {
-        wrapper.route is DetailRoute ||
-            wrapper.route is StreamRoute ||
-            wrapper.route is FolderDetailRoute
+        wrapper.route is DetailRoute || wrapper.route is StreamRoute
+    }
+
+    private var respectsNativeNavigationSafeArea: Bool {
+        wrapper.route is FolderDetailRoute
     }
 
     private var hidesNativeNavigationBar: Bool {
-        wrapper.route.hidesNavigationBar || usesComposeNavigationHeader
+        wrapper.route.hidesNavigationBar
     }
 
     private var showsReadabilityFade: Bool {
-        !hidesNativeNavigationBar
+        !hidesNativeNavigationBar && !usesComposeNavigationHeader
     }
 
     private var content: some View {
         ZStack(alignment: .top) {
-            DetailComposeView(
-                route: wrapper.route,
-                coordinator: coordinator,
-                appCoordinator: appCoordinator
-            )
-            .ignoresSafeArea(.all)
+            if respectsNativeNavigationSafeArea {
+                DetailComposeView(
+                    route: wrapper.route,
+                    coordinator: coordinator,
+                    appCoordinator: appCoordinator
+                )
+                .ignoresSafeArea(.all, edges: [.horizontal, .bottom])
+            } else {
+                DetailComposeView(
+                    route: wrapper.route,
+                    coordinator: coordinator,
+                    appCoordinator: appCoordinator
+                )
+                .ignoresSafeArea(.all)
+            }
 
             if showsReadabilityFade {
                 NativeToolbarReadabilityFade()


### PR DESCRIPTION
## Summary

<!-- What changed in this PR? -->
This PR fixes an iOS navigation issue where the native Liquid Glass navigation bar could overlap the catalog filter section after the Collection Folder header collapsed.

The overlapping navigation bar intercepted touch events, making the catalog filters difficult or impossible to interact with.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

<!-- Why this change is needed. Explain the user-visible bug, regression, maintenance need, docs error, or approved request. -->
On iOS, the native Liquid Glass navigation bar remains above the Collection Folder screen after the header collapses. As a result, the catalog filter chips become partially covered by the navigation bar and are difficult or impossible to interact with.

## Issue or approval
 
<!-- Required. Link the bug issue or approved feature request. For docs/translation/maintenance with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / Approved in #456 / No linked issue: typo-only docs fix. -->
Fixes #1566

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->
This PR is intentionally limited to the iOS native navigation integration for Collection Folder screens.
- Prevent the native navigation bar from obstructing the Collection Folder catalog filters.
- Preserve native iOS navigation behavior, including:
  - native back button
  - edge swipe back gesture
- Keep the Collection Folder layout consistent with Android while respecting iOS navigation conventions.


## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is docs/translation-only. -->
Tested on actual iPhone and iPad and confirmed:
- Collection Folder catalogs filter remain visible on scroll
- preserved native back button
- preserved edge swipe back gesture

## Screenshots / Video

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->
**Before**
<img width="3196" height="2400" alt="Before" src="https://github.com/user-attachments/assets/5ac5058a-01ff-4b03-bb36-3cbafbe543b5" />

**After**
<img width="3196" height="2400" alt="After" src="https://github.com/user-attachments/assets/7dffa41e-6139-4e18-a3d0-70462d9acdc1" />


## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None

## Linked issues

<!-- Required for bug fixes, UI glitch fixes, behavior fixes, and approved changes. For docs/translation/maintenance with no issue, write: No linked issue - reason. -->
Fixes #1566