### PR TITLE
Fix addon subtitles carrying into the next episode

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/core/storage/PlatformLocalAccountDataCleaner.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/core/storage/PlatformLocalAccountDataCleaner.android.kt
@@ -9,6 +9,7 @@ internal actual object PlatformLocalAccountDataCleaner {
         "nuvio_library_display_settings",
         "nuvio_home_catalog_settings",
         "nuvio_player_settings",
+        "nuvio_player_track_preferences",
         "torrent_settings",
         "nuvio_profile_cache",
         "nuvio_avatar_cache",

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -1267,11 +1267,25 @@ private class NuvioLibmpvView(
             }
 
             override fun clearExternalSubtitle() {
+                extractLibmpvTracks(context, type = "sub")
+                    .filter { it.isExternal }
+                    .forEach { track -> mpv.command("sub-remove", track.id.toString()) }
                 mpv.setPropertyString("sid", "no")
             }
 
             override fun clearExternalSubtitleAndSelect(trackIndex: Int) {
-                selectSubtitleTrack(trackIndex)
+                val tracks = extractLibmpvTracks(context, type = "sub")
+                val targetTrackId = tracks.getOrNull(trackIndex)
+                    ?.takeUnless { it.isExternal }
+                    ?.id
+                tracks
+                    .filter { it.isExternal }
+                    .forEach { track -> mpv.command("sub-remove", track.id.toString()) }
+                if (targetTrackId == null) {
+                    mpv.setPropertyString("sid", "no")
+                } else {
+                    mpv.setPropertyInt("sid", targetTrackId)
+                }
             }
 
             override fun applySubtitleStyle(style: SubtitleStyleState) {
@@ -1325,6 +1339,8 @@ private class NuvioLibmpvView(
                     label = label,
                     language = language,
                     isSelected = node.nodeBoolean("selected") ?: false,
+                    isExternal = node.nodeBoolean("external") == true ||
+                        node.nodeString("external-filename") != null,
                     isForced = inferForcedSubtitleTrack(
                         label = label,
                         language = language,
@@ -1341,6 +1357,7 @@ private data class LibmpvTrack(
     val label: String,
     val language: String?,
     val isSelected: Boolean,
+    val isExternal: Boolean,
     val isForced: Boolean,
 )
 

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerTrackPreferenceStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerTrackPreferenceStorage.android.kt
@@ -13,6 +13,7 @@ internal actual object PlayerTrackPreferenceStorage {
     private const val addonSubtitleIdKey = "addon_subtitle_id"
     private const val addonSubtitleUrlKey = "addon_subtitle_url"
     private const val addonSubtitleAddonNameKey = "addon_subtitle_addon_name"
+    private const val addonSubtitleVideoIdKey = "addon_subtitle_video_id"
     private const val audioLanguageKey = "audio_language"
     private const val audioNameKey = "audio_name"
     private const val audioTrackIdKey = "audio_track_id"
@@ -34,6 +35,7 @@ internal actual object PlayerTrackPreferenceStorage {
             addonSubtitleId = loadString(addonSubtitleIdKey, id),
             addonSubtitleUrl = loadString(addonSubtitleUrlKey, id),
             addonSubtitleAddonName = loadString(addonSubtitleAddonNameKey, id),
+            addonSubtitleVideoId = loadString(addonSubtitleVideoIdKey, id),
             audioLanguage = loadString(audioLanguageKey, id),
             audioName = loadString(audioNameKey, id),
             audioTrackId = loadString(audioTrackIdKey, id),
@@ -47,6 +49,7 @@ internal actual object PlayerTrackPreferenceStorage {
                 it.addonSubtitleId,
                 it.addonSubtitleUrl,
                 it.addonSubtitleAddonName,
+                it.addonSubtitleVideoId,
                 it.audioLanguage,
                 it.audioName,
                 it.audioTrackId,
@@ -64,6 +67,7 @@ internal actual object PlayerTrackPreferenceStorage {
             putOptionalString(addonSubtitleIdKey, id, preference.addonSubtitleId)
             putOptionalString(addonSubtitleUrlKey, id, preference.addonSubtitleUrl)
             putOptionalString(addonSubtitleAddonNameKey, id, preference.addonSubtitleAddonName)
+            putOptionalString(addonSubtitleVideoIdKey, id, preference.addonSubtitleVideoId)
             putOptionalString(audioLanguageKey, id, preference.audioLanguage)
             putOptionalString(audioNameKey, id, preference.audioName)
             putOptionalString(audioTrackIdKey, id, preference.audioTrackId)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimePlaybackActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimePlaybackActions.kt
@@ -65,6 +65,10 @@ internal fun PlayerScreenRuntime.resetIdentityStateIfNeeded() {
     val videoIdentity = "$identity:$activeVideoId:$activeSeasonNumber:$activeEpisodeNumber"
     if (lastResetVideoIdentity != videoIdentity) {
         lastResetVideoIdentity = videoIdentity
+        trackPreferenceRestoreApplied = false
+        preferredSubtitleSelectionApplied = false
+        selectedAddonSubtitleId = null
+        useCustomSubtitles = false
         hasRequestedScrobbleStartForCurrentItem = false
         scrobbleStartRequestGeneration = 0L
         pendingScrobbleStartAfterSeek = false

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimePlaybackActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimePlaybackActions.kt
@@ -65,6 +65,8 @@ internal fun PlayerScreenRuntime.resetIdentityStateIfNeeded() {
     val videoIdentity = "$identity:$activeVideoId:$activeSeasonNumber:$activeEpisodeNumber"
     if (lastResetVideoIdentity != videoIdentity) {
         lastResetVideoIdentity = videoIdentity
+        showSubtitleModal = false
+        subtitleModalVideoId = null
         trackPreferenceRestoreApplied = false
         preferredSubtitleSelectionApplied = false
         selectedAddonSubtitleId = null

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
@@ -426,6 +426,8 @@ private data class EpisodeResume(val positionMs: Long, val fraction: Float?)
 
 private fun PlayerScreenRuntime.resetEpisodePanelAndNextEpisodeState() {
     showNextEpisodeCard = false
+    showSubtitleModal = false
+    subtitleModalVideoId = null
     showSourcesPanel = false
     showEpisodesPanel = false
     episodeStreamsPanelState = EpisodeStreamsPanelState()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeState.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeState.kt
@@ -180,6 +180,7 @@ internal class PlayerScreenRuntime(
 
     var showAudioModal by mutableStateOf(false)
     var showSubtitleModal by mutableStateOf(false)
+    var subtitleModalVideoId by mutableStateOf<String?>(null)
     var showVideoSettingsModal by mutableStateOf(false)
     var audioTracks by mutableStateOf<List<AudioTrack>>(emptyList())
     var subtitleTracks by mutableStateOf<List<SubtitleTrack>>(emptyList())

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeTrackActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeTrackActions.kt
@@ -76,13 +76,14 @@ internal fun PlayerScreenRuntime.persistAddonSubtitlePreference(subtitle: AddonS
     }
 }
 
-internal fun PlayerScreenRuntime.restorePersistedTrackPreferenceIfNeeded() {
-    if (trackPreferenceRestoreApplied) return
+internal fun PlayerScreenRuntime.restorePersistedTrackPreferenceIfNeeded(): Boolean {
+    if (trackPreferenceRestoreApplied) return false
     val preference = PlayerTrackPreferenceStorage.load(parentMetaId)
     if (preference == null) {
         trackPreferenceRestoreApplied = true
-        return
+        return false
     }
+    var subtitleTracksInvalidated = false
 
     if (
         audioTracks.isNotEmpty() &&
@@ -100,11 +101,12 @@ internal fun PlayerScreenRuntime.restorePersistedTrackPreferenceIfNeeded() {
 
     when (preference.subtitleType) {
         PersistedSubtitleSelectionType.DISABLED -> {
-            playerController?.selectSubtitleTrack(-1)
+            playerController?.clearExternalSubtitle()
             selectedSubtitleIndex = -1
             selectedAddonSubtitleId = null
             useCustomSubtitles = false
             preferredSubtitleSelectionApplied = true
+            subtitleTracksInvalidated = true
         }
         PersistedSubtitleSelectionType.INTERNAL -> {
             if (subtitleTracks.isNotEmpty()) {
@@ -112,6 +114,7 @@ internal fun PlayerScreenRuntime.restorePersistedTrackPreferenceIfNeeded() {
                 if (restoredSubtitleIndex >= 0) {
                     if (useCustomSubtitles) {
                         playerController?.clearExternalSubtitleAndSelect(restoredSubtitleIndex)
+                        subtitleTracksInvalidated = true
                     } else {
                         playerController?.selectSubtitleTrack(restoredSubtitleIndex)
                     }
@@ -138,11 +141,13 @@ internal fun PlayerScreenRuntime.restorePersistedTrackPreferenceIfNeeded() {
                 selectedAddonSubtitleId = null
                 selectedSubtitleIndex = -1
                 useCustomSubtitles = false
+                subtitleTracksInvalidated = true
             }
         }
     }
 
     trackPreferenceRestoreApplied = true
+    return subtitleTracksInvalidated
 }
 
 internal fun PlayerScreenRuntime.refreshTracks() {
@@ -154,7 +159,10 @@ internal fun PlayerScreenRuntime.refreshTracks() {
     val selectedSub = subtitleTracks.firstOrNull { it.isSelected }
     if (selectedSub != null && !useCustomSubtitles) selectedSubtitleIndex = selectedSub.index
 
-    restorePersistedTrackPreferenceIfNeeded()
+    if (restorePersistedTrackPreferenceIfNeeded()) {
+        subtitleTracks = ctrl.getSubtitleTracks()
+        selectedSubtitleIndex = subtitleTracks.firstOrNull { it.isSelected }?.index ?: -1
+    }
 
     val preferredAudioTargets = resolvePreferredAudioLanguageTargets(
         preferredAudioLanguage = playerSettingsUiState.preferredAudioLanguage,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeTrackActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeTrackActions.kt
@@ -56,6 +56,7 @@ internal fun PlayerScreenRuntime.persistInternalSubtitlePreference(track: Subtit
             addonSubtitleId = null,
             addonSubtitleUrl = null,
             addonSubtitleAddonName = null,
+            addonSubtitleVideoId = null,
         )
     }
 }
@@ -70,6 +71,7 @@ internal fun PlayerScreenRuntime.persistAddonSubtitlePreference(subtitle: AddonS
             addonSubtitleId = subtitle.id,
             addonSubtitleUrl = subtitle.url,
             addonSubtitleAddonName = subtitle.addonName,
+            addonSubtitleVideoId = playbackSession.videoId,
         )
     }
 }
@@ -121,13 +123,21 @@ internal fun PlayerScreenRuntime.restorePersistedTrackPreferenceIfNeeded() {
             }
         }
         PersistedSubtitleSelectionType.ADDON -> {
-            val url = preference.addonSubtitleUrl?.takeIf { it.isNotBlank() }
+            val url = persistedAddonSubtitleUrlForVideo(
+                preference = preference,
+                videoId = playbackSession.videoId,
+            )
             if (url != null) {
                 selectedAddonSubtitleId = preference.addonSubtitleId ?: url
                 selectedSubtitleIndex = -1
                 useCustomSubtitles = true
                 playerController?.setSubtitleUri(url)
                 preferredSubtitleSelectionApplied = true
+            } else {
+                playerController?.clearExternalSubtitle()
+                selectedAddonSubtitleId = null
+                selectedSubtitleIndex = -1
+                useCustomSubtitles = false
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -222,6 +222,7 @@ private fun PlayerScreenRuntime.RenderPlayerControls(displayedPositionMs: Long, 
             onSpeedClick = { cyclePlaybackSpeed() },
             onSubtitleClick = {
                 refreshTracks()
+                subtitleModalVideoId = playbackSession.videoId
                 showSubtitleModal = true
             },
             onAudioClick = {
@@ -416,7 +417,10 @@ private fun PlayerScreenRuntime.RenderPlayerModals(displayedPositionMs: Long) {
                 playerController?.selectSubtitleTrack(index)
             }
         },
-        onAddonSubtitleSelected = { addon ->
+        onAddonSubtitleSelected = selection@{ addon ->
+            if (!isSubtitleModalSelectionCurrent(subtitleModalVideoId, playbackSession.videoId)) {
+                return@selection
+            }
             selectedAddonSubtitleId = addon.id
             selectedSubtitleIndex = -1
             useCustomSubtitles = true
@@ -430,7 +434,10 @@ private fun PlayerScreenRuntime.RenderPlayerModals(displayedPositionMs: Long) {
         onAutoSyncCapture = { captureSubtitleAutoSyncTime() },
         onAutoSyncCueSelected = { cue -> applySubtitleAutoSyncCue(cue) },
         onAutoSyncReload = { loadSubtitleAutoSyncCues(force = true) },
-        onSubtitleModalDismissed = { showSubtitleModal = false },
+        onSubtitleModalDismissed = {
+            showSubtitleModal = false
+            subtitleModalVideoId = null
+        },
         showVideoSettingsModal = showVideoSettingsModal,
         playerSettings = playerSettingsUiState,
         onVideoSettingsChanged = {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerTrackPreferenceStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerTrackPreferenceStorage.kt
@@ -8,6 +8,7 @@ data class PersistedPlayerTrackPreference(
     val addonSubtitleId: String? = null,
     val addonSubtitleUrl: String? = null,
     val addonSubtitleAddonName: String? = null,
+    val addonSubtitleVideoId: String? = null,
     val audioLanguage: String? = null,
     val audioName: String? = null,
     val audioTrackId: String? = null,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerTrackSelection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerTrackSelection.kt
@@ -228,3 +228,8 @@ internal fun persistedAddonSubtitleUrlForVideo(
     if (persistedVideoId != videoId.takeIf { it.isNotBlank() }) return null
     return preference.addonSubtitleUrl?.takeIf { it.isNotBlank() }
 }
+
+internal fun isSubtitleModalSelectionCurrent(
+    modalVideoId: String?,
+    currentVideoId: String,
+): Boolean = !modalVideoId.isNullOrBlank() && modalVideoId == currentVideoId

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerTrackSelection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerTrackSelection.kt
@@ -219,3 +219,12 @@ internal fun findPersistedSubtitleTrackIndex(
     }
     return -1
 }
+
+internal fun persistedAddonSubtitleUrlForVideo(
+    preference: PersistedPlayerTrackPreference,
+    videoId: String,
+): String? {
+    val persistedVideoId = preference.addonSubtitleVideoId?.takeIf { it.isNotBlank() } ?: return null
+    if (persistedVideoId != videoId.takeIf { it.isNotBlank() }) return null
+    return preference.addonSubtitleUrl?.takeIf { it.isNotBlank() }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/PlayerTrackSelectionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/PlayerTrackSelectionTest.kt
@@ -266,6 +266,17 @@ class PlayerTrackSelectionTest {
         assertEquals(null, persistedAddonSubtitleUrlForVideo(preference, "series:1:1"))
     }
 
+    @Test
+    fun subtitleModalSelectionIsAcceptedForTheSameEpisode() {
+        assertEquals(true, isSubtitleModalSelectionCurrent("series:1:1", "series:1:1"))
+    }
+
+    @Test
+    fun subtitleModalSelectionIsRejectedAfterEpisodeChanges() {
+        assertEquals(false, isSubtitleModalSelectionCurrent("series:1:1", "series:1:2"))
+        assertEquals(false, isSubtitleModalSelectionCurrent(null, "series:1:2"))
+    }
+
     private fun subtitleTrack(
         index: Int,
         language: String?,

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/PlayerTrackSelectionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/PlayerTrackSelectionTest.kt
@@ -234,6 +234,38 @@ class PlayerTrackSelectionTest {
         assertEquals(listOf("french", "english"), visibleSubtitles.map { it.id })
     }
 
+    @Test
+    fun addonSubtitleUrlIsRestoredForTheSameEpisode() {
+        val preference = PersistedPlayerTrackPreference(
+            addonSubtitleUrl = "https://example.com/episode-1.srt",
+            addonSubtitleVideoId = "series:1:1",
+        )
+
+        assertEquals(
+            "https://example.com/episode-1.srt",
+            persistedAddonSubtitleUrlForVideo(preference, "series:1:1"),
+        )
+    }
+
+    @Test
+    fun addonSubtitleUrlIsNotReusedForAnotherEpisode() {
+        val preference = PersistedPlayerTrackPreference(
+            addonSubtitleUrl = "https://example.com/episode-1.srt",
+            addonSubtitleVideoId = "series:1:1",
+        )
+
+        assertEquals(null, persistedAddonSubtitleUrlForVideo(preference, "series:1:2"))
+    }
+
+    @Test
+    fun legacyUnscopedAddonSubtitleUrlIsNotRestored() {
+        val preference = PersistedPlayerTrackPreference(
+            addonSubtitleUrl = "https://example.com/episode-1.srt",
+        )
+
+        assertEquals(null, persistedAddonSubtitleUrlForVideo(preference, "series:1:1"))
+    }
+
     private fun subtitleTrack(
         index: Int,
         language: String?,

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/core/storage/PlatformLocalAccountDataCleaner.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/core/storage/PlatformLocalAccountDataCleaner.ios.kt
@@ -59,6 +59,20 @@ internal actual object PlatformLocalAccountDataCleaner {
         "collection_mobile_settings_payload",
         "collections_payload",
     )
+    private val playerTrackPreferencePrefixes = listOf(
+        "subtitle_type|",
+        "subtitle_language|",
+        "subtitle_name|",
+        "subtitle_track_id|",
+        "addon_subtitle_id|",
+        "addon_subtitle_url|",
+        "addon_subtitle_addon_name|",
+        "addon_subtitle_video_id|",
+        "audio_language|",
+        "audio_name|",
+        "audio_track_id|",
+        "subtitle_delay_ms|",
+    )
 
     actual fun wipe() {
         val defaults = NSUserDefaults.standardUserDefaults
@@ -81,7 +95,8 @@ internal actual object PlatformLocalAccountDataCleaner {
             val keyString = key as? String ?: continue
             if (
                 keyString.startsWith("stream_link_") ||
-                keyString.startsWith("cw_enrichment_cache_")
+                keyString.startsWith("cw_enrichment_cache_") ||
+                playerTrackPreferencePrefixes.any(keyString::startsWith)
             ) {
                 defaults.removeObjectForKey(keyString)
             }

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerTrackPreferenceStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/PlayerTrackPreferenceStorage.ios.kt
@@ -11,6 +11,7 @@ internal actual object PlayerTrackPreferenceStorage {
     private const val addonSubtitleIdKey = "addon_subtitle_id"
     private const val addonSubtitleUrlKey = "addon_subtitle_url"
     private const val addonSubtitleAddonNameKey = "addon_subtitle_addon_name"
+    private const val addonSubtitleVideoIdKey = "addon_subtitle_video_id"
     private const val audioLanguageKey = "audio_language"
     private const val audioNameKey = "audio_name"
     private const val audioTrackIdKey = "audio_track_id"
@@ -26,6 +27,7 @@ internal actual object PlayerTrackPreferenceStorage {
             addonSubtitleId = loadString(addonSubtitleIdKey, id),
             addonSubtitleUrl = loadString(addonSubtitleUrlKey, id),
             addonSubtitleAddonName = loadString(addonSubtitleAddonNameKey, id),
+            addonSubtitleVideoId = loadString(addonSubtitleVideoIdKey, id),
             audioLanguage = loadString(audioLanguageKey, id),
             audioName = loadString(audioNameKey, id),
             audioTrackId = loadString(audioTrackIdKey, id),
@@ -39,6 +41,7 @@ internal actual object PlayerTrackPreferenceStorage {
                 it.addonSubtitleId,
                 it.addonSubtitleUrl,
                 it.addonSubtitleAddonName,
+                it.addonSubtitleVideoId,
                 it.audioLanguage,
                 it.audioName,
                 it.audioTrackId,
@@ -55,6 +58,7 @@ internal actual object PlayerTrackPreferenceStorage {
         saveOptionalString(addonSubtitleIdKey, id, preference.addonSubtitleId)
         saveOptionalString(addonSubtitleUrlKey, id, preference.addonSubtitleUrl)
         saveOptionalString(addonSubtitleAddonNameKey, id, preference.addonSubtitleAddonName)
+        saveOptionalString(addonSubtitleVideoIdKey, id, preference.addonSubtitleVideoId)
         saveOptionalString(audioLanguageKey, id, preference.audioLanguage)
         saveOptionalString(audioNameKey, id, preference.audioName)
         saveOptionalString(audioTrackIdKey, id, preference.audioTrackId)


### PR DESCRIPTION
## Summary

Scope persisted addon subtitle URLs to the video/episode where they were selected. Episode identity changes now reset subtitle restoration even if a provider reuses the same playback source identity.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Addon subtitle preferences are stored per parent series so the selected language/source can be remembered. The stored entry also contained an episode-specific subtitle URL, but the player restored that URL without checking the active episode. Starting the next episode therefore attached the previous episode's subtitle file.

## Issue or approval

Fixes #1446

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This only changes restoration of addon subtitle URLs. A URL is restored when resuming the exact same video ID, but is cleared for another episode and for legacy unscoped entries. Built-in subtitle selection, preferred languages, subtitle fetching, styling, delay, and stream selection are unchanged. The separate black-frame report when manually switching addon subtitles is not included.

## Testing

- `./gradlew --console=plain :composeApp:testAndroidHostTest --tests "com.nuvio.app.features.player.PlayerTrackSelectionTest"`
- `./gradlew --console=plain -Pnuvio.android.distribution=full :composeApp:testAndroidHostTest :composeApp:checkLegacyAbi :androidApp:assembleFullDebug`
- Added regression coverage proving same-episode URLs restore, different-episode URLs do not restore, and legacy unscoped URLs do not restore.
- Installed and launched the final full debug APK on BlueStacks Android 13 (API 33) at the reporter's 2652x1200 resolution.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1446