### PR TITLE
Fix navigation style changing after rotation

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -68,6 +68,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -1842,7 +1843,11 @@ private fun MainAppContent(
                     )
 
                     BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-                        val isTabletLayout = useTabletFloatingTabBar || maxWidth >= 768.dp
+                        val isTabletLayout = isTabletAppLayout(
+                            width = maxWidth,
+                            height = maxHeight,
+                            forceTabletLayout = useTabletFloatingTabBar,
+                        )
                         val useNativeBottomTabs = if (useNativeNavigation) {
                             useNativeTabBar
                         } else {
@@ -3573,6 +3578,12 @@ private fun MainAppContent(
             }
         }
 }
+
+internal fun isTabletAppLayout(
+    width: Dp,
+    height: Dp,
+    forceTabletLayout: Boolean = false,
+): Boolean = forceTabletLayout || minOf(width, height) >= 768.dp
 
 @Composable
 private fun rememberGuardedPopBackStack(

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/AppLayoutTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/AppLayoutTest.kt
@@ -1,0 +1,32 @@
+package com.nuvio.app
+
+import androidx.compose.ui.unit.dp
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppLayoutTest {
+
+    @Test
+    fun `phone navigation classification stays stable across rotation`() {
+        assertFalse(isTabletAppLayout(width = 666.dp, height = 1000.dp))
+        assertFalse(isTabletAppLayout(width = 1000.dp, height = 666.dp))
+    }
+
+    @Test
+    fun `tablet navigation classification stays stable across rotation`() {
+        assertTrue(isTabletAppLayout(width = 800.dp, height = 1280.dp))
+        assertTrue(isTabletAppLayout(width = 1280.dp, height = 800.dp))
+    }
+
+    @Test
+    fun `platform override still forces tablet navigation`() {
+        assertTrue(
+            isTabletAppLayout(
+                width = 390.dp,
+                height = 844.dp,
+                forceTabletLayout = true,
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Keep the root navigation style stable when the same device rotates between portrait and landscape. Device form factor is now classified by the smallest window dimension instead of the current width, with focused regression coverage for rotated phone and tablet dimensions.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The navigation layout used only `maxWidth >= 768.dp`. On devices whose portrait width is below 768dp but landscape width is above it, rotating the screen reclassified the device and replaced the new bottom navigation bar with the legacy tablet top bar. Using the smallest window dimension makes the form-factor decision rotation-invariant while preserving the existing 768dp tablet threshold and the explicit platform override.

## Issue or approval

Fixes #1570

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Only the root navigation form-factor classification is changed. This does not redesign navigation, alter settings, change navigation actions, or modify screen content. Windows whose smallest dimension is at least 768dp remain tablet layouts, smaller windows remain phone layouts, and the existing forced tablet-layout override remains intact.

## Testing

- `./gradlew :composeApp:testAndroidHostTest --tests com.nuvio.app.AppLayoutTest`
- `./gradlew -Pnuvio.android.distribution=full :composeApp:testAndroidHostTest :composeApp:checkLegacyAbi :androidApp:assembleFullDebug`
- Installed the Full debug APK on BlueStacks Android 13 (API 33).
- Reproduced the original glitch at 666x1000dp portrait / 1000x666dp landscape.
- Rotated portrait -> landscape -> portrait -> landscape -> portrait after the fix and confirmed the bottom navigation style remained stable and the app stayed running.
- Regression tests also verify a true 800x1280dp tablet stays a tablet in both orientations and the explicit forced-tablet override still works.

## Screenshots / Video (UI changes only)

| | Portrait | Landscape |
|---|---|---|
| Before | ![Before portrait](https://raw.githubusercontent.com/i7xre/NuvioMobile/pr-assets/pr-assets/1570-before-portrait.png) | ![Before landscape](https://raw.githubusercontent.com/i7xre/NuvioMobile/pr-assets/pr-assets/1570-before-landscape.png) |
| After | ![After portrait](https://raw.githubusercontent.com/i7xre/NuvioMobile/pr-assets/pr-assets/1570-after-portrait.png) | ![After landscape](https://raw.githubusercontent.com/i7xre/NuvioMobile/pr-assets/pr-assets/1570-after-landscape.png) |

## Breaking changes

None.

## Linked issues

Fixes #1570