### PR TITLE
fix: recycled bitmap crash in Now Playing metadata

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerNowPlayingController.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerNowPlayingController.android.kt
@@ -90,7 +90,10 @@ internal class AndroidPlayerNowPlayingController(
 
     private var metadata: AndroidNowPlayingMetadata? = null
     private var snapshot = PlayerPlaybackSnapshot()
-    private var artworkBitmap: Bitmap? = null
+    private var artworkArt: Bitmap? = null
+    private var artworkAlbumArt: Bitmap? = null
+    private var artworkDisplayIcon: Bitmap? = null
+    private var artworkNotificationIcon: Bitmap? = null
     private var released = false
     private var lastPublishedPositionMs = Long.MIN_VALUE
     private var lastPublishedDurationMs = Long.MIN_VALUE
@@ -126,7 +129,10 @@ internal class AndroidPlayerNowPlayingController(
             mediaSession.isActive = true
 
             if (artworkChanged) {
-                artworkBitmap = null
+                artworkArt = null
+                artworkAlbumArt = null
+                artworkDisplayIcon = null
+                artworkNotificationIcon = null
                 loadArtwork(normalized.artworkUrl)
             }
 
@@ -184,7 +190,10 @@ internal class AndroidPlayerNowPlayingController(
         artworkGeneration.incrementAndGet()
         metadata = null
         snapshot = PlayerPlaybackSnapshot()
-        artworkBitmap = null
+        artworkArt = null
+        artworkAlbumArt = null
+        artworkDisplayIcon = null
+        artworkNotificationIcon = null
         resetPublishedPlaybackState()
         mediaSession.setMetadata(null)
         mediaSession.setPlaybackState(
@@ -209,13 +218,23 @@ internal class AndroidPlayerNowPlayingController(
         snapshot.durationMs.takeIf { it > 0L }?.let { durationMs ->
             builder.putLong(MediaMetadata.METADATA_KEY_DURATION, durationMs)
         }
-        artworkBitmap?.let { artwork ->
-            builder.putBitmap(MediaMetadata.METADATA_KEY_ART, artwork)
-            builder.putBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART, artwork)
-            builder.putBitmap(MediaMetadata.METADATA_KEY_DISPLAY_ICON, artwork)
+
+        val base = builder.build()
+        val withArtwork = artworkArt?.takeIf { !it.isRecycled }?.let { art ->
+            MediaMetadata.Builder(base)
+                .putBitmap(MediaMetadata.METADATA_KEY_ART, art)
+                .apply {
+                    artworkAlbumArt?.takeIf { !it.isRecycled }
+                        ?.let { putBitmap(MediaMetadata.METADATA_KEY_ALBUM_ART, it) }
+                    artworkDisplayIcon?.takeIf { !it.isRecycled }
+                        ?.let { putBitmap(MediaMetadata.METADATA_KEY_DISPLAY_ICON, it) }
+                }
+                .build()
         }
 
-        mediaSession.setMetadata(builder.build())
+        if (withArtwork == null || runCatching { mediaSession.setMetadata(withArtwork) }.isFailure) {
+            runCatching { mediaSession.setMetadata(base) }
+        }
     }
 
     private fun publishPlaybackState(force: Boolean) {
@@ -275,7 +294,7 @@ internal class AndroidPlayerNowPlayingController(
             sessionToken = mediaSession.sessionToken,
             metadata = currentMetadata,
             snapshot = snapshot,
-            artwork = artworkBitmap,
+            artwork = artworkNotificationIcon?.takeIf { !it.isRecycled },
         )
         PlayerNowPlayingService.publish(appContext, notification)
     }
@@ -291,10 +310,12 @@ internal class AndroidPlayerNowPlayingController(
 
             mainHandler.post {
                 if (released || generation != artworkGeneration.get() || metadata?.artworkUrl != urlString) {
-                    bitmap?.recycle()
                     return@post
                 }
-                artworkBitmap = bitmap
+                artworkArt = bitmap
+                artworkAlbumArt = bitmap?.let(::copyArtwork)
+                artworkDisplayIcon = bitmap?.let(::copyArtwork)
+                artworkNotificationIcon = bitmap?.let(::copyArtwork)
                 publishMetadata()
                 publishNotification()
             }
@@ -532,6 +553,9 @@ private fun downloadArtwork(urlString: String): Bitmap? {
         connection.disconnect()
     }
 }
+
+private fun copyArtwork(bitmap: Bitmap): Bitmap? =
+    if (bitmap.isRecycled) null else runCatching { bitmap.copy(bitmap.config ?: Bitmap.Config.ARGB_8888, false) }.getOrNull()
 
 private fun decodeSampledBitmap(bytes: ByteArray, maxEdgePx: Int): Bitmap? {
     val bounds = BitmapFactory.Options().apply { inJustDecodeBounds = true }


### PR DESCRIPTION
## Summary

Fixes a crash that happens right after playback starts on Android. The Now Playing controller was sharing a single artwork Bitmap across three MediaMetadata keys and the notification's large icon, then reusing the same instance on every metadata publish. The framework can recycle that instance after one of those uses, so the next `setMetadata()` call throws `IllegalArgumentException: cannot use a recycled source in createBitmap` and takes the app down.

## PR type

- [x] Reproducible bug fix

## Why

App force closes on every stream start on some devices (confirmed on a Redmi Note 8, Android 15). Started with the Now Playing media controls feature, worked fine before that.

## Issue or approval

Fixes #1589

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only touches `PlayerNowPlayingController.android.kt`. No new dependencies, no changes to the Now Playing UI/notification layout or behavior when everything works normally, only how artwork bitmaps are owned and how a failed metadata publish is handled.

## Testing

- Reproduced the crash on a Redmi Note 8 (Android 15) using the current GitHub release, crashes on every stream start.
- Built this branch locally (`:androidApp:installFullDebug`) and installed it on the same device.
- Started playback through an addon on the fixed build, watched logcat live through the exact point where it used to crash (tracks resolved, Now Playing metadata published). No crash, playback continued normally.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1589
