### PR TITLE
fix: uneven top padding of the accent line now uniform for all catalogues, collections and CW.

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/ShelfComponents.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/ShelfComponents.kt
@@ -281,7 +281,7 @@ private fun NuvioShelfSectionHeader(
         if (showAccent) {
             Box(
                 modifier = Modifier
-                    .padding(top = NuvioTokens.Space.s6)
+                    .padding(top = NuvioTokens.Space.s2)
                     .width(NuvioTokens.Space.s64 - NuvioTokens.Space.s4)
                     .height(NuvioTokens.Space.s4)
                     .background(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeCollectionRowSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeCollectionRowSection.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nuvio.app.core.ui.NuvioCardDepthSurface
 import com.nuvio.app.core.ui.NuvioShelfSection
+import com.nuvio.app.core.ui.NuvioViewAllPillSize
 import com.nuvio.app.core.ui.PosterLandscapeAspectRatio
 import com.nuvio.app.core.ui.landscapePosterWidth
 import com.nuvio.app.core.ui.nuvioCardDepth
@@ -89,6 +90,7 @@ private fun HomeCollectionRowSectionContent(
         headerHorizontalPadding = sectionPadding,
         rowContentPadding = PaddingValues(horizontal = sectionPadding),
         showHeaderAccent = !homeCatalogSettings.hideCatalogUnderline,
+        viewAllPillSize = NuvioViewAllPillSize.Compact,
         key = { folder -> "collection_${collection.id}_folder_${folder.id}" },
     ) { folder ->
         CollectionFolderCard(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeContinueWatchingSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeContinueWatchingSection.kt
@@ -55,6 +55,7 @@ import com.nuvio.app.core.ui.NuvioProgressBar
 import com.nuvio.app.core.ui.nuvioCardDepth
 import com.nuvio.app.core.ui.NuvioShelfSection
 import com.nuvio.app.core.ui.NuvioTokens
+import com.nuvio.app.core.ui.NuvioViewAllPillSize
 import com.nuvio.app.core.ui.PosterLandscapeAspectRatio
 import com.nuvio.app.core.ui.landscapePosterHeightForWidth
 import com.nuvio.app.core.ui.landscapePosterWidth
@@ -307,6 +308,7 @@ private fun HomeContinueWatchingSectionContent(
         rowContentPadding = PaddingValues(horizontal = sectionPadding),
         itemSpacing = layout.itemGap,
         showHeaderAccent = !homeCatalogSettings.hideCatalogUnderline,
+        viewAllPillSize = NuvioViewAllPillSize.Compact,
         key = { entry -> entry.videoId },
         animatePlacement = true,
         state = listState,
@@ -1039,9 +1041,9 @@ private fun ContinueWatchingPosterCard(
                 ),
         ) {
             val shouldBlurArtwork = blurNextUp &&
-                useEpisodeThumbnails &&
-                item.isNextUp &&
-                imageUrl == firstNonBlank(item.episodeThumbnail)
+                    useEpisodeThumbnails &&
+                    item.isNextUp &&
+                    imageUrl == firstNonBlank(item.episodeThumbnail)
             if (imageUrl != null) {
                 AsyncImage(
                     model = cloudLibraryDisplayArtworkUrl(imageUrl),


### PR DESCRIPTION
## Summary

Fixed an inconsistent accent underline spacing across catalogue-style headings. The accent line's top padding was not uniform — Continue Watching and Collection row headings rendered the accent line with visibly more top padding than standard Catalog rows, making the same visual element look further from the heading text on some shelves versus others. Normalized this by fixing the top padding in the single shared header composable (NuvioShelfSectionHeader in ShelfComponents.kt) that all of these shelves route through, and reduced so the accent line now sits closer and consistently to the heading everywhere it's used (Home Catalog sections, Continue Watching, Collection rows, Search screen results, and Library row view).

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The accent line under Continue Watching and Collection headings had noticeably more top padding than the accent line under standard Catalog row headings, breaking visual consistency across the same shared UI element on the same screen. This inconsistency was visible on Home, Search, and Library screens since they all reuse the same header component. Fixing the padding in the shared component both removes the CW/Collection-vs-Catalog mismatch and tightens the accent line's proximity to its heading, matching the app's overall tight spacing rhythm.

## Issue or approval

No linked issue - fix the uneven top padding of the accent line.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

- Only the accent line's top padding value was changed; width, height, color, and shape of the accent line are untouched.

- No changes to showAccent / showHeaderAccent toggle logic or the hideCatalogUnderline setting.

- No changes to heading typography, view-all pill, or spacing of unrelated components/screens outside the shared shelf header.

- Did not touch the height-estimation helpers (e.g. continueWatchingSectionHeightEstimate) that reference accent spacing for layout reservation — flagged as a possible minor follow-up if drift is observed, not included here to keep this PR focused.



## Testing

- Verified in a live build that the accent line now renders with consistent, reduced top padding under: Home → Catalog sections, Home → Continue Watching, Home → Collection rows, Search screen results, and Library row view.

- Compared CW/Collection headings side-by-side with Catalog row headings to confirm the previously mismatched padding is now uniform.

- Confirmed the hideCatalogUnderline setting still correctly hides/shows the accent line.

- No functional or behavioral regressions observed.



## Screenshots / Video

| Before | After |
| :---: | :---: |
| <img src="https://github.com/user-attachments/assets/f44f52bc-3820-4338-97dd-339fc5e839d1" width="242" alt="Before Update" /> | <img src="https://github.com/user-attachments/assets/27e98bda-d833-444e-a745-cbfd9775eba6" width="242" alt="After Update" /> |

## Breaking changes

None.

## Linked issues

No linked issue - Glitch identified and confirmed via discord dev-chat server.
