### PR TITLE
feat(library): Search the cloud library

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1657,6 +1657,7 @@
     <string name="cloud_library_playable_file_count">%1$d playable files</string>
     <string name="cloud_library_provider_all">All</string>
     <string name="cloud_library_refresh">Refresh cloud library</string>
+    <string name="cloud_library_search_label">Search cloud library</string>
     <string name="cloud_library_select_provider">Select provider</string>
     <string name="cloud_library_select_type">Select type</string>
     <string name="cloud_library_status_ready">Ready to play</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryScreen.kt
@@ -31,15 +31,18 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.InsertDriveFile
 import androidx.compose.material.icons.automirrored.rounded.ArrowBack
+import androidx.compose.material.icons.rounded.Close
 import androidx.compose.material.icons.rounded.GridView
 import androidx.compose.material.icons.rounded.PlayArrow
 import androidx.compose.material.icons.rounded.Refresh
+import androidx.compose.material.icons.rounded.Search
 import androidx.compose.material.icons.rounded.ViewAgenda
 import com.nuvio.app.core.ui.NuvioLoadingIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -132,6 +135,7 @@ fun LibraryScreen(
     }
     var selectedProviderId by rememberSaveable { mutableStateOf<String?>(null) }
     var selectedTypeName by rememberSaveable { mutableStateOf<String?>(null) }
+    var cloudSearchQuery by rememberSaveable { mutableStateOf("") }
     val selectedType = remember(selectedTypeName) {
         selectedTypeName?.let { runCatching { CloudLibraryItemType.valueOf(it) }.getOrNull() }
     }
@@ -305,6 +309,11 @@ fun LibraryScreen(
                     selectedProviderId = selectedProviderId,
                     selectedType = selectedType,
                     selectedCloudItemKey = selectedCloudItemKey,
+                    searchQuery = cloudSearchQuery,
+                    onSearchQueryChange = {
+                        cloudSearchQuery = it
+                        selectedCloudItemKey = null
+                    },
                     onProviderSelected = {
                         selectedProviderId = it
                         selectedTypeName = null
@@ -443,6 +452,8 @@ private fun LazyListScope.cloudLibraryContent(
     selectedProviderId: String?,
     selectedType: CloudLibraryItemType?,
     selectedCloudItemKey: String?,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
     onProviderSelected: (String?) -> Unit,
     onTypeSelected: (CloudLibraryItemType?) -> Unit,
     onItemSelected: (CloudLibraryItem) -> Unit,
@@ -488,8 +499,19 @@ private fun LazyListScope.cloudLibraryContent(
                 .distinct()
                 .sortedBy { type -> type.ordinal }
             val effectiveSelectedType = selectedType?.takeIf { type -> type in availableTypes }
-            val filteredItems = providerItems
+            val typeFilteredItems = providerItems
                 .filter { item -> effectiveSelectedType == null || item.type == effectiveSelectedType }
+            // Local filter over the already-loaded library. Matches the item name or any of its
+            // file names, since the useful identifier is often in the filename, not the title.
+            val trimmedQuery = searchQuery.trim()
+            val filteredItems = if (trimmedQuery.isEmpty()) {
+                typeFilteredItems
+            } else {
+                typeFilteredItems.filter { item ->
+                    item.name.contains(trimmedQuery, ignoreCase = true) ||
+                        item.files.any { file -> file.name.contains(trimmedQuery, ignoreCase = true) }
+                }
+            }
             val selectedItem = filteredItems.firstOrNull { it.stableKey == selectedCloudItemKey }
 
             if (selectedItem != null) {
@@ -511,6 +533,14 @@ private fun LazyListScope.cloudLibraryContent(
                         onTypeSelected = onTypeSelected,
                         onRefresh = onRefresh,
                         modifier = Modifier.padding(horizontal = 16.dp),
+                    )
+                }
+
+                item(key = "cloud-library-search") {
+                    CloudLibrarySearchField(
+                        query = searchQuery,
+                        onQueryChange = onSearchQueryChange,
+                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                     )
                 }
 
@@ -555,6 +585,38 @@ private fun LazyListScope.cloudLibraryContent(
             }
         }
     }
+}
+
+@Composable
+private fun CloudLibrarySearchField(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    OutlinedTextField(
+        value = query,
+        onValueChange = onQueryChange,
+        modifier = modifier.fillMaxWidth(),
+        singleLine = true,
+        shape = RoundedCornerShape(12.dp),
+        placeholder = { Text(stringResource(Res.string.cloud_library_search_label)) },
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Rounded.Search,
+                contentDescription = null,
+            )
+        },
+        trailingIcon = {
+            if (query.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(
+                        imageVector = Icons.Rounded.Close,
+                        contentDescription = stringResource(Res.string.compose_search_clear),
+                    )
+                }
+            }
+        },
+    )
 }
 
 private fun LazyListScope.cloudLibrarySkeletonItems() {


### PR DESCRIPTION
## Summary

Library → Cloud only had provider and type dropdowns, so finding a specific release in a large debrid account meant scrolling the entire list, even though the item names and file names are already loaded on the client. Adds a search field that filters the loaded cloud library only:

- Purely local. It never triggers a provider request, it just narrows the already loaded items.
- Matches the item name **or any of its file names**, since the useful identifier is often in the filename rather than the item title.
- Stacks on top of the existing provider and type filters.
- Narrows on every keystroke.
- A clear button appears once there is text.
- Changing the query clears the expanded-item selection, so you are never left on an item that the filter has removed.

This is the Mobile counterpart to NuvioMedia/NuvioTV#2724, which adds the same cloud library search on Android TV.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

Once a debrid account has a large cached library, the provider and type filters are not enough to find a specific release, and everything needed to filter it is already in memory. Filtering on the filename as well as the title matters in practice because release names frequently carry the episode or quality information that the item title does not.

## Issue or approval

Maintainer approved. Same change as the approved Android TV counterpart in NuvioMedia/NuvioTV#2724.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally not changed:

- No provider-side or remote search. The filter runs entirely against items already loaded.
- No change to how the cloud library is fetched, cached, refreshed, or paginated.
- No change to the Saved library, or to its existing search or filtering.
- No change to the provider and type filter controls themselves.
- No change to playback or file resolution.

## Testing

Built `:androidApp:assembleFullDebug` and installed on an NVIDIA Shield (Android 11), with a Torbox account holding a large cached library.

- Typed partial titles and confirmed the grid narrows per keystroke.
- Typed a fragment that appears only in a filename and not in the item title, and confirmed the parent item is still matched.
- Combined the query with the provider and type filters and confirmed they stack.
- Cleared with the clear button and confirmed the full list is restored.
- Expanded an item, then changed the query so that item no longer matches, and confirmed the view does not strand you on the hidden selection.
- Rotated and reopened the screen to confirm the query survives via `rememberSaveable`.

## Screenshots / Video (UI changes only)

**Demo (searching the cloud library by title and by filename):**

https://github.com/user-attachments/assets/f3c529c6-81f9-4f81-97e5-0917c60c2778

## Breaking changes

None.

## Linked issues

Counterpart to NuvioMedia/NuvioTV#2724 (same feature on Android TV).

