### PR TITLE
fix: next episode button restarts stream search when streams already loaded

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
@@ -371,6 +371,22 @@ internal fun PlayerScreenRuntime.switchToDownloadedEpisode(downloadItem: Downloa
 }
 
 internal fun PlayerScreenRuntime.playNextEpisode() {
+    // If streams for the next episode are already loaded (e.g. autoplay found one
+    // during its countdown), re-use them immediately instead of restarting the
+    // entire search. This prevents a visible "Searching…" flicker when the user
+    // manually taps the Next Episode button while the countdown is in progress.
+    val nextVideoId = nextEpisodeInfo?.videoId
+    val nextVideo = nextVideoId?.let { id -> playerMetaVideos.firstOrNull { it.id == id } }
+    if (nextVideo != null && nextEpisodeInfo?.hasAired == true) {
+        val cachedStreams = PlayerStreamsRepository.episodeStreamsState.value.groups
+            .flatMap { it.streams }
+        if (cachedStreams.isNotEmpty()) {
+            nextEpisodeAutoPlayJob?.cancel()
+            switchToEpisodeStream(cachedStreams.first(), nextVideo)
+            return
+        }
+    }
+
     scope.launchPlayerNextEpisodeAutoPlay(
         previousJob = nextEpisodeAutoPlayJob,
         nextEpisodeInfo = nextEpisodeInfo,


### PR DESCRIPTION
## Summary

Tapping the Next Episode button while the autoplay countdown (3→2→1) was running cancelled the countdown coroutine and relaunched the full stream search from scratch, even though streams were already found. This caused a visible "Searching…" flicker and unnecessary re-fetching on every manual tap.

The fix adds a fast-path in `playNextEpisode()`: if `episodeStreamsState` already contains loaded streams for the next episode, cancel the running job and play the first one immediately. The full search path is only taken when no streams are yet available, preserving all existing autoplay behavior.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [x] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

**Old behavior:** Tapping "Next Episode" while the autoplay job had already found a stream and was counting down would cancel that job and restart the entire stream search from scratch via `launchPlayerNextEpisodeAutoPlay`, showing "Searching…" again even though the streams were ready.

**Broken/unwanted behavior:** The button appears to do nothing useful — it restarts a search the app had already completed, adding 1–3 seconds of unnecessary wait and showing a confusing state change.

**New behavior:** If streams are already in `episodeStreamsState` when the button is tapped, the first stream is applied immediately without going through the search again. Falls back to the full search path when no streams are cached.

## Issue or approval

No linked issue - self-contained internal maintenance fix. The fast-path reuse was always the intended behavior but was never implemented.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally not changed:

- The full `launchPlayerNextEpisodeAutoPlay` search path is unchanged — it still runs exactly as before when no streams are cached.
- No change to the autoplay countdown or the automatic (non-manual) next episode flow.
- No change to `PlayerStreamsRepository`, `PlayerNextEpisodeAutoPlay`, or any other file.
- No change to how streams are fetched, cached, or cleared.
- No UI changes of any kind.

## Testing

Reproduced and verified manually:

- Started a series episode and waited for the autoplay next-episode card to appear with the countdown running.
- **Before fix:** tapping the Next button cancelled the countdown and restarted the search ("Searching…" appeared again).
- **After fix:** tapping the Next button immediately starts playing the next episode without any search restart.
- Verified the full search path still runs correctly when the button is tapped before any streams are loaded (e.g. immediately after the card appears, before the search has returned results).
- Verified manual episode selection from the episodes panel is unaffected.

## Screenshots / Video

No UI changes.

## Breaking changes

None.

## Linked issues

No linked issue - maintenance fix with no associated issue.
