### PR TITLE
fix(tmdb): restore anime enrichment through IMDb aliases

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsModels.kt
@@ -38,6 +38,7 @@ data class MetaDetails(
     val trailers: List<MetaTrailer> = emptyList(),
     val links: List<MetaLink> = emptyList(),
     val videos: List<MetaVideo> = emptyList(),
+    val imdbId: String? = null,
 )
 
 enum class MoreLikeThisSource {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
@@ -55,6 +55,7 @@ internal object MetaDetailsParser {
             trailers = meta.trailers(),
             links = links,
             videos = meta.videos(),
+            imdbId = meta.string("imdb_id") ?: meta.string("imdbId"),
         )
     }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -261,11 +261,17 @@ fun MetaDetailsScreen(
             return@LaunchedEffect
         }
 
-        val imdbId = extractImdbId(metaForRatings.id) ?: extractImdbId(id)
+        val imdbId = metaForRatings.imdbId?.takeIf { it.startsWith("tt", ignoreCase = true) }
+            ?: extractImdbId(metaForRatings.id)
+            ?: extractImdbId(id)
         val tmdbId = extractTmdbId(metaForRatings.id)
             ?: extractTmdbId(id)
-            ?: TmdbService.ensureTmdbId(metaForRatings.id, metaForRatings.type)?.toIntOrNull()
-            ?: TmdbService.ensureTmdbId(id, type)?.toIntOrNull()
+            ?: TmdbService.ensureTmdbId(
+                metaForRatings.id,
+                metaForRatings.type,
+                metaForRatings.imdbId,
+            )?.toIntOrNull()
+            ?: TmdbService.ensureTmdbId(id, type, metaForRatings.imdbId)?.toIntOrNull()
 
         if (imdbId == null && tmdbId == null) {
             episodeImdbRatings = emptyMap()
@@ -1565,6 +1571,7 @@ private fun MetaDetails.toMetaPreview(): MetaPreview =
         releaseInfo = releaseInfo,
         imdbRating = imdbRating,
         genres = genres,
+        imdbId = imdbId,
     )
 
 private fun LazyListScope.configuredMetaSectionItems(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeCatalogParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeCatalogParser.kt
@@ -57,6 +57,7 @@ internal object HomeCatalogParser {
                     genres = meta.array("genres").mapNotNull { genre ->
                         genre.jsonPrimitive.contentOrNull?.takeIf { it.isNotBlank() }
                     },
+                    imdbId = meta.string("imdb_id") ?: meta.string("imdbId"),
                 )
                 if (seenKeys.add(item.stableKey())) {
                     add(item)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeModels.kt
@@ -18,6 +18,7 @@ data class MetaPreview(
     val voteCount: Int? = null,
     val imdbRating: String? = null,
     val genres: List<String> = emptyList(),
+    val imdbId: String? = null,
 )
 
 fun MetaPreview.stableKey(): String = "$type:$id"

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/mdblist/MdbListMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/mdblist/MdbListMetadataService.kt
@@ -49,7 +49,9 @@ object MdbListMetadataService {
         if (!settings.enabled) return false
         if (settings.apiKey.trim().isBlank()) return false
         if (settings.enabledProvidersInPriorityOrder().isEmpty()) return false
-        return extractImdbId(meta.id) != null || extractImdbId(fallbackItemId) != null
+        return validImdbId(meta.imdbId) != null ||
+            extractImdbId(meta.id) != null ||
+            extractImdbId(fallbackItemId) != null
     }
 
     suspend fun enrichMeta(
@@ -62,7 +64,8 @@ object MdbListMetadataService {
         }
         val apiKey = settings.apiKey.trim()
 
-        val imdbId = extractImdbId(meta.id)
+        val imdbId = validImdbId(meta.imdbId)
+            ?: extractImdbId(meta.id)
             ?: extractImdbId(fallbackItemId)
             ?: return meta.copy(externalRatings = emptyList())
         val mediaType = toMdbListMediaType(meta.type)
@@ -107,6 +110,11 @@ object MdbListMetadataService {
         ratingsCache[cacheKey] = ratings
         ratings
     }
+
+    private fun validImdbId(value: String?): String? =
+        value
+            ?.trim()
+            ?.takeIf { imdbRegex.matches(it) }
 
     private suspend fun fetchProviderRating(
         imdbId: String,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -524,8 +524,8 @@ object TmdbMetadataService {
         if (!settings.enabled || !settings.hasApiKey) return meta
 
         val tmdbType = normalizeMetaType(meta.type)
-        val tmdbId = TmdbService.ensureTmdbId(meta.id, tmdbType)
-            ?: TmdbService.ensureTmdbId(fallbackItemId, tmdbType)
+        val tmdbId = TmdbService.ensureTmdbId(meta.id, tmdbType, meta.imdbId)
+            ?: TmdbService.ensureTmdbId(fallbackItemId, tmdbType, meta.imdbId)
             ?: return meta
 
         val needsEpisodes = (

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbService.kt
@@ -15,22 +15,26 @@ object TmdbService {
     private val tmdbToImdbCache = linkedMapOf<String, String>()
     private val cacheMutex = Mutex()
 
-    suspend fun ensureTmdbId(videoId: String, mediaType: String): String? {
+    suspend fun ensureTmdbId(
+        videoId: String,
+        mediaType: String,
+        fallbackImdbId: String? = null,
+    ): String? {
         val apiKey = currentApiKey() ?: return null
+        val normalizedType = normalizeMediaType(mediaType)
 
-        val normalized = videoId
-            .removePrefix("tmdb:")
-            .removePrefix("movie:")
-            .removePrefix("series:")
-            .substringBefore(':')
-            .substringBefore('/')
-            .trim()
+        tmdbLookupCandidates(videoId, fallbackImdbId).forEach { candidate ->
+            if (candidate.all(Char::isDigit)) return candidate
+            if (candidate.startsWith("tt", ignoreCase = true)) {
+                imdbToTmdb(
+                    imdbId = candidate,
+                    mediaType = normalizedType,
+                    apiKey = apiKey,
+                )?.let { return it }
+            }
+        }
 
-        if (normalized.isBlank()) return null
-        if (normalized.all(Char::isDigit)) return normalized
-        if (!normalized.startsWith("tt", ignoreCase = true)) return null
-
-        return imdbToTmdb(imdbId = normalized, mediaType = mediaType, apiKey = apiKey)
+        return null
     }
 
     suspend fun tmdbToImdb(tmdbId: Int, mediaType: String): String? {
@@ -109,6 +113,24 @@ object TmdbService {
             else -> mediaType.trim().lowercase()
         }
 }
+
+internal fun tmdbLookupCandidates(
+    videoId: String,
+    fallbackImdbId: String?,
+): List<String> =
+    listOfNotNull(videoId, fallbackImdbId)
+        .mapNotNull { rawId ->
+            rawId
+                .trim()
+                .removePrefix("tmdb:")
+                .removePrefix("movie:")
+                .removePrefix("series:")
+                .substringBefore(':')
+                .substringBefore('/')
+                .trim()
+                .takeIf(String::isNotBlank)
+        }
+        .distinct()
 
 internal fun buildTmdbUrl(
     endpoint: String,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktRelatedRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktRelatedRepository.kt
@@ -106,12 +106,19 @@ object TraktRelatedRepository {
     ): ResolvedRelatedTarget? {
         val type = resolveRelatedType(meta = meta, fallbackItemType = fallbackItemType) ?: return null
         resolveDirectPathId(meta.id)?.let { return ResolvedRelatedTarget(type, it) }
+        resolveDirectPathId(meta.imdbId)?.let { return ResolvedRelatedTarget(type, it) }
         resolveDirectPathId(fallbackItemId)?.let { return ResolvedRelatedTarget(type, it) }
 
         val tmdbId = resolveTmdbCandidate(meta.id)
             ?: resolveTmdbCandidate(fallbackItemId)
-            ?: TmdbService.ensureTmdbId(meta.id, meta.type)?.toIntOrNull()
-            ?: fallbackItemId?.let { TmdbService.ensureTmdbId(it, fallbackItemType ?: meta.type) }?.toIntOrNull()
+            ?: TmdbService.ensureTmdbId(meta.id, meta.type, meta.imdbId)?.toIntOrNull()
+            ?: fallbackItemId?.let {
+                TmdbService.ensureTmdbId(
+                    it,
+                    fallbackItemType ?: meta.type,
+                    meta.imdbId,
+                )
+            }?.toIntOrNull()
             ?: return null
 
         return resolveViaTraktSearch(type = type, tmdbId = tmdbId, headers = headers)

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/MetaDetailsParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/MetaDetailsParserTest.kt
@@ -22,7 +22,8 @@ class MetaDetailsParserTest {
             {
               "id": "mal:62516",
               "type": "series",
-              "name": "The Fragrant Flower Blooms with Dignity"
+              "name": "The Fragrant Flower Blooms with Dignity",
+              "imdb_id": "tt30217403"
             }
             """.trimIndent(),
         )
@@ -30,6 +31,7 @@ class MetaDetailsParserTest {
         assertEquals("mal:62516", result.id)
         assertEquals("series", result.type)
         assertEquals("The Fragrant Flower Blooms with Dignity", result.name)
+        assertEquals("tt30217403", result.imdbId)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/home/HomeCatalogParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/home/HomeCatalogParserTest.kt
@@ -9,12 +9,17 @@ class HomeCatalogParserTest {
     fun `parse catalog response de-duplicates repeated metas but preserves raw count`() {
         val result = HomeCatalogParser.parseCatalogResponse(
             """
-            {
-              "metas": [
-                { "id": "mal:62516", "type": "series", "name": "A" },
-                { "id": "mal:62516", "type": "series", "name": "A duplicate" },
-                { "id": "mal:1", "type": "movie", "name": "B" }
-              ]
+                {
+                  "metas": [
+                    {
+                      "id": "mal:62516",
+                      "type": "series",
+                      "name": "A",
+                      "imdb_id": "tt30217403"
+                    },
+                    { "id": "mal:62516", "type": "series", "name": "A duplicate" },
+                    { "id": "mal:1", "type": "movie", "name": "B" }
+                  ]
             }
             """.trimIndent(),
         )
@@ -25,6 +30,7 @@ class HomeCatalogParserTest {
             result.items.map { it.stableKey() },
         )
         assertEquals("A", result.items.first().name)
+        assertEquals("tt30217403", result.items.first().imdbId)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/mdblist/MdbListMetadataServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/mdblist/MdbListMetadataServiceTest.kt
@@ -1,0 +1,29 @@
+package com.nuvio.app.features.mdblist
+
+import com.nuvio.app.features.details.MetaDetails
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class MdbListMetadataServiceTest {
+
+    @Test
+    fun `addon imdb alias enables ratings for anime id`() {
+        val meta = MetaDetails(
+            id = "mal:49894",
+            type = "series",
+            name = "Hero Classroom",
+            imdbId = "tt28254942",
+        )
+
+        assertTrue(
+            MdbListMetadataService.shouldFetchForMeta(
+                meta = meta,
+                fallbackItemId = meta.id,
+                settings = MdbListSettings(
+                    enabled = true,
+                    apiKey = "test",
+                ),
+            ),
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbServiceTest.kt
@@ -1,0 +1,40 @@
+package com.nuvio.app.features.tmdb
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TmdbServiceTest {
+
+    @Test
+    fun `anime id keeps addon imdb alias as fallback candidate`() {
+        assertEquals(
+            listOf("mal", "tt28254942"),
+            tmdbLookupCandidates(
+                videoId = "mal:49894",
+                fallbackImdbId = "tt28254942",
+            ),
+        )
+    }
+
+    @Test
+    fun `numeric tmdb id remains ahead of fallback imdb alias`() {
+        assertEquals(
+            listOf("228234", "tt28254942"),
+            tmdbLookupCandidates(
+                videoId = "tmdb:228234",
+                fallbackImdbId = "tt28254942",
+            ),
+        )
+    }
+
+    @Test
+    fun `duplicate primary and fallback ids are resolved once`() {
+        assertEquals(
+            listOf("tt0133093"),
+            tmdbLookupCandidates(
+                videoId = "tt0133093:1:1",
+                fallbackImdbId = "tt0133093",
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Mobile now parses and preserves the Stremio `imdb_id` field from addon catalog and full metadata responses. TMDB resolution uses that IMDb alias only when a primary MAL or Kitsu content ID cannot resolve, and the preserved alias is also available to episode ratings, MDBList ratings, and related title resolution.

Existing numeric TMDB and primary IMDb IDs remain authoritative. The release date behavior from #1558 is unchanged: addon timestamps remain authoritative when TMDB release dates are off, while users who opt into TMDB dates keep the existing midnight UTC parsing, exact availability filtering, and cache invalidation behavior.

Android TV counterpart: NuvioMedia/NuvioTV#2743

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Affected anime metadata already contains the IMDb identifier needed by TMDB, but Mobile discarded `imdb_id` while parsing the addon response. TMDB then received only the unsupported `mal:` or `kitsu:` ID, causing configured enrichment and dependent metadata paths to remain unavailable even though a valid alias was present.

## Issue or approval

Fixes #1614

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This only preserves the existing addon IMDb field and uses it as an identifier fallback for metadata services. It does not replace addon content IDs, change metadata source precedence, alter release date selection or episode availability, add settings, change UI, or affect stream and playback resolution. Items without a valid IMDb alias continue through the existing paths.

## Testing

- `./gradlew :composeApp:testAndroidHostTest`
- `./gradlew :androidApp:assembleFullDebug`
- Verified full metadata and catalog parsers preserve addon `imdb_id` values.
- Verified MAL IDs retain the addon IMDb alias as a fallback candidate.
- Verified numeric TMDB IDs and primary IMDb IDs keep priority.
- Verified duplicate primary and fallback IDs are resolved once.
- Verified MDBList recognizes an addon IMDb alias for an anime ID.
- Verified the #1558 release date parser tests pass with this change.

The changed production paths are in `commonMain` and are shared by Android and iOS. Android host tests and the full Android build pass on Windows. Native iOS compilation was not run because Apple cinterop targets require a macOS toolchain.

## Screenshots / Video

No UI layout change. These images demonstrate the metadata behavior before and after the fix.

### Before

<img width="3840" height="2160" alt="BeforeMobile" src="https://github.com/user-attachments/assets/b67277ff-7931-4b66-bbda-ece4da7ef7b0" />


### After

<img width="3840" height="2160" alt="AfterMobile" src="https://github.com/user-attachments/assets/7317b1c1-3631-443b-b7c6-c892f33408a9" />


## Breaking changes

None.

## Linked issues

Fixes #1614

Android TV issue and parity PR: NuvioMedia/NuvioTV#2742, NuvioMedia/NuvioTV#2743

Related Mobile release date behavior: #1558