### PR TITLE
fix(ui): clip CardDepthEffect sheen overlay to container shape

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/CardDepthEffect.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/CardDepthEffect.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 
+import androidx.compose.ui.graphics.drawscope.clipPath
+
 @Composable
 fun rememberCardDepthStyleUiState(): CardDepthStyleUiState {
     CardDepthStyleRepository.ensureLoaded()
@@ -77,20 +79,31 @@ fun Modifier.cardDepthVisual(
             drawContent()
             val sheenHeight = size.height * 0.22f
             if (sheenHeight > 0f) {
-                drawRect(
-                    brush = Brush.verticalGradient(
-                        colors = listOf(
-                            Color.White.copy(alpha = sheen),
-                            Color.Transparent,
+                val outline = shape.createOutline(size, layoutDirection, this)
+                val shapePath = outline.toPath()
+                clipPath(shapePath) {
+                    drawRect(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(
+                                Color.White.copy(alpha = sheen),
+                                Color.Transparent,
+                            ),
+                            startY = 0f,
+                            endY = sheenHeight,
                         ),
-                        startY = 0f,
-                        endY = sheenHeight,
-                    ),
-                    size = Size(size.width, sheenHeight),
-                )
+                        size = Size(size.width, sheenHeight),
+                    )
+                }
             }
         }
     } else {
         withEdge
     }
 }
+
+private fun androidx.compose.ui.graphics.Outline.toPath(): androidx.compose.ui.graphics.Path = when (this) {
+    is androidx.compose.ui.graphics.Outline.Rectangle -> androidx.compose.ui.graphics.Path().apply { addRect(rect) }
+    is androidx.compose.ui.graphics.Outline.Rounded -> androidx.compose.ui.graphics.Path().apply { addRoundRect(roundRect) }
+    is androidx.compose.ui.graphics.Outline.Generic -> path
+}
+


### PR DESCRIPTION
## Summary

### 1. Card Depth Corner Clipping UI Glitch
- **Card Sheen Overlay Clipping**: Wrapped top sheen gradient overlays inside `clipPath(shapePath)` in `CardDepthEffect.kt` so the sheen respects the container's rounded corner shape (`shapeCorner`) instead of drawing 90-degree square edges over collection cards and poster containers.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Top sheen gradient overlays drawn inside `drawWithContent` via `drawRect` were unclipped, drawing square 90-degree corners across the top width of card containers and overriding `shapeCorner` rounded corner bounds on collection cards.

## Scope

Android, iOS, and shared Compose code (`composeApp/src/commonMain`).

## Issue or approval

Fixes card depth sheen overlay corner clipping on rounded collection cards.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This only clips top sheen overlays to the container outline in `CardDepthEffect.kt`. It does not alter card depth calculation parameters, border styling, card sizes, or playback/metadata logic.

## Testing

- Executed `./gradlew metadataCommonMainClasses` (Build successful).
- Verified `CardDepthEffect.kt` compiles with 0 errors across commonMain targets.
- Verified rounded collection cards render smooth top corners without 90-degree square sheen overlays.

## Screenshots / Video

| Before (Square corner glitch) | After (Rounded corner fix) |
| :---: | :---: |
| *<img width="485" height="1071" alt="Screenshot 2026-07-26 045653" src="https://github.com/user-attachments/assets/22f36b14-4894-4441-8cf1-5412bccc2200" />* | *<img width="496" height="1097" alt="Screenshot 2026-07-26 045628" src="https://github.com/user-attachments/assets/aeea9a3b-ae93-47c9-aa85-9251861d81fe" />* |

## Breaking changes

None.

## Linked issues

No linked issue - fixes CardDepthEffect sheen overlay shape clipping on rounded cards.
