### PR TITLE
feat(details): show episode-specific runtime on episode cards

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
@@ -234,7 +234,7 @@ internal object MetaDetailsParser {
                 season = video.int("season"),
                 episode = video.int("episode"),
                 overview = video.string("overview") ?: video.string("description"),
-                runtime = video.int("runtime"),
+                runtime = parseRuntimeMinutes(video.string("runtime"))?.takeIf { it > 0 },
                 streams = video.embeddedStreams(),
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/RuntimeFormat.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/RuntimeFormat.kt
@@ -32,22 +32,25 @@ internal fun formatRuntimeFromMinutes(totalMinutes: Int): String {
     }
 }
 
-private fun parseRuntimeMinutes(value: String): Int? {
-    hourMinuteColonRegex.matchEntire(value)?.let { match ->
+internal fun parseRuntimeMinutes(value: String?): Int? {
+    val normalized = value?.trim()?.takeIf { it.isNotBlank() } ?: return null
+    if (normalized.startsWith("-")) return null
+
+    hourMinuteColonRegex.matchEntire(normalized)?.let { match ->
         val hours = match.groupValues[1].toIntOrNull() ?: return null
         val minutes = match.groupValues[2].toIntOrNull() ?: return null
         return (hours * 60) + minutes
     }
 
-    val hoursToken = hourTokenRegex.find(value)?.groupValues?.getOrNull(1)?.toIntOrNull()
-    val minutesToken = minuteTokenRegex.find(value)?.groupValues?.getOrNull(1)?.toIntOrNull()
+    val hoursToken = hourTokenRegex.find(normalized)?.groupValues?.getOrNull(1)?.toIntOrNull()
+    val minutesToken = minuteTokenRegex.find(normalized)?.groupValues?.getOrNull(1)?.toIntOrNull()
     if (hoursToken != null || minutesToken != null) {
         val hours = (hoursToken ?: 0).coerceAtLeast(0)
         val minutes = (minutesToken ?: 0).coerceAtLeast(0)
         return (hours * 60) + minutes
     }
 
-    digitsOnlyRegex.matchEntire(value)?.let { match ->
+    digitsOnlyRegex.matchEntire(normalized)?.let { match ->
         return match.groupValues[1].toIntOrNull()?.coerceAtLeast(0)
     }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
@@ -36,6 +36,9 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Schedule
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -684,7 +687,7 @@ private fun EpisodeHorizontalCard(
     val cardShape = RoundedCornerShape(metrics.cornerRadius)
     val ratingLabel = remember(imdbRating) { imdbRating?.takeIf { it > 0.0 }?.let(::formatEpisodeRating) }
     val formattedDate = remember(video.released) { video.released?.let { formatReleaseDateForDisplay(it) } }
-    val runtimeLabel = remember(video.runtime) { video.runtime?.takeIf { it > 0 }?.let(::formatEpisodeRuntime) }
+    val runtimeLabel = remember(video.runtime) { episodeRuntimeLabel(video.runtime) }
     val imageUrl = video.thumbnail ?: fallbackImage
     Box(
         modifier = Modifier
@@ -791,11 +794,11 @@ private fun EpisodeHorizontalCard(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
                     runtimeLabel?.let { runtime ->
-                        Text(
-                            text = runtime,
-                            style = MaterialTheme.typography.labelSmall.copy(fontSize = metrics.metaTextSize),
+                        EpisodeRuntimeMetadata(
+                            label = runtime,
+                            iconSize = metrics.imdbLogoHeight + 1.dp,
+                            textSize = metrics.metaTextSize,
                             color = Color.White.copy(alpha = 0.78f),
-                            maxLines = 1,
                         )
                     }
                     ratingLabel?.let { rating ->
@@ -964,6 +967,40 @@ private fun formatEpisodeRuntime(runtimeMinutes: Int): String {
     return formatRuntimeFromMinutes(runtimeMinutes)
 }
 
+internal fun episodeRuntimeLabel(runtimeMinutes: Int?): String? =
+    runtimeMinutes
+        ?.takeIf(::shouldShowEpisodeRuntime)
+        ?.let(::formatEpisodeRuntime)
+
+internal fun shouldShowEpisodeRuntime(runtimeMinutes: Int?): Boolean =
+    runtimeMinutes != null && runtimeMinutes > 0
+
+@Composable
+private fun EpisodeRuntimeMetadata(
+    label: String,
+    iconSize: Dp,
+    textSize: androidx.compose.ui.unit.TextUnit,
+    color: Color,
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Outlined.Schedule,
+            contentDescription = null,
+            tint = color,
+            modifier = Modifier.size(iconSize),
+        )
+        Text(
+            text = label,
+            style = MaterialTheme.typography.labelSmall.copy(fontSize = textSize),
+            color = color,
+            maxLines = 1,
+        )
+    }
+}
+
 @Composable
 private fun EpisodeCodeBadge(
     text: String,
@@ -1054,6 +1091,7 @@ private fun EpisodeListCard(
     val cardShape = RoundedCornerShape(sizing.cardRadius)
     val ratingLabel = remember(imdbRating) { imdbRating?.takeIf { it > 0.0 }?.let(::formatEpisodeRating) }
     val formattedDate = remember(video.released) { video.released?.let { formatReleaseDateForDisplay(it) } }
+    val runtimeLabel = remember(video.runtime) { episodeRuntimeLabel(video.runtime) }
     Box(
         modifier = modifier
             .fillMaxWidth()
@@ -1145,11 +1183,19 @@ private fun EpisodeListCard(
                     overflow = TextOverflow.Ellipsis,
                 )
 
-                if (formattedDate != null || ratingLabel != null) {
+                if (runtimeLabel != null || formattedDate != null || ratingLabel != null) {
                     Row(
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
+                        runtimeLabel?.let { runtime ->
+                            EpisodeRuntimeMetadata(
+                                label = runtime,
+                                iconSize = 13.dp,
+                                textSize = sizing.metaTextSize,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.8f),
+                            )
+                        }
                         formattedDate?.let { date ->
                             Text(
                                 text = date,

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/MetaDetailsParserTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/MetaDetailsParserTest.kt
@@ -4,6 +4,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class MetaDetailsParserTest {
@@ -64,6 +65,34 @@ class MetaDetailsParserTest {
 
         assertFalse(result.videos[0].available)
         assertTrue(result.videos[1].available)
+    }
+
+    @Test
+    fun `parse normalizes valid runtime and rejects missing or invalid values`() {
+        val result = MetaDetailsParser.parse(
+            """
+            {
+              "meta": {
+                "id": "show",
+                "type": "series",
+                "name": "Show",
+                "videos": [
+                  {"id": "valid", "title": "Valid", "runtime": "1h 5m"},
+                  {"id": "missing", "title": "Missing"},
+                  {"id": "invalid", "title": "Invalid", "runtime": "unknown"},
+                  {"id": "zero", "title": "Zero", "runtime": 0},
+                  {"id": "negative", "title": "Negative", "runtime": -20}
+                ]
+              }
+            }
+            """.trimIndent(),
+        )
+
+        assertEquals(65, result.videos[0].runtime)
+        assertNull(result.videos[1].runtime)
+        assertNull(result.videos[2].runtime)
+        assertNull(result.videos[3].runtime)
+        assertNull(result.videos[4].runtime)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/components/EpisodeCardRulesTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/components/EpisodeCardRulesTest.kt
@@ -1,0 +1,16 @@
+package com.nuvio.app.features.details.components
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class EpisodeCardRulesTest {
+
+    @Test
+    fun `runtime metadata rule requires positive minutes`() {
+        assertTrue(shouldShowEpisodeRuntime(25))
+        assertFalse(shouldShowEpisodeRuntime(null))
+        assertFalse(shouldShowEpisodeRuntime(0))
+        assertFalse(shouldShowEpisodeRuntime(-1))
+    }
+}


### PR DESCRIPTION
## Summary

Adds episode-specific runtime formatting and rendering to episode cards in series details.

When valid runtime metadata is available for an episode, the UI now displays it as compact secondary metadata on the episode card.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Episode cards in series details currently do not display runtime metadata even when episode runtime information is present in the parsed details payload.

This makes it harder for users to estimate the duration of an individual episode before opening or playing it.

This change surfaces valid episode-specific runtime directly on episode cards.

## Issue or approval

No approved feature request is currently linked.

This PR is being submitted directly for maintainer review. The implementation is complete, independently scoped, tested, and includes before/after visual evidence.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

This PR adds visible runtime metadata to episode cards. Explicit maintainer approval has not yet been provided.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [ ] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [ ] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR is limited to displaying episode-specific runtime on episode cards.

It does not:

- add episode availability behavior or an unavailable badge;
- add episode sorting;
- change subtitle handling;
- change playback or source selection;
- change watched-state or progress storage;
- infer runtime from streams;
- add dependencies or test infrastructure;
- include unrelated refactoring;
- modify Nuvio Android TV.

This change adapts an existing user-facing concept already present in NuvioTV, but the implementation is scoped to NuvioMobile only.

## Testing

Tested using Microsoft OpenJDK `21.0.11`.

Commands:

```powershell
.\gradlew.bat :composeApp:testAndroidHostTest :androidApp:testFullDebugUnitTest
.\gradlew.bat :androidApp:assembleFullDebug
```

Results:

- `BUILD SUCCESSFUL`
- 67 actionable Gradle tasks executed.
- All common and unit tests passed.
- Full Debug APK assembled successfully.
- `git diff --check` passed.
- No new dependency or Android test-host configuration was added.

Manual validation:

- Tested on BlueStacks running Android 11 / API 30.
- Tested on Samsung Galaxy S26 Ultra.
- Verified that valid runtime metadata is displayed on episode cards.
- Verified that runtime is formatted compactly (for example, `24m`).
- Verified that runtime is displayed alongside existing episode metadata.
- Verified that episode cards remain clickable.
- Verified that runtime rendering works in portrait layout.
- Verified that missing, invalid, zero, or non-positive runtime values are not shown as visible runtime metadata.
- Verified that playback, progress, and watched-state behavior remain unchanged.

Branch head:

`0fbb95944c5cef7b688038035b936e6140b14ea7`

Full Debug APK SHA-256:

`B72705429AA489A4181E930AB6F1AF7E92A16E59272F925A6EFA9915D07E4398`

## Screenshots / Video (UI changes only)

The screenshots were captured from a combined local QA build.

This PR diff is limited to episode runtime only.

### Before — runtime not displayed on episode cards

Episode cards do not show runtime metadata even when runtime data is available.

![Before — runtime not displayed](https://raw.githubusercontent.com/i7xre/NuvioMobile/pr-evidence/runtime-sorting-20260726/pr-evidence/runtime-sorting-20260726/runtime-before.png)

### After — runtime displayed on episode cards

Episode cards display formatted runtime metadata such as `24m`.

![After — runtime displayed](https://raw.githubusercontent.com/i7xre/NuvioMobile/pr-evidence/runtime-sorting-20260726/pr-evidence/runtime-sorting-20260726/runtime-after.png)

## Breaking changes

None.

- No persisted data or public schema is changed.
- No addon or playback contract is changed.
- No watched-state or progress behavior is changed.
- No dependency or architecture change is introduced.

## Linked issues

No linked issue.

This is a direct implementation proposal submitted for maintainer review. No prior maintainer approval is being claimed.