### PR TITLE
feat(details): add ascending and descending episode ordering

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-ar/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="episodes_sort_descending_action">ترتيب الحلقات تنازليًا</string>
+    <string name="episodes_sort_ascending_action">ترتيب الحلقات تصاعديًا</string>
+</resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -2055,6 +2055,8 @@
     <string name="entity_browse_about">About</string>
     <string name="player_external_loading_subtitles">Loading subtitles from addons...</string>
     <string name="player_external_downloading_subtitles">Downloading subtitles...</string>
+    <string name="episodes_sort_descending_action">Sort episodes descending</string>
+    <string name="episodes_sort_ascending_action">Sort episodes ascending</string>
     <plurals name="entity_browse_title_count">
         <item quantity="one">%d title</item>
         <item quantity="other">%d titles</item>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/EpisodeSortOrder.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/EpisodeSortOrder.kt
@@ -1,0 +1,32 @@
+package com.nuvio.app.features.details
+
+internal enum class EpisodeSortOrder {
+    Ascending,
+    Descending,
+    ;
+
+    fun toggled(): EpisodeSortOrder = when (this) {
+        Ascending -> Descending
+        Descending -> Ascending
+    }
+}
+
+internal fun List<MetaVideo>.orderedForEpisodeDisplay(
+    order: EpisodeSortOrder,
+): List<MetaVideo> = withIndex()
+    .sortedWith { left, right ->
+        val leftNumber = left.value.validEpisodeNumber()
+        val rightNumber = right.value.validEpisodeNumber()
+        when {
+            leftNumber == null && rightNumber == null -> left.index.compareTo(right.index)
+            leftNumber == null -> 1
+            rightNumber == null -> -1
+            leftNumber == rightNumber -> left.index.compareTo(right.index)
+            order == EpisodeSortOrder.Ascending -> leftNumber.compareTo(rightNumber)
+            else -> rightNumber.compareTo(leftNumber)
+        }
+    }
+    .map(IndexedValue<MetaVideo>::value)
+
+private fun MetaVideo.validEpisodeNumber(): Int? =
+    episode?.takeIf { it > 0 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
@@ -36,6 +36,10 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.ArrowDownward
+import androidx.compose.material.icons.rounded.ArrowUpward
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -69,6 +73,7 @@ import com.nuvio.app.core.ui.NuvioProgressBar
 import com.nuvio.app.core.ui.nuvioCardDepth
 import com.nuvio.app.core.ui.nuvioHorizontalScrollBleed
 import com.nuvio.app.core.ui.posterCardClickable
+import com.nuvio.app.features.details.EpisodeSortOrder
 import com.nuvio.app.features.details.MetaDetails
 import com.nuvio.app.features.details.MetaEpisodeCardStyle
 import com.nuvio.app.features.details.MetaVideo
@@ -77,6 +82,7 @@ import com.nuvio.app.features.details.SeasonViewModeStorage
 import com.nuvio.app.features.details.formatRuntimeFromMinutes
 import com.nuvio.app.features.details.metaVideoSeasonEpisodeComparator
 import com.nuvio.app.features.details.normalizeSeasonNumber
+import com.nuvio.app.features.details.orderedForEpisodeDisplay
 import com.nuvio.app.features.details.seasonSortKey
 import com.nuvio.app.features.watchprogress.WatchProgressEntry
 import com.nuvio.app.features.watchprogress.buildPlaybackVideoId
@@ -175,6 +181,12 @@ fun DetailSeriesContent(
     val currentSeason = selectedSeasonOverride
         ?.takeIf { it in groupedEpisodes }
         ?: defaultSeason
+    var isEpisodeOrderDescending by rememberSaveable(meta.id) { mutableStateOf(false) }
+    val episodeSortOrder = if (isEpisodeOrderDescending) {
+        EpisodeSortOrder.Descending
+    } else {
+        EpisodeSortOrder.Ascending
+    }
 
     var seasonViewMode by remember {
         mutableStateOf(SeasonViewModeStorage.load() ?: SeasonViewMode.Posters)
@@ -284,13 +296,34 @@ fun DetailSeriesContent(
                 Column(
                     verticalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
-                    DetailSectionTitle(
-                        title = sectionTitle,
-                    )
-                    val seasonEpisodes = groupedEpisodes.getValue(seasonForContent)
+                    val seasonEpisodes = remember(groupedEpisodes, seasonForContent, episodeSortOrder) {
+                        groupedEpisodes
+                            .getValue(seasonForContent)
+                            .orderedForEpisodeDisplay(episodeSortOrder)
+                    }
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        DetailSectionTitle(
+                            title = sectionTitle,
+                            fullWidth = false,
+                            modifier = Modifier.weight(1f),
+                        )
+                        if (meta.type == "series" && seasonEpisodes.size > 1) {
+                            EpisodeSortToggle(
+                                order = episodeSortOrder,
+                                onClick = {
+                                    isEpisodeOrderDescending = !isEpisodeOrderDescending
+                                },
+                            )
+                        }
+                    }
                     if (episodeCardStyle == MetaEpisodeCardStyle.Horizontal) {
                         EpisodeHorizontalRow(
                             episodes = seasonEpisodes,
+                            sortOrder = episodeSortOrder,
                             maxWidthDp = containerWidthDp,
                             horizontalScrollPadding = horizontalScrollPadding,
                             parentMetaId = meta.id,
@@ -338,6 +371,44 @@ fun DetailSeriesContent(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun EpisodeSortToggle(
+    order: EpisodeSortOrder,
+    onClick: () -> Unit,
+) {
+    val sortsDescending = order == EpisodeSortOrder.Ascending
+    val actionDescription = if (sortsDescending) {
+        stringResource(Res.string.episodes_sort_descending_action)
+    } else {
+        stringResource(Res.string.episodes_sort_ascending_action)
+    }
+
+    Box(
+        modifier = Modifier
+            .size(38.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.48f))
+            .border(
+                width = 1.dp,
+                color = Color.White.copy(alpha = 0.16f),
+                shape = RoundedCornerShape(10.dp),
+            )
+            .clickable(onClick = onClick),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = if (sortsDescending) {
+                Icons.Rounded.ArrowDownward
+            } else {
+                Icons.Rounded.ArrowUpward
+            },
+            contentDescription = actionDescription,
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+            modifier = Modifier.size(20.dp),
+        )
     }
 }
 
@@ -593,6 +664,7 @@ private fun SeasonPosterButton(
 @Composable
 private fun EpisodeHorizontalRow(
     episodes: List<MetaVideo>,
+    sortOrder: EpisodeSortOrder,
     maxWidthDp: Float,
     horizontalScrollPadding: Dp,
     parentMetaId: String,
@@ -608,15 +680,20 @@ private fun EpisodeHorizontalRow(
 ) {
     val rowMetrics = rememberEpisodeHorizontalCardMetrics(maxWidthDp)
     val listState = rememberLazyListState()
-    var hasPositioned by remember(episodes) { mutableStateOf(false) }
+    var hasPositioned by remember { mutableStateOf(false) }
+    var previousSortOrder by remember { mutableStateOf(sortOrder) }
 
-    LaunchedEffect(episodes, preferredEpisodeNumber) {
+    LaunchedEffect(episodes, preferredEpisodeNumber, sortOrder) {
+        val sortOrderChanged = sortOrder != previousSortOrder
         val targetIndex = if (preferredEpisodeNumber != null) {
             episodes.indexOfFirst { it.episode == preferredEpisodeNumber }
         } else {
             -1
         }
-        if (targetIndex >= 0) {
+        if (sortOrderChanged) {
+            listState.animateScrollToItem(0)
+            hasPositioned = true
+        } else if (targetIndex >= 0) {
             if (hasPositioned) {
                 listState.animateScrollToItem(targetIndex)
             } else {
@@ -624,6 +701,7 @@ private fun EpisodeHorizontalRow(
                 hasPositioned = true
             }
         }
+        previousSortOrder = sortOrder
     }
 
     LazyRow(
@@ -639,7 +717,7 @@ private fun EpisodeHorizontalRow(
     ) {
         itemsIndexed(
             items = episodes,
-            key = { index, episode -> "${episode.season}:${episode.episode}:${episode.id}#$index" },
+            key = { _, episode -> "${episode.season}:${episode.episode}:${episode.id}" },
         ) { _, episode ->
             val episodeVideoId = buildPlaybackVideoId(
                 parentMetaId = parentMetaId,

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/EpisodeSortOrderTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/EpisodeSortOrderTest.kt
@@ -1,0 +1,127 @@
+package com.nuvio.app.features.details
+
+import com.nuvio.app.features.watchprogress.buildPlaybackVideoId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class EpisodeSortOrderTest {
+
+    @Test
+    fun ordersNumberedEpisodesAscendingAndDescending() {
+        val episodes = listOf(episode(1), episode(2), episode(3), episode(4))
+
+        assertEquals(
+            listOf(1, 2, 3, 4),
+            episodes.orderedForEpisodeDisplay(EpisodeSortOrder.Ascending).map(MetaVideo::episode),
+        )
+        assertEquals(
+            listOf(4, 3, 2, 1),
+            episodes.orderedForEpisodeDisplay(EpisodeSortOrder.Descending).map(MetaVideo::episode),
+        )
+    }
+
+    @Test
+    fun unknownAndInvalidNumbersStayAtTheEndInBothDirections() {
+        val episodes = listOf(episode(1), episode(2), episode(null), episode(4))
+
+        assertEquals(
+            listOf(1, 2, 4, null),
+            episodes.orderedForEpisodeDisplay(EpisodeSortOrder.Ascending).map(MetaVideo::episode),
+        )
+        assertEquals(
+            listOf(4, 2, 1, null),
+            episodes.orderedForEpisodeDisplay(EpisodeSortOrder.Descending).map(MetaVideo::episode),
+        )
+
+        val invalidNumbers = listOf(episode(2), episode(0), episode(-1), episode(1))
+        assertEquals(
+            listOf(1, 2, 0, -1),
+            invalidNumbers.orderedForEpisodeDisplay(EpisodeSortOrder.Ascending).map(MetaVideo::episode),
+        )
+        assertEquals(
+            listOf(2, 1, 0, -1),
+            invalidNumbers.orderedForEpisodeDisplay(EpisodeSortOrder.Descending).map(MetaVideo::episode),
+        )
+    }
+
+    @Test
+    fun sortsSpecialsWithoutChangingSeasonOrderOrSourceList() {
+        val source = listOf(
+            episode(number = 2, season = 0),
+            episode(number = 1, season = 0),
+            episode(number = 1, season = 1),
+            episode(number = 2, season = 1),
+        )
+        val originalIds = source.map(MetaVideo::id)
+        val bySeason = source.groupBy { normalizeSeasonNumber(it.season) }
+
+        assertEquals(
+            listOf(2, 1),
+            bySeason.getValue(0)
+                .orderedForEpisodeDisplay(EpisodeSortOrder.Descending)
+                .map(MetaVideo::episode),
+        )
+        assertEquals(listOf(0, 1), bySeason.keys.toList())
+        assertEquals(originalIds, source.map(MetaVideo::id))
+    }
+
+    @Test
+    fun selectedOrderAppliesWhenChangingSeasonsAndRepeatedlyToggling() {
+        val bySeason = listOf(
+            episode(number = 1, season = 1),
+            episode(number = 2, season = 1),
+            episode(number = 1, season = 2),
+            episode(number = 2, season = 2),
+        ).groupBy { normalizeSeasonNumber(it.season) }
+        val descending = EpisodeSortOrder.Ascending.toggled()
+
+        assertEquals(
+            listOf(2, 1),
+            bySeason.getValue(1).orderedForEpisodeDisplay(descending).map(MetaVideo::episode),
+        )
+        assertEquals(
+            listOf(2, 1),
+            bySeason.getValue(2).orderedForEpisodeDisplay(descending).map(MetaVideo::episode),
+        )
+        assertEquals(
+            EpisodeSortOrder.Ascending,
+            descending.toggled(),
+        )
+    }
+
+    @Test
+    fun reversingPreservesEpisodeIdentityAndProgressLookup() {
+        val first = episode(1)
+        val fourth = episode(4)
+        val parentMetaId = "series-fixture"
+        val progressByVideoId = mapOf(
+            first.playbackVideoId(parentMetaId) to 0.25f,
+            fourth.playbackVideoId(parentMetaId) to 0.75f,
+        )
+
+        val reversed = listOf(first, fourth).orderedForEpisodeDisplay(EpisodeSortOrder.Descending)
+
+        assertSame(fourth, reversed.first())
+        assertEquals("season-1-episode-4", reversed.first().id)
+        assertEquals(0.75f, progressByVideoId[reversed.first().playbackVideoId(parentMetaId)])
+    }
+
+    private fun MetaVideo.playbackVideoId(parentMetaId: String): String =
+        buildPlaybackVideoId(
+            parentMetaId = parentMetaId,
+            seasonNumber = season,
+            episodeNumber = episode,
+            fallbackVideoId = id,
+        )
+
+    private fun episode(
+        number: Int?,
+        season: Int = 1,
+    ) = MetaVideo(
+        id = "season-$season-episode-$number",
+        title = "Episode $number",
+        season = season,
+        episode = number,
+    )
+}


### PR DESCRIPTION
## Summary

Adds an ascending/descending episode-order toggle to series detail screens.

Ascending remains the default order. The toggle changes only the displayed order of episodes within the selected season.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Episodes are currently displayed only in ascending numerical order.

For seasons containing many episodes, reaching the highest-numbered or most recent episode requires scrolling through the full list.

This change adds an optional descending order while preserving ascending order as the default.

## Issue or approval

No approved feature request is currently linked.

This PR is being submitted directly for maintainer review. The implementation is complete, independently scoped, tested, and includes before/after visual evidence.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

This PR adds both a small UI control and an optional episode-ordering behavior. Explicit maintainer approval has not yet been provided.

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [ ] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [ ] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR is limited to ordering episodes within the selected season.

It does not:

- reorder seasons;
- modify the original episode source lists in place;
- add episode runtime metadata;
- add episode availability behavior;
- change subtitle handling;
- change playback or source selection;
- change progress or watched-state storage;
- add dependencies or test infrastructure;
- include unrelated refactoring;
- modify Nuvio Android TV.

This is a NuvioMobile-specific feature. No equivalent user-facing episode-order control was verified in Nuvio Android TV.

## Testing

Tested using Microsoft OpenJDK `21.0.11`.

Commands:

```powershell
.\gradlew.bat :composeApp:testAndroidHostTest :androidApp:testFullDebugUnitTest
.\gradlew.bat :androidApp:assembleFullDebug
```

Results:

- `BUILD SUCCESSFUL`
- 67 actionable Gradle tasks executed.
- All common and unit tests passed.
- Full Debug APK assembled successfully.
- `git diff --check` passed.
- No new dependency or Android test-host configuration was added.

Manual validation:

- Tested on BlueStacks running Android 11 / API 30.
- Tested on Samsung Galaxy S26 Ultra.
- Verified that ascending order remains the default.
- Verified that ascending order starts with Episode 1.
- Verified that descending order starts with the highest valid episode.
- Verified that Episode 12 is followed by Episode 11 in the tested season.
- Verified that invalid or unknown episode numbers remain after valid numbered episodes.
- Verified that seasons themselves are not reordered.
- Verified that changing the order moves the list to index zero of the newly ordered result.
- Verified that changing seasons while descending starts at index zero of the newly sorted season.
- Verified that selecting a displayed card opens the corresponding episode.
- Verified that episode identity, playback ID generation, progress, and watched state remain associated with the correct episode.

Branch head:

`6d2446bb54cba2778ddef190b24d93bd6c3ab346`

Full Debug APK SHA-256:

`4B40518A01BD0F72EA48F4096B3C11D323F02CA1C541917A24CDBF636D29F1BB`

## Screenshots / Video (UI changes only)

The screenshots were captured from a combined local QA build.

Runtime metadata visible in the screenshots is not included in this PR diff. This PR contains only the episode-ordering feature.

### Before — no episode-order control

Episodes are displayed in a fixed ascending order, with no control for reversing the list.

![Before — no sorting control](https://raw.githubusercontent.com/i7xre/NuvioMobile/pr-evidence/runtime-sorting-20260726/pr-evidence/runtime-sorting-20260726/sorting-before.png)

### Ascending order

Ascending remains the default, with Episode 1 displayed first.

![Ascending — Episode 1 first](https://raw.githubusercontent.com/i7xre/NuvioMobile/pr-evidence/runtime-sorting-20260726/pr-evidence/runtime-sorting-20260726/sorting-ascending.png)

### Descending order

Descending displays Episode 12 first, followed by Episode 11.

![Descending — Episode 12 first](https://raw.githubusercontent.com/i7xre/NuvioMobile/pr-evidence/runtime-sorting-20260726/pr-evidence/runtime-sorting-20260726/sorting-descending.png)

## Breaking changes

None.

- Existing ascending order remains the default.
- No persisted data or public schema is changed.
- No addon, playback, progress, or watched-state contract is changed.
- No dependency or architecture change is introduced.

## Linked issues

No linked issue.

This is a direct implementation proposal submitted for maintainer review. No prior maintainer approval is being claimed.