### PR TITLE
feat: pass currently selected or last selected subtitle to external p…

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/ExternalPlayerPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/ExternalPlayerPlatform.android.kt
@@ -109,6 +109,7 @@ internal actual object ExternalPlayerPlatform {
         val subtitles = request.subtitles
         if (!subtitles.isNullOrEmpty()) {
             val subtitleUris = subtitles.map { Uri.parse(it.url) }.toTypedArray()
+            val subtitleCurrentOrFirstUri = request.currentSubtitle?.url ?: subtitles.first().url
             val subtitleNames = subtitles.map { it.name }.toTypedArray()
             val subtitleFilenames = subtitles.map { "${it.lang}_${it.name}.srt" }.toTypedArray()
 
@@ -120,7 +121,7 @@ internal actual object ExternalPlayerPlatform {
             val clipData = android.content.ClipData(
                 "subtitles",
                 arrayOf("application/x-subrip", "text/vtt"),
-                android.content.ClipData.Item(subtitleUris.first())
+                android.content.ClipData.Item(subtitleCurrentOrFirstUri)
             )
             subtitleUris.drop(1).forEach { subtitleUri ->
                 clipData.addItem(android.content.ClipData.Item(subtitleUri))
@@ -131,17 +132,17 @@ internal actual object ExternalPlayerPlatform {
             putExtra("subs", subtitleUris)
             putExtra("subs.name", subtitleNames)
             putExtra("subs.filename", subtitleFilenames)
-            putExtra("subs.enable", arrayOf(subtitleUris.first()))
+            putExtra("subs.enable", arrayOf(subtitleCurrentOrFirstUri))
 
             // Just Player
             putExtra("subtitle_uri", subtitleUris)
             putExtra("subtitle_name", subtitleNames)
 
-            // VLC (single subtitle — use first one)
-            putExtra("subtitles_location", subtitleUris.first())
+            // VLC (single subtitle — use selected one)
+            putExtra("subtitles_location", subtitleCurrentOrFirstUri)
 
             // Vimu Player
-            putExtra("forcedsrt", subtitles.first().url)
+            putExtra("forcedsrt", subtitleCurrentOrFirstUri)
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -176,9 +176,11 @@ import com.nuvio.app.features.player.PlayerPlaybackSnapshot
 import com.nuvio.app.features.player.ExternalPlayerIntentResult
 import com.nuvio.app.features.player.ExternalPlayerPlatform
 import com.nuvio.app.features.player.ExternalPlayerPlaybackRequest
+import com.nuvio.app.features.player.SubtitleInput
 import com.nuvio.app.features.player.rememberExternalPlayerLauncher
 import com.nuvio.app.features.player.prepareExternalPlayerLaunch
 import com.nuvio.app.features.player.SubtitleLanguageOption
+import com.nuvio.app.features.streams.StreamSubtitle
 import com.nuvio.app.features.player.sanitizePlaybackHeaders
 import com.nuvio.app.features.player.sanitizePlaybackResponseHeaders
 import com.nuvio.app.features.profiles.AvatarRepository
@@ -394,6 +396,14 @@ private fun PlayerLaunch.toExternalPlayerPlaybackRequest(): ExternalPlayerPlayba
         season = seasonNumber,
         episode = episodeNumber,
         episodeTitle = episodeTitle,
+        currentSubtitle = currentSubtitle,
+        subtitles = externalSubtitles.map { sub: StreamSubtitle ->
+            SubtitleInput(
+                url = sub.url,
+                name = sub.name ?: sub.language,
+                lang = sub.language
+            )
+        }.takeIf { it.isNotEmpty() }
     )
 
 private enum class AppGateScreen {
@@ -1398,6 +1408,7 @@ private fun MainAppContent(
                 request = baseRequest,
                 type = launch.contentType ?: launch.parentMetaType,
                 videoId = launch.videoId ?: launch.parentMetaId,
+                parentMetaId = launch.parentMetaId,
                 forwardSubtitles = playerSettingsUiState.externalPlayerForwardSubtitles,
                 sendSkipSegments = shouldSendSkipSegments,
                 preferredLanguage = playerSettingsUiState.preferredSubtitleLanguage,
@@ -2983,6 +2994,7 @@ private fun MainAppContent(
                                 parentMetaId = launch.parentMetaId,
                                 parentMetaType = launch.parentMetaType,
                                 initialPositionMs = request.resumePositionMs,
+                                currentSubtitle = request.currentSubtitle,
                             )
                             lastExternalPlayerLaunch = playerLaunch
                             val intentResult = ExternalPlayerPlatform.buildIntent(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerLaunchCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerLaunchCoordinator.kt
@@ -33,6 +33,7 @@ suspend fun prepareExternalPlayerLaunch(
     request: ExternalPlayerPlaybackRequest,
     type: String,
     videoId: String,
+    parentMetaId: String,
     forwardSubtitles: Boolean,
     sendSkipSegments: Boolean,
     preferredLanguage: String,
@@ -48,6 +49,7 @@ suspend fun prepareExternalPlayerLaunch(
             val subtitles = SubtitleForwarder.fetchForExternalPlayer(
                 type = type,
                 videoId = videoId,
+                parentMetaId = parentMetaId,
                 preferredLanguage = preferredLanguage,
                 secondaryLanguage = secondaryLanguage,
             )
@@ -76,6 +78,17 @@ suspend fun prepareExternalPlayerLaunch(
     }
     skipSegmentsDeferred?.await()?.let { skipSegmentsJson ->
         result = result.copy(skipSegmentsJson = skipSegmentsJson)
+    }
+
+    val preference = PlayerTrackPreferenceStorage.load(parentMetaId)
+    if (result.currentSubtitle == null && preference != null) {
+        val match = result.subtitles?.find {
+            it.url == preference.addonSubtitleUrl ||
+                    (it.name == preference.subtitleName && it.lang == preference.subtitleLanguage)
+        }
+        if (match != null) {
+            result = result.copy(currentSubtitle = match)
+        }
     }
 
     return@coroutineScope result

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerPlatform.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerPlatform.kt
@@ -18,6 +18,7 @@ data class ExternalPlayerPlaybackRequest(
     val sourceHeaders: Map<String, String> = emptyMap(),
     val resumePositionMs: Long = 0L,
     val subtitles: List<SubtitleInput>? = null,
+    val currentSubtitle: SubtitleInput? = null,
     val season: Int? = null,
     val episode: Int? = null,
     val episodeTitle: String? = null,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerModels.kt
@@ -46,6 +46,7 @@ data class PlayerLaunch(
     val initialPositionMs: Long = 0L,
     val initialProgressFraction: Float? = null,
     val contentLanguage: String? = null,
+    val currentSubtitle: SubtitleInput? = null,
 )
 
 object PlayerLaunchStore {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenArgs.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenArgs.kt
@@ -39,4 +39,5 @@ internal data class PlayerScreenArgs(
     val initialPositionMs: Long,
     val initialProgressFraction: Float?,
     val contentLanguage: String? = null,
+    val currentSubtitle: SubtitleInput? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -308,6 +308,13 @@ private fun PlayerScreenRuntime.RenderPlayerControls(displayedPositionMs: Long, 
                             sourceHeaders = activeSourceHeaders,
                             resumePositionMs = playbackSnapshot.positionMs,
                             subtitles = loadedSubtitles,
+                            currentSubtitle = selectedAddonSubtitle?.let {
+                                SubtitleInput(
+                                    it.url,
+                                    it.display,
+                                    it.language
+                                )
+                            },
                             season = activeSeasonNumber,
                             episode = activeEpisodeNumber,
                             episodeTitle = activeEpisodeTitle,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleForwarder.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleForwarder.kt
@@ -13,6 +13,7 @@ object SubtitleForwarder {
     suspend fun fetchForExternalPlayer(
         type: String,
         videoId: String,
+        parentMetaId: String,
         preferredLanguage: String,
         secondaryLanguage: String?,
         timeoutMs: Long = 10_000L,
@@ -31,11 +32,18 @@ object SubtitleForwarder {
                 }
 
                 val allSubtitles = SubtitleRepository.addonSubtitles.value
+                val preference = PlayerTrackPreferenceStorage.load(parentMetaId)
 
                 val filtered = allSubtitles.filter { subtitle ->
-                    languageMatchesPreference(subtitle.language, preferredLanguage) ||
-                        (secondaryLanguage != null &&
-                            languageMatchesPreference(subtitle.language, secondaryLanguage))
+                    val isLastSelected = preference != null && (
+                            subtitle.url == preference.addonSubtitleUrl ||
+                                    (subtitle.display == preference.subtitleName && subtitle.language == preference.subtitleLanguage)
+                            )
+
+                    isLastSelected ||
+                            languageMatchesPreference(subtitle.language, preferredLanguage) ||
+                            (secondaryLanguage != null &&
+                                    languageMatchesPreference(subtitle.language, secondaryLanguage))
                 }
 
                 filtered.map { subtitle ->

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/ExternalPlayerPlatform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/player/ExternalPlayerPlatform.ios.kt
@@ -36,7 +36,7 @@ private val iosExternalPlayerSpecs = listOf(
             buildString {
                 append("vlc-x-callback://x-callback-url/stream?url=")
                 append(request.sourceUrl.urlQueryEncode())
-                request.subtitles?.firstOrNull()?.let { subtitle ->
+                (request.currentSubtitle ?: request.subtitles?.firstOrNull())?.let { subtitle ->
                     append("&sub=")
                     append(subtitle.url.urlQueryEncode())
                 }


### PR DESCRIPTION
## Summary

<!-- What changed in this PR? -->

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

<!-- Why this change is needed. Explain the user-visible bug, regression, maintenance need, docs error, or approved request. -->

As of currently, Nuvio passes the whatever is first in the list to external player through the intent. What is more convenient is to pass the currently or last selected subtitle through the intent if the player only supports single subtitle to be passed.

## Issue or approval

<!-- Required. Link the bug issue or approved feature request. For docs/translation/maintenance with no issue, explain why no issue is needed. -->
<!-- Examples: Fixes #123 / Approved in #456 / No linked issue: typo-only docs fix. -->

Fixes #1629

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

<!-- List anything intentionally not changed. If this is a bug fix, confirm it does not include extra UI polish or behavior tweaks. -->

This only includes a change in the behavior of external player request open request. Whether the issue could be considered as a bug, im not sure.

## Testing

<!-- What you tested and how. Include devices/emulators, commands, and manual flows. Do not write only "not tested" unless this is docs/translation-only. -->

Tested by launching an external player (directly or from within the internal player) and observing that the external player does not use whatever subtitle was selected in the internal player but the first one in the list of subtitles.

## Screenshots / Video (UI changes only)

<!-- Required for any UI change. Write "Not a UI change" only if no UI changed. -->

Not a UI change

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->

None

## Linked issues

<!-- Required for bug fixes, UI glitch fixes, behavior fixes, and approved changes. For docs/translation/maintenance with no issue, write: No linked issue - reason. -->

#1629
