### PR TITLE
fix: Simkl anime - prevent show wipe, reactive CW update, next episode resolution

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -568,12 +568,13 @@ fun MetaDetailsScreen(
                 val movieProgress = progressByVideoId[meta.id]
                     ?.takeUnless { it.isCompleted }
                 val cwPrefs by ContinueWatchingPreferencesRepository.uiState.collectAsStateWithLifecycle()
-                val seriesAction = remember(watchProgressUiState.entries, watchedUiState.items, meta, todayIsoDate, cwPrefs.upNextFromFurthestEpisode) {
+                val seriesAction = remember(watchProgressUiState.entries, watchedUiState.items, meta, todayIsoDate, cwPrefs.upNextFromFurthestEpisode, watchedUiState.watchedKeys) {
                     meta.seriesPrimaryAction(
                         entries = watchProgressUiState.entries,
                         watchedItems = watchedUiState.items,
                         todayIsoDate = todayIsoDate,
                         preferFurthestEpisode = cwPrefs.upNextFromFurthestEpisode,
+                        watchedKeys = watchedUiState.watchedKeys,
                     )
                 }
                 val seriesActionVideo = remember(seriesAction, meta.id, meta.videos) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/SeriesPlaybackResolver.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/SeriesPlaybackResolver.kt
@@ -2,6 +2,8 @@ package com.nuvio.app.features.details
 
 import com.nuvio.app.features.watched.WatchedItem
 import com.nuvio.app.features.watched.normalizeWatchedMarkedAtEpochMs
+import com.nuvio.app.features.watched.watchedItemKey
+import com.nuvio.app.features.watching.application.WatchingState
 import com.nuvio.app.features.watchprogress.WatchProgressEntry
 import com.nuvio.app.features.watching.domain.WatchingCompletedEpisode
 import com.nuvio.app.features.watching.domain.WatchingContentRef
@@ -144,15 +146,33 @@ internal fun MetaDetails.seriesPrimaryAction(
     todayIsoDate: String,
     preferFurthestEpisode: Boolean = true,
     showUnairedNextUp: Boolean = false,
-): SeriesPrimaryAction? =
-    seriesPrimaryAction(
-        content = WatchingContentRef(type = type, id = id),
+    watchedKeys: Set<String> = emptySet(),
+): SeriesPrimaryAction? {
+    val content = WatchingContentRef(type = type, id = id)
+    val effectiveWatchedItems = buildList {
+        addAll(watchedItems.filter { it.type.equals(type, ignoreCase = true) && it.id.equals(id, ignoreCase = true) })
+        if (watchedKeys.isNotEmpty()) {
+            val existingKeys = mapTo(mutableSetOf()) { watchedItemKey(it.type, it.id, it.season, it.episode) }
+            videos.forEach { video ->
+                val season = video.season ?: return@forEach
+                val episode = video.episode ?: return@forEach
+                val key = watchedItemKey(type, id, season, episode)
+                if (key in existingKeys) return@forEach
+                if (WatchingState.isEpisodeWatched(watchedKeys, type, id, video)) {
+                    add(WatchedItem(id = id, type = type, season = season, episode = episode, name = "", markedAtEpochMs = 0L))
+                }
+            }
+        }
+    }
+    return seriesPrimaryAction(
+        content = content,
         entries = entries,
-        watchedItems = watchedItems,
+        watchedItems = effectiveWatchedItems,
         todayIsoDate = todayIsoDate,
         preferFurthestEpisode = preferFurthestEpisode,
         showUnairedNextUp = showUnairedNextUp,
     )
+}
 
 internal fun MetaDetails.seriesPrimaryAction(
     content: WatchingContentRef,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklApplicationAdapters.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklApplicationAdapters.kt
@@ -100,11 +100,13 @@ object SimklWatchedSyncAdapter : TrackingWatchedProvider {
 
     override suspend fun delete(profileId: Int, items: Collection<WatchedItem>) {
         if (profileId != ProfileRepository.activeProfileId || items.isEmpty()) return
+        val episodeItems = items.filter { item -> item.season != null && item.episode != null }
+        if (episodeItems.isEmpty()) return
         // Optimistically mark video IDs as removed so fallback won't show them as watched
-        items.forEach { item -> item.videoId?.let(SimklAnimeWatchedFallback::markOptimisticallyRemoved) }
+        episodeItems.forEach { item -> item.videoId?.let(SimklAnimeWatchedFallback::markOptimisticallyRemoved) }
         SimklSyncRepository.ensureLoaded()
         val snapshot = SimklSyncRepository.state.value.snapshot
-        val media = items.map { item ->
+        val media = episodeItems.map { item ->
             snapshot.mediaReference(
                 contentId = item.id,
                 contentType = item.type,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watched/WatchedRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watched/WatchedRepository.kt
@@ -818,6 +818,7 @@ object WatchedRepository {
         } else if (source.providerId != null) {
             // Items not found in local store (e.g. anime resolved via snapshot fallback).
             // Still push delete to provider so it can remove from remote.
+            // The observer on snapshot changes will re-pull items and update the store.
             pushDeleteToServer(items = items.toList(), source = source)
         }
     }
@@ -1010,7 +1011,8 @@ object WatchedRepository {
     /**
      * Observes provider extra watched keys (e.g. Simkl anime alternate IDs).
      * When the provider's snapshot changes (after mutations, syncs), recomputes
-     * extra keys and re-publishes so watchedKeys stays reactive and current.
+     * extra keys, re-pulls watched items, and re-publishes so watchedKeys and
+     * items stay reactive and current.
      */
     private fun startExtraKeysObserverIfNeeded() {
         if (extraKeysObserverJob != null) return
@@ -1021,9 +1023,19 @@ object WatchedRepository {
             adapter.observeExtraWatchedKeys(currentProfileId)
                 .distinctUntilChanged()
                 .collectLatest { extraKeys ->
-                    val changed = providerExtraWatchedKeys[providerId] != extraKeys
-                    if (changed) {
+                    val keysChanged = providerExtraWatchedKeys[providerId] != extraKeys
+                    if (keysChanged) {
                         providerExtraWatchedKeys[providerId] = extraKeys
+                        // Re-pull items from provider to reflect snapshot changes
+                        // (e.g. after remote episode removal)
+                        val freshItems = adapter.pull(
+                            profileId = currentProfileId,
+                            pageSize = watchedItemsPageSize,
+                        )
+                        val itemsByKey = freshItems.associateBy { item ->
+                            watchedItemKey(item.type, item.id, item.season, item.episode)
+                        }.toMutableMap()
+                        providerItemsByKey[providerId] = itemsByKey
                         publish()
                     }
                 }


### PR DESCRIPTION
## Summary

Three follow-up fixes to https://github.com/NuvioMedia/NuvioMobile/pull/1619:

1. Skip series-level removal in Simkl delete to prevent wiping entire show from library
2. Observer re-pulls watched items after snapshot change so CW updates reactively
3. Next episode calculation resolves anime watched via fallback for franchise parent IDs

## PR type

- [x] Reproducible bug fix

## Why

Three bugs found during testing of anime tracking:

1. **Entire show wiped from Simkl:** When user unmarks an episode, `reconcileSeriesWatchedState` removes the series-level marker (WatchedItem without season/episode). This was forwarded to Simkl as a show-level removal, deleting the entire entry and all episode history.

2. **CW not updating after unmark via MAL:** When unmarking from a franchise parent page (e.g. `mal:60636`), the item in local store is under canonical IMDB so it can't be found by primary key. The delete goes to Simkl API successfully, snapshot refreshes, but the observer only updated extra keys without re-pulling items -> CW stayed stale until app restart.

3. **Next episode stuck on S1E1 when entering via MAL:** `seriesPrimaryAction` filtered watched items by `meta.id` which is the franchise parent MAL. Items in store are under canonical IMDB -> empty list -> next = first episode. Even though checkmarks were correct (via fallback), the next-up calculation didn't use the same resolution path.

## Issue or approval

No linked issue - found during real-device testing of https://github.com/NuvioMedia/NuvioMobile/pull/1619

## Reproduction steps

**Bug 1:**
1. Mark 3 episodes via MAL content ID
2. Enter same anime via IMDB
3. Unmark last episode -> entire series disappears from Simkl

**Bug 2:**
1. Have anime in CW showing correct next episode (via IMDB)
2. Enter via MAL, unmark an episode
3. Return to home -> CW still shows old next episode (until restart)

**Bug 3:**
1. Enter Bleach via `mal:60636` (franchise parent)
2. All episodes shown as watched (checkmarks correct)
3. Next episode shows S1E1 instead of S17E41

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

Changes:
- SimklWatchedSyncAdapter.delete(): filters out items without season/episode
- WatchedRepository observer: re-pulls items from provider after snapshot change (not just extra keys)
- SeriesPlaybackResolver: seriesPrimaryAction accepts watchedKeys, synthesizes watched records via isEpisodeWatched fallback for episodes not in store under meta.id
- MetaDetailsScreen: passes watchedKeys to seriesPrimaryAction

No changes to: Trakt, scrobble path, mark-watched path, CW home screen logic.

## Testing

- Verified on device: unmark episode no longer wipes entire show from Simkl
- Verified on device: CW updates within 1-2s after unmark via MAL page
- Verified on device: next episode correct when entering via franchise parent MAL ID
- Verified on device: marking new episode via MAL -> exit -> re-enter -> next episode advances

## Screenshots / Video

Not a UI change.

## Breaking changes

None. `seriesPrimaryAction` gains optional `watchedKeys` parameter with default empty set.

## Linked issues

Follow-up to https://github.com/NuvioMedia/NuvioMobile/pull/1619
