### PR TITLE
fix: resolve anime skip intros (Kitsu/MAL routing & AniSkip query fix)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -397,12 +397,21 @@ private fun PlayerScreenRuntime.BindPlayerMetadataAndSkipEffects() {
         if (season == null || episode == null || vid == null) return@LaunchedEffect
 
         launch {
-            val imdbId = vid.split(":").firstOrNull()?.takeIf { it.startsWith("tt") }
-            val intervals = SkipIntroRepository.getSkipIntervals(
-                imdbId = imdbId,
-                season = season,
-                episode = episode,
-            )
+            val intervals = when {
+                vid.startsWith("mal:") -> {
+                    val malId = vid.removePrefix("mal:").substringBefore(':')
+                    SkipIntroRepository.getSkipIntervalsForMal(malId = malId, episode = episode)
+                }
+                vid.startsWith("kitsu:") -> {
+                    val kitsuId = vid.removePrefix("kitsu:").substringBefore(':')
+                    SkipIntroRepository.getSkipIntervalsForKitsu(kitsuId = kitsuId, episode = episode)
+                }
+                else -> SkipIntroRepository.getSkipIntervals(
+                    imdbId = vid.substringBefore(':').takeIf { it.startsWith("tt") },
+                    season = season,
+                    episode = episode,
+                )
+            }
             skipIntervals = intervals
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipIntroApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipIntroApi.kt
@@ -92,8 +92,8 @@ internal object SkipIntroApi {
         malId: String,
         episode: Int,
     ): AniSkipResponse? {
-        val types = "op,ed,recap,mixed-op,mixed-ed"
-        val url = "${ANISKIP_BASE}skip-times/$malId/$episode?types=$types&episodeLength=0"
+        val types = "types=op&types=ed&types=recap&types=mixed-op&types=mixed-ed"
+        val url = "${ANISKIP_BASE}skip-times/$malId/$episode?$types&episodeLength=0"
         return try {
             val text = httpGetText(url)
             json.decodeFromString<AniSkipResponse>(text)


### PR DESCRIPTION
## Summary

Fixed skip intro functionality for anime when using addons (like AIO Metadata) that return Kitsu or MAL IDs. Corrected the AniSkip API request to prevent HTTP 400 errors.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The in-app player previously only attempted skip-intro lookups if the episode ID started with `tt` (IMDb). Anime IDs with `kitsu:` or `mal:` prefixes were completely ignored and returned early, bypassing the existing Kitsu/MAL resolvers inside `SkipIntroRepository`. 
Additionally, the AniSkip v2 API was failing silently with an HTTP 400 error because the `types` query parameter was passed as a comma-separated string (`types=op,ed...`) instead of the required repeated parameters (`types=op&types=ed...`).

## Issue or approval

Fixes #1640

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This PR strictly fixes the ID routing for `kitsu:` and `mal:` in `PlayerScreenRuntimeEffects.kt` and fixes the URL formatting in `SkipIntroApi.kt`. It does not alter the Skip Intro UI components, nor does it introduce new third-party dependencies.

## Testing

* Tested locally on Android.
* Played an anime episode (*One Piece*) using AIO Metadata, which supplies a Kitsu episode ID (`kitsu:12:...`).
* Verified via logs that the `kitsu:` ID is correctly routed to `SkipIntroRepository.getSkipIntervalsForKitsu()`.
* Verified that Anime Skip (GraphQL) successfully resolved the show and returned skip intervals.
* Verified that AniSkip (REST API) received the correctly formatted `types=op&types=ed...` query and returned a 200 OK instead of crashing.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1640