### PR TITLE
fix(library): preserve leading articles in title sorting for natural alphabetical order

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryDisplaySettings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryDisplaySettings.kt
@@ -227,12 +227,8 @@ private val LibraryDisplaySettingsJson = Json {
     encodeDefaults = true
 }
 
-private val LeadingLibraryTitleArticle = Regex("^(the|an|a)\\s+", RegexOption.IGNORE_CASE)
-
 private fun libraryTitleSortKey(item: LibraryItem): String =
     libraryTitleTieBreakKey(item)
-        .trim()
-        .replace(LeadingLibraryTitleArticle, "")
 
 private fun libraryTitleTieBreakKey(item: LibraryItem): String =
     item.name

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryDisplaySettings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryDisplaySettings.kt
@@ -110,17 +110,17 @@ internal fun sortLibraryItems(
         LibrarySortOption.DEFAULT -> items.sortedWith(
             compareBy<LibraryItem> { it.traktRank ?: Int.MAX_VALUE }
                 .thenByDescending { it.savedAtEpochMs }
-                .thenBy { libraryTitleTieBreakKey(it) }
+                .thenBy { libraryTitleSortKey(it) }
                 .thenBy { it.id },
         )
         LibrarySortOption.ADDED_DESC -> items.sortedWith(
             compareByDescending<LibraryItem> { it.savedAtEpochMs }
-                .thenBy { libraryTitleTieBreakKey(it) }
+                .thenBy { libraryTitleSortKey(it) }
                 .thenBy { it.id },
         )
         LibrarySortOption.ADDED_ASC -> items.sortedWith(
             compareBy<LibraryItem> { it.savedAtEpochMs }
-                .thenBy { libraryTitleTieBreakKey(it) }
+                .thenBy { libraryTitleSortKey(it) }
                 .thenBy { it.id },
         )
         LibrarySortOption.TITLE_ASC -> items.sortedWith(
@@ -227,16 +227,10 @@ private val LibraryDisplaySettingsJson = Json {
     encodeDefaults = true
 }
 
-private val LeadingLibraryTitleArticle = Regex("^(the|an|a)\\s+", RegexOption.IGNORE_CASE)
-
 private fun libraryTitleSortKey(item: LibraryItem): String =
-    libraryTitleTieBreakKey(item)
-        .trim()
-        .replace(LeadingLibraryTitleArticle, "")
-
-private fun libraryTitleTieBreakKey(item: LibraryItem): String =
     item.name
-        .ifBlank { item.id }
+        .trim()
+        .ifBlank { item.id.trim() }
         .lowercase()
 
 private fun libraryDisplayItemKey(item: LibraryItem): String =

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/library/LibraryDisplaySettingsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/library/LibraryDisplaySettingsTest.kt
@@ -55,7 +55,7 @@ class LibraryDisplaySettingsTest {
     }
 
     @Test
-    fun `title sorting ignores leading English articles`() {
+    fun `title sorting preserves leading articles for literal alphabetical order`() {
         val input = listOf(
             item("batman", name = "The Batman"),
             item("arrival", name = "Arrival"),
@@ -63,11 +63,11 @@ class LibraryDisplaySettingsTest {
         )
 
         assertEquals(
-            listOf("arrival", "batman", "quiet"),
+            listOf("quiet", "arrival", "batman"),
             sortLibraryItems(input, LibrarySortOption.TITLE_ASC, LibrarySourceMode.LOCAL).map { it.id },
         )
         assertEquals(
-            listOf("quiet", "batman", "arrival"),
+            listOf("batman", "arrival", "quiet"),
             sortLibraryItems(input, LibrarySortOption.TITLE_DESC, LibrarySourceMode.LOCAL).map { it.id },
         )
     }


### PR DESCRIPTION
## Summary

Fixes title sorting in the mobile library to preserve leading articles ("The", "A", "An") so that titles are sorted in natural/literal alphabetical order (e.g., "The Batman" under 'T' rather than 'B').

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

When sorting library titles alphabetically (A–Z / Z–A), leading articles were being stripped, causing titles starting with "The", "A", or "An" to sort under their second word. Preserving leading articles aligns title sorting with natural alphabetical expectations.

## Issue or approval

Fixes #1676; title sorting bug identified directly during manual testing.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Limited strictly to title sorting logic in `LibraryDisplaySettings.kt`. Does not include additional sort options, UI refactors, database schema changes, or unrelated library features.

## Testing

- **Unit Tests**: Verified with `./gradlew test` including `LibraryDisplaySettingsTest` to confirm literal alphabetical ordering for titles with leading articles.
- **Manual Verification**: Verified title sorting order on Mobile Library screen.

## Screenshots / Video

*Note: Title A–Z sorting is shown below for representation.*

| Before | After |
| :---: | :---: |
| *<img width="486" height="1082" alt="Screenshot 2026-07-27 183450" src="https://github.com/user-attachments/assets/000c13cb-97c4-4bf8-a8f3-11ba8d399612" />* | *<img width="501" height="1091" alt="Screenshot 2026-07-27 183517" src="https://github.com/user-attachments/assets/f5ac72eb-5e7a-4296-9671-2dbc95ed209b" />* |

## Breaking changes

None.

## Linked issues

#1676 
