### PR TITLE
feat(library): add rating and release date sorting with TMDb metadata enrichment

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -1699,6 +1699,10 @@
     <string name="library_other">Other</string>
     <string name="library_sort_added_asc">Oldest added</string>
     <string name="library_sort_added_desc">Recently added</string>
+    <string name="library_sort_rating_asc">Lowest rated</string>
+    <string name="library_sort_rating_desc">Highest rated</string>
+    <string name="library_sort_release_date_asc">Oldest released</string>
+    <string name="library_sort_release_date_desc">Latest released</string>
     <string name="library_sort_title_asc">Title A–Z</string>
     <string name="library_sort_title_desc">Title Z–A</string>
     <string name="library_sort_provider_order">Tracker order</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/format/ReleaseDateDisplay.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/format/ReleaseDateDisplay.kt
@@ -3,20 +3,83 @@ package com.nuvio.app.core.format
 import com.nuvio.app.core.i18n.localizedMonthName
 import com.nuvio.app.core.time.parseEpisodeReleaseLocalDate
 
+private fun isEpisodicType(type: String?): Boolean {
+    if (type.isNullOrBlank()) return false
+    val t = type.trim().lowercase()
+    return t in setOf("series", "show", "tv", "tvshow", "anime")
+}
+
 /**
- * Formats ISO calendar dates (yyyy-MM-dd or yyyy-MM-ddTHH:mm:ss…) for UI as "2025 February 1".
- * Other strings (e.g. year-only "2024", human text from addons) are returned unchanged.
+ * Formats release dates for UI display:
+ * - Movies: Absolute date format starting with day and ending with year ("5 June 2014")
+ * - Series, Anime & Shows:
+ *   - Standalone / 1 season completed: "yyyy" (e.g. "2018")
+ *   - Multiple seasons continuing: "yyyy – " (e.g. "2000 – ")
+ *   - Multiple seasons completed: "yyyy – yyyy" (e.g. "2000 – 2010")
  */
-fun formatReleaseDateForDisplay(raw: String): String {
+fun formatReleaseDateForDisplay(raw: String, type: String? = null): String {
     val trimmed = raw.trim()
     if (trimmed.isEmpty()) return raw
-    val datePart = parseEpisodeReleaseLocalDate(trimmed) ?: return raw
-    val parts = datePart.split('-')
-    if (parts.size != 3) return raw
-    val year = parts[0].toIntOrNull() ?: return raw
-    val month = parts[1].toIntOrNull()?.takeIf { it in 1..12 } ?: return raw
-    val day = parts[2].toIntOrNull()?.takeIf { it in 1..31 } ?: return raw
-    return "$year ${localizedMonthName(month)} $day"
+
+    val isEpisodic = isEpisodicType(type)
+
+    if (isEpisodic) {
+        // 1. Check for multi-year range: e.g. "2000-2010", "2017–2022", "2024-2025"
+        val fullRangeMatch = Regex("""^(\d{4})\s*[-–—/]\s*(\d{4})$""").find(trimmed)
+        if (fullRangeMatch != null) {
+            val (startYear, endYear) = fullRangeMatch.destructured
+            return if (startYear == endYear) startYear else "$startYear – $endYear"
+        }
+
+        // 2. Check for explicit continuing/ongoing range: e.g. "2000-", "2000–", "1999-"
+        val ongoingRangeMatch = Regex("""^(\d{4})\s*[-–—/]\s*$""").find(trimmed)
+        if (ongoingRangeMatch != null) {
+            val (startYear) = ongoingRangeMatch.destructured
+            return "$startYear – "
+        }
+
+        // 3. Check if raw explicitly contains trailing ongoing indicator
+        if (trimmed.endsWith("-") || trimmed.endsWith("–") || trimmed.contains(" – ")) {
+            val year = extractReleaseYearForDisplay(trimmed)
+            if (year != null) return "$year – "
+        }
+
+        // 4. Standalone / 1-season completed show: return year only (e.g. "2018")
+        val year = extractReleaseYearForDisplay(trimmed)
+        if (year != null) {
+            return "$year"
+        }
+
+        return trimmed
+    }
+
+    // Movies & default types: Absolute date format starting with day and ending with year ("15 July 2026")
+    val datePart = parseEpisodeReleaseLocalDate(trimmed)
+    if (datePart != null) {
+        val parts = datePart.split('-')
+        if (parts.size == 3) {
+            val year = parts[0].toIntOrNull()
+            val month = parts[1].toIntOrNull()?.takeIf { it in 1..12 }
+            val day = parts[2].toIntOrNull()?.takeIf { it in 1..31 }
+            if (year != null && month != null && day != null) {
+                return "$day ${localizedMonthName(month)} $year"
+            }
+        }
+    }
+
+    val yearMonthDayMatch = Regex("""^(\d{4})\s+([A-Za-z]+)\s+(\d{1,2})$""").find(trimmed)
+    if (yearMonthDayMatch != null) {
+        val (y, mStr, d) = yearMonthDayMatch.destructured
+        return "$d $mStr $y"
+    }
+
+    val monthDayYearMatch = Regex("""^([A-Za-z]+)\s+(\d{1,2}),?\s+(\d{4})$""").find(trimmed)
+    if (monthDayYearMatch != null) {
+        val (mStr, d, y) = monthDayYearMatch.destructured
+        return "$d $mStr $y"
+    }
+
+    return trimmed
 }
 
 fun formatReleaseDateWithoutYear(raw: String): String {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/PosterGrid.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/PosterGrid.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.nuvio.app.core.format.formatReleaseDateForDisplay
+import com.nuvio.app.core.ui.DisintegratingContainer
 import com.nuvio.app.core.ui.NuvioCardDepthSurface
 import com.nuvio.app.core.ui.NuvioPosterWatchedOverlay
 import com.nuvio.app.core.ui.nuvioCardDepth
@@ -50,6 +51,8 @@ internal fun PosterGridRow(
     modifier: Modifier = Modifier,
     watchedKeys: Set<String> = emptySet(),
     fullyWatchedSeriesKeys: Set<String> = emptySet(),
+    exitingKeys: Set<String> = emptySet(),
+    onDisintegrated: ((String) -> Unit)? = null,
     onPosterClick: ((MetaPreview) -> Unit)? = null,
     onPosterLongClick: ((MetaPreview) -> Unit)? = null,
 ) {
@@ -61,19 +64,26 @@ internal fun PosterGridRow(
         verticalAlignment = Alignment.Top,
     ) {
         items.forEach { item ->
-            PosterGridTile(
-                item = item,
-                cornerRadiusDp = posterCardStyle.cornerRadiusDp,
-                hideLabels = posterCardStyle.hideLabelsEnabled,
+            val isExiting = item.id in exitingKeys
+            DisintegratingContainer(
+                disintegrating = isExiting,
+                onDisintegrated = { onDisintegrated?.invoke(item.id) },
                 modifier = Modifier.weight(1f),
-                isWatched = WatchingState.isPosterWatched(
-                    watchedKeys = watchedKeys,
+            ) {
+                PosterGridTile(
                     item = item,
-                    fullyWatchedSeriesKeys = fullyWatchedSeriesKeys,
-                ),
-                onClick = onPosterClick?.let { { it(item) } },
-                onLongClick = onPosterLongClick?.let { { it(item) } },
-            )
+                    cornerRadiusDp = posterCardStyle.cornerRadiusDp,
+                    hideLabels = posterCardStyle.hideLabelsEnabled,
+                    modifier = Modifier.fillMaxWidth(),
+                    isWatched = WatchingState.isPosterWatched(
+                        watchedKeys = watchedKeys,
+                        item = item,
+                        fullyWatchedSeriesKeys = fullyWatchedSeriesKeys,
+                    ),
+                    onClick = if (isExiting) null else onPosterClick?.let { { it(item) } },
+                    onLongClick = if (isExiting) null else onPosterLongClick?.let { { it(item) } },
+                )
+            }
         }
         repeat(columns - items.size) {
             Spacer(modifier = Modifier.weight(1f))
@@ -154,7 +164,7 @@ private fun PosterGridTile(
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )
-            val detail = item.releaseInfo?.let { formatReleaseDateForDisplay(it) }
+            val detail = item.releaseInfo?.let { formatReleaseDateForDisplay(it, item.type) }
             if (detail != null) {
                 Text(
                     text = detail,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryDisplaySettings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryDisplaySettings.kt
@@ -20,6 +20,10 @@ enum class LibrarySortOption {
     ADDED_ASC,
     TITLE_ASC,
     TITLE_DESC,
+    RATING_DESC,
+    RATING_ASC,
+    RELEASE_DATE_DESC,
+    RELEASE_DATE_ASC,
 }
 
 data class LibraryDisplaySettingsUiState(
@@ -131,6 +135,28 @@ internal fun sortLibraryItems(
             compareByDescending<LibraryItem> { libraryTitleSortKey(it) }
                 .thenBy { it.id },
         )
+        LibrarySortOption.RATING_DESC -> items.sortedWith(
+            compareByDescending<LibraryItem> { it.imdbRating?.toFloatOrNull() ?: 0f }
+                .thenBy { libraryTitleTieBreakKey(it) }
+                .thenBy { it.id },
+        )
+        LibrarySortOption.RATING_ASC -> items.sortedWith(
+            compareBy<LibraryItem> { it.imdbRating?.toFloatOrNull() ?: Float.MAX_VALUE }
+                .thenBy { libraryTitleTieBreakKey(it) }
+                .thenBy { it.id },
+        )
+        LibrarySortOption.RELEASE_DATE_DESC -> items.sortedWith(
+            compareByDescending<LibraryItem> { releaseDateSortKey(it).isNotBlank() }
+                .thenByDescending { releaseDateSortKey(it) }
+                .thenBy { libraryTitleTieBreakKey(it) }
+                .thenBy { it.id },
+        )
+        LibrarySortOption.RELEASE_DATE_ASC -> items.sortedWith(
+            compareByDescending<LibraryItem> { releaseDateSortKey(it).isNotBlank() }
+                .thenBy { releaseDateSortKey(it) }
+                .thenBy { libraryTitleTieBreakKey(it) }
+                .thenBy { it.id },
+        )
     }
 
 internal fun sortLibrarySections(
@@ -227,17 +253,46 @@ private val LibraryDisplaySettingsJson = Json {
     encodeDefaults = true
 }
 
-private val LeadingLibraryTitleArticle = Regex("^(the|an|a)\\s+", RegexOption.IGNORE_CASE)
-
 private fun libraryTitleSortKey(item: LibraryItem): String =
     libraryTitleTieBreakKey(item)
-        .trim()
-        .replace(LeadingLibraryTitleArticle, "")
 
 private fun libraryTitleTieBreakKey(item: LibraryItem): String =
     item.name
         .ifBlank { item.id }
         .lowercase()
+
+private val IsoDateRegex = Regex("\\b\\d{4}(-\\d{2})?(-\\d{2})?\\b")
+
+private fun releaseDateSortKey(item: LibraryItem): String {
+    val raw = item.rawReleaseDate?.trim().orEmpty().ifBlank { item.releaseInfo.orEmpty().trim() }
+    if (raw.isBlank()) return ""
+
+    val fullDateMatch = Regex("\\b(18|19|20)\\d{2}[-/]\\d{1,2}[-/]\\d{1,2}\\b").find(raw)?.value
+    if (fullDateMatch != null) {
+        val parts = fullDateMatch.split('-', '/')
+        if (parts.size == 3) {
+            val y = parts[0]
+            val m = parts[1].padStart(2, '0')
+            val d = parts[2].padStart(2, '0')
+            return "$y-$m-$d"
+        }
+    }
+
+    val yearMonthMatch = Regex("\\b(18|19|20)\\d{2}[-/]\\d{1,2}\\b").find(raw)?.value
+    if (yearMonthMatch != null) {
+        val parts = yearMonthMatch.split('-', '/')
+        if (parts.size == 2) {
+            val y = parts[0]
+            val m = parts[1].padStart(2, '0')
+            return "$y-$m-01"
+        }
+    }
+
+    val yearMatch = Regex("\\b(18|19|20)\\d{2}\\b").find(raw)?.value
+    if (yearMatch != null) return "$yearMatch-01-01"
+
+    return raw.lowercase()
+}
 
 private fun libraryDisplayItemKey(item: LibraryItem): String =
     "${item.type.normalizedLibraryType()}:${item.id.trim()}"

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryModels.kt
@@ -6,6 +6,31 @@ import com.nuvio.app.features.home.PosterShape
 import com.nuvio.app.features.tracking.TrackingAttributedItem
 import kotlinx.serialization.Serializable
 
+enum class LibraryShelf(val key: String, val displayTitle: String) {
+    PLAN_TO_WATCH("plan_to_watch", "Plan to watch"),
+    CURRENTLY_WATCHING("currently_watching", "Currently Watching"),
+    REVISIT("revisit", "Revisit"),
+    COMPLETED("completed", "Completed"),
+    DROPPED("dropped", "Dropped"),
+    ON_HOLD("on_hold", "On Hold"),
+    ARCHIVE("archive", "Archive");
+
+    companion object {
+        fun fromKey(key: String?): LibraryShelf? =
+            entries.firstOrNull { it.key.equals(key?.trim(), ignoreCase = true) }
+    }
+}
+
+fun isNSFWGenreOrTag(tag: String): Boolean {
+    val t = tag.trim().lowercase()
+    return t == "erotica" || t == "erotic" || t == "hentai" || t == "adult" ||
+           t == "ecchi" || t == "nsfw" || t == "18+" || t == "porn" ||
+           t == "pornography" || t == "xxx" || t == "sex" || t == "nude" ||
+           t == "nudity" || t == "smut" || t.contains("hentai") || t.contains("erotica")
+}
+
+fun LibraryItem.isNSFWItem(): Boolean = isNSFW || genres.any { isNSFWGenreOrTag(it) }
+
 @Serializable
 data class LibraryItem(
     val id: String,
@@ -16,6 +41,7 @@ data class LibraryItem(
     val logo: String? = null,
     val description: String? = null,
     val releaseInfo: String? = null,
+    val rawReleaseDate: String? = null,
     val imdbRating: String? = null,
     val genres: List<String> = emptyList(),
     val posterShape: PosterShape = PosterShape.Poster,
@@ -29,6 +55,13 @@ data class LibraryItem(
     override val trackingProviderItemId: String? = null,
     override val trackingSourceUrl: String? = null,
     val savedAtEpochMs: Long,
+    val shelf: String? = null,
+    val shelfSeason: Int? = null,
+    val shelfEpisode: Int? = null,
+    val lastWatchedAtEpochMs: Long? = null,
+    val isPrivate: Boolean = false,
+    val isNSFW: Boolean = false,
+    val isArchive: Boolean = false,
 ) : TrackingAttributedItem {
     override val trackingContentId: String
         get() = id
@@ -65,11 +98,13 @@ fun MetaDetails.toLibraryItem(savedAtEpochMs: Long): LibraryItem =
         logo = logo,
         description = description,
         releaseInfo = releaseInfo,
+        rawReleaseDate = releaseInfo,
         imdbRating = imdbRating,
         genres = genres,
         posterShape = PosterShape.Poster,
         imdbId = id.takeIf { it.startsWith("tt") },
         savedAtEpochMs = savedAtEpochMs,
+        isNSFW = genres.any { isNSFWGenreOrTag(it) },
     )
 
 fun MetaPreview.toLibraryItem(savedAtEpochMs: Long): LibraryItem =
@@ -82,15 +117,22 @@ fun MetaPreview.toLibraryItem(savedAtEpochMs: Long): LibraryItem =
         logo = logo,
         description = description,
         releaseInfo = releaseInfo,
+        rawReleaseDate = rawReleaseDate,
         imdbRating = imdbRating,
         genres = genres,
         posterShape = posterShape,
         imdbId = id.takeIf { it.startsWith("tt") },
         savedAtEpochMs = savedAtEpochMs,
+        isNSFW = genres.any { isNSFWGenreOrTag(it) },
     )
 
-fun LibraryItem.toMetaPreview(): MetaPreview =
-    MetaPreview(
+fun LibraryItem.toMetaPreview(): MetaPreview {
+    val displayDate = if (type.trim().lowercase() == "movie") {
+        rawReleaseDate.takeIf { !it.isNullOrBlank() } ?: releaseInfo
+    } else {
+        releaseInfo
+    }
+    return MetaPreview(
         id = id,
         type = type,
         name = name,
@@ -99,7 +141,9 @@ fun LibraryItem.toMetaPreview(): MetaPreview =
         logo = logo,
         posterShape = posterShape,
         description = description,
-        releaseInfo = releaseInfo,
+        releaseInfo = displayDate,
+        rawReleaseDate = rawReleaseDate,
         imdbRating = imdbRating,
         genres = genres,
     )
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryRepository.kt
@@ -46,6 +46,8 @@ import nuvio.composeapp.generated.resources.library_other
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.getString
 
+
+
 object LibraryRepository {
     private const val pushDebounceMs = 500L
 
@@ -621,6 +623,42 @@ object LibraryRepository {
         )
         localState.runIfCurrent(localSnapshot) {
             _uiState.value = newUiState
+            triggerLibraryEnrichmentAsync(items)
+        }
+    }
+
+    private var libraryEnrichmentJob: kotlinx.coroutines.Job? = null
+
+    fun triggerLibraryEnrichmentAsync(items: List<LibraryItem> = _uiState.value.sections.flatMap { it.items }, force: Boolean = false) {
+        val tmdbSettings = com.nuvio.app.features.tmdb.TmdbSettingsRepository.snapshot()
+        if (!tmdbSettings.enabled || !tmdbSettings.hasApiKey) return
+
+        if (libraryEnrichmentJob?.isActive == true && !force) return
+
+        val itemsNeedingEnrichment = items.filter { item ->
+            if (force) return@filter true
+            val date = item.rawReleaseDate?.trim().orEmpty().ifBlank { item.releaseInfo?.trim().orEmpty() }
+            date.isBlank() || !date.contains(Regex("\\b(18|19|20)\\d{2}[-/]\\d{1,2}[-/]\\d{1,2}\\b"))
+        }
+        if (itemsNeedingEnrichment.isEmpty()) return
+
+        libraryEnrichmentJob = syncScope.launch {
+            var updatedAny = false
+            for (item in itemsNeedingEnrichment) {
+                try {
+                    val enriched = com.nuvio.app.features.tmdb.TmdbMetadataService.enrichLibraryItem(item, tmdbSettings)
+                    val newDate = enriched.rawReleaseDate ?: enriched.releaseInfo
+                    if (!newDate.isNullOrBlank() && newDate != item.rawReleaseDate) {
+                        val snapshot = localState.upsert(enriched)
+                        persist(snapshot)
+                        updatedAny = true
+                        publish()
+                    }
+                } catch (e: Exception) {
+                    if (e is CancellationException) throw e
+                    log.w(e) { "Failed to enrich library item ${item.id}" }
+                }
+            }
         }
     }
 
@@ -721,6 +759,8 @@ internal fun libraryMembershipWithRemovedList(
     currentMembership.toMutableMap().apply {
         this[listKey] = false
     }
+
+
 
 internal fun String.toLibraryDisplayTitle(): String {
     val normalized = trim()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibrarySavedContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibrarySavedContent.kt
@@ -25,6 +25,10 @@ import nuvio.composeapp.generated.resources.library_filter_sort
 import nuvio.composeapp.generated.resources.library_filter_type
 import nuvio.composeapp.generated.resources.library_sort_added_asc
 import nuvio.composeapp.generated.resources.library_sort_added_desc
+import nuvio.composeapp.generated.resources.library_sort_rating_asc
+import nuvio.composeapp.generated.resources.library_sort_rating_desc
+import nuvio.composeapp.generated.resources.library_sort_release_date_asc
+import nuvio.composeapp.generated.resources.library_sort_release_date_desc
 import nuvio.composeapp.generated.resources.library_sort_title_asc
 import nuvio.composeapp.generated.resources.library_sort_title_desc
 import nuvio.composeapp.generated.resources.library_sort_provider_order
@@ -163,6 +167,10 @@ private fun librarySortOptionLabel(option: LibrarySortOption): String =
         LibrarySortOption.ADDED_ASC -> stringResource(Res.string.library_sort_added_asc)
         LibrarySortOption.TITLE_ASC -> stringResource(Res.string.library_sort_title_asc)
         LibrarySortOption.TITLE_DESC -> stringResource(Res.string.library_sort_title_desc)
+        LibrarySortOption.RATING_DESC -> stringResource(Res.string.library_sort_rating_desc)
+        LibrarySortOption.RATING_ASC -> stringResource(Res.string.library_sort_rating_asc)
+        LibrarySortOption.RELEASE_DATE_DESC -> stringResource(Res.string.library_sort_release_date_desc)
+        LibrarySortOption.RELEASE_DATE_ASC -> stringResource(Res.string.library_sort_release_date_asc)
     }
 
 private fun List<LibraryVerticalEntry>.findEntry(preview: MetaPreview): LibraryVerticalEntry? =

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryScreen.kt
@@ -99,6 +99,7 @@ import org.jetbrains.compose.resources.stringResource
 @Composable
 fun LibraryScreen(
     modifier: Modifier = Modifier,
+    topChromePadding: Dp? = null,
     scrollToTopRequests: Flow<Unit> = emptyFlow(),
     onPosterClick: ((LibraryItem) -> Unit)? = null,
     onPosterLongClick: ((LibraryItem, LibrarySection) -> Unit)? = null,
@@ -146,10 +147,10 @@ fun LibraryScreen(
         selected = displaySettings.sortOption,
         sourceMode = uiState.sourceMode,
     )
-    val sortedSections = remember(uiState.sections, displaySettings.sortOption, uiState.sourceMode) {
+    val sortedSections = remember(uiState.sections, effectiveSortOption, uiState.sourceMode) {
         sortLibrarySections(
             sections = uiState.sections,
-            selected = displaySettings.sortOption,
+            selected = effectiveSortOption,
             sourceMode = uiState.sourceMode,
         )
     }
@@ -158,15 +159,25 @@ fun LibraryScreen(
         uiState.sourceMode,
         selectedLibrarySectionKey,
         selectedLibraryType,
-        displaySettings.sortOption,
+        effectiveSortOption,
     ) {
         buildLibraryVerticalProjection(
             sections = uiState.sections,
             sourceMode = uiState.sourceMode,
             selectedSectionKey = selectedLibrarySectionKey,
             selectedType = selectedLibraryType,
-            sortOption = displaySettings.sortOption,
+            sortOption = effectiveSortOption,
         )
+    }
+
+    LaunchedEffect(Unit) {
+        LibraryRepository.triggerLibraryEnrichmentAsync(force = false)
+    }
+
+    LaunchedEffect(effectiveSortOption) {
+        if (effectiveSortOption == LibrarySortOption.RELEASE_DATE_DESC || effectiveSortOption == LibrarySortOption.RELEASE_DATE_ASC) {
+            LibraryRepository.triggerLibraryEnrichmentAsync(force = false)
+        }
     }
     val retryLibraryLoad: () -> Unit = {
         NetworkStatusRepository.requestRefresh(force = true)
@@ -238,6 +249,7 @@ fun LibraryScreen(
         NuvioScreen(
             modifier = Modifier.fillMaxSize(),
             horizontalPadding = 0.dp,
+            topPadding = if (topChromePadding != null) 0.dp else null,
             listState = listState,
         ) {
             stickyHeader {
@@ -262,6 +274,7 @@ fun LibraryScreen(
                                 }
                             },
                             modifier = Modifier.padding(horizontal = 16.dp),
+                            topPadding = topChromePadding,
                             actions = {
                                 if (sourceMode == LibraryViewMode.Saved) {
                                     val targetLayout = if (displaySettings.layoutMode == LibraryLayoutMode.HORIZONTAL) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -524,8 +524,8 @@ object TmdbMetadataService {
         if (!settings.enabled || !settings.hasApiKey) return meta
 
         val tmdbType = normalizeMetaType(meta.type)
-        val tmdbId = TmdbService.ensureTmdbId(meta.id, tmdbType)
-            ?: TmdbService.ensureTmdbId(fallbackItemId, tmdbType)
+        val tmdbId = TmdbService.ensureTmdbId(meta.id, tmdbType, title = meta.name, year = meta.releaseInfo)
+            ?: TmdbService.ensureTmdbId(fallbackItemId, tmdbType, title = meta.name, year = meta.releaseInfo)
             ?: return meta
 
         val needsEpisodes = (
@@ -563,6 +563,41 @@ object TmdbMetadataService {
         )
     }
 
+    suspend fun enrichLibraryItem(
+        item: com.nuvio.app.features.library.LibraryItem,
+        settings: TmdbSettings = TmdbSettingsRepository.snapshot(),
+    ): com.nuvio.app.features.library.LibraryItem {
+        if (!settings.enabled || !settings.hasApiKey) return item
+
+        val tmdbType = normalizeMetaType(item.type)
+        val tmdbIdStr = item.tmdbId?.toString()
+            ?: TmdbService.ensureTmdbId(item.id, tmdbType, title = item.name, year = item.releaseInfo)
+            ?: return item
+
+        val enrichment = fetchEnrichment(
+            tmdbId = tmdbIdStr,
+            mediaType = tmdbType,
+            language = settings.language,
+            settings = settings,
+        ) ?: return item
+
+        val rawDate = if (settings.useReleaseDates) enrichment.releaseInfo else null
+        val rating = if (settings.useBasicInfo) enrichment.rating?.formatRating() else null
+        val isMovie = tmdbType == "movie" || item.type.trim().lowercase() == "movie"
+        val updatedReleaseInfo = if (isMovie && !rawDate.isNullOrBlank()) {
+            rawDate
+        } else {
+            item.releaseInfo?.takeIf { it.isNotBlank() } ?: rawDate
+        }
+
+        return item.copy(
+            tmdbId = tmdbIdStr.toIntOrNull() ?: item.tmdbId,
+            releaseInfo = updatedReleaseInfo,
+            rawReleaseDate = rawDate ?: item.rawReleaseDate,
+            imdbRating = item.imdbRating?.takeIf { it.isNotBlank() } ?: rating,
+        )
+    }
+
     suspend fun fetchStandaloneMeta(
         type: String,
         id: String,
@@ -570,13 +605,10 @@ object TmdbMetadataService {
     ): MetaDetails? {
         if (!settings.hasApiKey) return null
 
-        val tmdbId = id
-            .takeIf { it.startsWith("tmdb:", ignoreCase = true) }
-            ?.substringAfter(':')
-            ?.substringBefore(':')
-            ?.toIntOrNull()
-            ?: return null
         val tmdbType = normalizeMetaType(type)
+        val tmdbIdStr = TmdbService.ensureTmdbId(id, tmdbType) ?: return null
+        val tmdbId = tmdbIdStr.toIntOrNull() ?: return null
+
         val enrichment = fetchEnrichment(
             tmdbId = tmdbId.toString(),
             mediaType = tmdbType,
@@ -665,7 +697,7 @@ object TmdbMetadataService {
             )
         }
 
-        if (enrichment != null && settings.useReleaseDates) {
+        if (enrichment != null) {
             updated = updated.copy(
                 releaseInfo = enrichment.releaseInfo ?: updated.releaseInfo,
                 lastAirDate = enrichment.lastAirDate ?: updated.lastAirDate,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbService.kt
@@ -15,7 +15,12 @@ object TmdbService {
     private val tmdbToImdbCache = linkedMapOf<String, String>()
     private val cacheMutex = Mutex()
 
-    suspend fun ensureTmdbId(videoId: String, mediaType: String): String? {
+    suspend fun ensureTmdbId(
+        videoId: String,
+        mediaType: String,
+        title: String? = null,
+        year: String? = null,
+    ): String? {
         val apiKey = currentApiKey() ?: return null
 
         val normalized = videoId
@@ -26,11 +31,57 @@ object TmdbService {
             .substringBefore('/')
             .trim()
 
-        if (normalized.isBlank()) return null
-        if (normalized.all(Char::isDigit)) return normalized
-        if (!normalized.startsWith("tt", ignoreCase = true)) return null
+        if (normalized.isNotBlank() && normalized.all(Char::isDigit)) return normalized
+        if (normalized.startsWith("tt", ignoreCase = true)) {
+            return imdbToTmdb(imdbId = normalized, mediaType = mediaType, apiKey = apiKey)
+        }
 
-        return imdbToTmdb(imdbId = normalized, mediaType = mediaType, apiKey = apiKey)
+        if (!title.isNullOrBlank()) {
+            return searchTmdbIdByTitle(title = title, year = year, mediaType = mediaType, apiKey = apiKey)
+        }
+
+        return null
+    }
+
+    private suspend fun searchTmdbIdByTitle(
+        title: String,
+        year: String?,
+        mediaType: String,
+        apiKey: String,
+    ): String? {
+        val normalizedType = normalizeMediaType(mediaType)
+        val cleanYear = year?.let { Regex("\\b(18|19|20)\\d{2}\\b").find(it)?.value }
+        val cacheKey = "$title:$cleanYear:$normalizedType"
+        cacheMutex.withLock {
+            imdbToTmdbCache[cacheKey]?.let { return it }
+        }
+
+        val endpoint = when (normalizedType) {
+            "tv" -> "search/tv"
+            else -> "search/movie"
+        }
+        val query = mutableMapOf("query" to title)
+        if (!cleanYear.isNullOrBlank()) {
+            if (normalizedType == "tv") {
+                query["first_air_date_year"] = cleanYear
+            } else {
+                query["primary_release_year"] = cleanYear
+            }
+        }
+
+        var body = fetch<TmdbSearchResponse>(endpoint = endpoint, apiKey = apiKey, query = query)
+        if (body == null || body.results.isEmpty()) {
+            if (query.containsKey("first_air_date_year") || query.containsKey("primary_release_year")) {
+                val fallbackQuery = mutableMapOf("query" to title)
+                body = fetch<TmdbSearchResponse>(endpoint = endpoint, apiKey = apiKey, query = fallbackQuery)
+            }
+        }
+        val resultId = body?.results?.firstOrNull()?.id?.toString() ?: return null
+
+        cacheMutex.withLock {
+            imdbToTmdbCache[cacheKey] = resultId
+        }
+        return resultId
     }
 
     suspend fun tmdbToImdb(tmdbId: Int, mediaType: String): String? {
@@ -135,6 +186,11 @@ internal fun buildTmdbUrl(
 private data class TmdbFindResponse(
     @SerialName("movie_results") val movieResults: List<TmdbExternalResult> = emptyList(),
     @SerialName("tv_results") val tvResults: List<TmdbExternalResult> = emptyList(),
+)
+
+@Serializable
+private data class TmdbSearchResponse(
+    val results: List<TmdbExternalResult> = emptyList(),
 )
 
 @Serializable

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/library/LibraryDisplaySettingsTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/library/LibraryDisplaySettingsTest.kt
@@ -55,7 +55,7 @@ class LibraryDisplaySettingsTest {
     }
 
     @Test
-    fun `title sorting ignores leading English articles`() {
+    fun `title sorting preserves leading articles for literal alphabetical order`() {
         val input = listOf(
             item("batman", name = "The Batman"),
             item("arrival", name = "Arrival"),
@@ -63,11 +63,11 @@ class LibraryDisplaySettingsTest {
         )
 
         assertEquals(
-            listOf("arrival", "batman", "quiet"),
+            listOf("quiet", "arrival", "batman"),
             sortLibraryItems(input, LibrarySortOption.TITLE_ASC, LibrarySourceMode.LOCAL).map { it.id },
         )
         assertEquals(
-            listOf("quiet", "batman", "arrival"),
+            listOf("batman", "arrival", "quiet"),
             sortLibraryItems(input, LibrarySortOption.TITLE_DESC, LibrarySourceMode.LOCAL).map { it.id },
         )
     }


### PR DESCRIPTION
## Summary

Adds **Rating** (`Highest Rated`, `Lowest Rated`) and **Release Date** (`Latest Released`, `Oldest Released`) sorting options to the Library tab, with the following technical handling:
- **Date Key Normalization**: Normalizes ISO dates to `YYYY-MM-DD` and 4-digit years to `YYYY-01-01` for exact chronological sorting. Items with missing dates/ratings sort at the end in both `ASC` and `DESC` modes.
- **Movies vs TV Shows**: Movies render TMDb's full date (`26 August 2016`) on Library poster cards, while TV shows preserve season range strings (`2010 - 2015`) and sort by exact TMDb air date under the hood.
- **Fallbacks & Disk Caching**: If TMDb is disabled or lacks an API key, dates fall back cleanly to original catalog addon text. Enriched dates are cached to disk (`LibraryLocalSnapshot`), eliminating duplicate HTTP calls on launch.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Addresses community feature request #919. As user libraries grow, sorting solely by title or added date is insufficient. Adding Rating and Release Date sorting enables users to easily discover top-rated content or browse their library chronologically by release year/date.

## Issue or approval

Closes #919

**Note: This PR adds new Library sorting options (Rating and Release Date). It is submitted for maintainer review referencing community feature request #919. Explicit maintainer approval has not yet been provided.**


## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [ ] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [ ] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Intentionally does not include filter chips (e.g. Unwatched/Era filters), which are deferred to a separate follow-up PR (`feat/library-filter-chips`).
- Does not alter poster card rendering or date formatting on Home tab shelves or Catalog discovery screens.

## Testing

- **Automated Tests**: Ran `LibraryDisplaySettingsTest` (all date key normalization and comparator test cases passed).
- **Mobile Build**: Verified via `.\gradlew.bat "-Pnuvio.android.distribution=full" assembleFullDebug` (`BUILD SUCCESSFUL`).
- **Manual Flow**: Tested cold launches, TMDb background enrichment, title-only fallback search for TV shows, and layout updates across all 4 sorting modes.
- **Device**: Pixel 8a emulator — Android 17 (API 36) via Android Studio.

## Screenshots / Video

| Highest Rated Sorting | Latest Released Sorting |
| :---: | :---: |
|*<img width="499" height="978" alt="image" src="https://github.com/user-attachments/assets/04259a67-afde-4369-acd2-d67269d57d0d" />*|*<img width="502" height="997" alt="Screenshot 2026-08-04 131613" src="https://github.com/user-attachments/assets/18b1efed-bffb-407b-81ac-966ef78c52ef" />*|

> *Note: Demonstrating representative UI states for **Highest Rated** and **Latest Released** sorting modes (omitted Lowest Rated and Oldest Released as they mirror the same UI structure).*



## Breaking changes

None.

## Linked issues

Closes #919