### PR TITLE
fix(tmdb): resolve anime IDs through ARM for enrichment

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/MainActivity.kt
@@ -51,6 +51,7 @@ import com.nuvio.app.features.trakt.TraktLibraryStorage
 import com.nuvio.app.features.trakt.TraktSettingsStorage
 import com.nuvio.app.features.simkl.SimklAuthStorage
 import com.nuvio.app.features.simkl.SimklSyncStorage
+import com.nuvio.app.features.tmdb.AnimeIdCacheStorage
 import com.nuvio.app.features.tmdb.TmdbSettingsStorage
 import com.nuvio.app.features.updater.AndroidAppUpdaterPlatform
 import com.nuvio.app.core.ui.CardDepthStyleStorage
@@ -103,6 +104,7 @@ open class MainActivity : AppCompatActivity() {
         CardDepthStyleStorage.initialize(applicationContext)
         DebridSettingsStorage.initialize(applicationContext)
         TmdbSettingsStorage.initialize(applicationContext)
+        AnimeIdCacheStorage.initialize(applicationContext)
         MdbListSettingsStorage.initialize(applicationContext)
         TraktAuthStorage.initialize(applicationContext)
         TraktCommentsStorage.initialize(applicationContext)

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/tmdb/AnimeIdCacheStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/tmdb/AnimeIdCacheStorage.android.kt
@@ -1,0 +1,25 @@
+package com.nuvio.app.features.tmdb
+
+import android.content.Context
+import android.content.SharedPreferences
+
+internal actual object AnimeIdCacheStorage {
+    private const val PREFERENCES_NAME = "nuvio_anime_id_cache"
+    private const val PAYLOAD_KEY = "anime_tmdb_mappings_v1"
+
+    private var preferences: SharedPreferences? = null
+
+    fun initialize(context: Context) {
+        preferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
+    }
+
+    actual fun loadPayload(): String? = preferences?.getString(PAYLOAD_KEY, null)
+
+    actual fun savePayload(payload: String) {
+        preferences?.edit()?.putString(PAYLOAD_KEY, payload)?.apply()
+    }
+
+    actual fun clear() {
+        preferences?.edit()?.remove(PAYLOAD_KEY)?.apply()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -334,8 +334,8 @@ fun MetaDetailsScreen(
         val imdbId = extractImdbId(metaForRatings.id) ?: extractImdbId(id)
         val tmdbId = extractTmdbId(metaForRatings.id)
             ?: extractTmdbId(id)
-            ?: TmdbService.ensureTmdbId(metaForRatings.id, metaForRatings.type)?.toIntOrNull()
-            ?: TmdbService.ensureTmdbId(id, type)?.toIntOrNull()
+            ?: TmdbService.ensureTmdbIdForEnrichment(metaForRatings.id, metaForRatings.type)?.toIntOrNull()
+            ?: TmdbService.ensureTmdbIdForEnrichment(id, type)?.toIntOrNull()
 
         if (imdbId == null && tmdbId == null) {
             episodeImdbRatings = emptyMap()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/mdblist/MdbListMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/mdblist/MdbListMetadataService.kt
@@ -4,6 +4,7 @@ import co.touchlab.kermit.Logger
 import com.nuvio.app.features.addons.httpPostJson
 import com.nuvio.app.features.details.MetaDetails
 import com.nuvio.app.features.details.MetaExternalRating
+import com.nuvio.app.features.tmdb.TmdbService
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -49,7 +50,10 @@ object MdbListMetadataService {
         if (!settings.enabled) return false
         if (settings.apiKey.trim().isBlank()) return false
         if (settings.enabledProvidersInPriorityOrder().isEmpty()) return false
-        return extractImdbId(meta.id) != null || extractImdbId(fallbackItemId) != null
+        return extractImdbId(meta.id) != null ||
+            extractImdbId(fallbackItemId) != null ||
+            TmdbService.canResolveForEnrichment(meta.id) ||
+            TmdbService.canResolveForEnrichment(fallbackItemId)
     }
 
     suspend fun enrichMeta(
@@ -64,6 +68,8 @@ object MdbListMetadataService {
 
         val imdbId = extractImdbId(meta.id)
             ?: extractImdbId(fallbackItemId)
+            ?: resolveImdbLookup(meta.id, meta.type)
+            ?: resolveImdbLookup(fallbackItemId, meta.type)
             ?: return meta.copy(externalRatings = emptyList())
         val mediaType = toMdbListMediaType(meta.type)
         val enabledProviders = settings.enabledProvidersInPriorityOrder()
@@ -137,6 +143,12 @@ object MdbListMetadataService {
         if (value.isNullOrBlank()) return null
         return imdbRegex.find(value)?.value
     }
+
+    private suspend fun resolveImdbLookup(value: String, mediaType: String): String? =
+        TmdbService.ensureTmdbIdForEnrichment(value, mediaType)
+            ?.toIntOrNull()
+            ?.let { TmdbService.tmdbToImdb(tmdbId = it, mediaType = mediaType) }
+            ?.takeIf { it.startsWith("tt", ignoreCase = true) }
 
     private fun toMdbListMediaType(metaType: String): String {
         val normalized = metaType.trim().lowercase()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/AnimeIdCacheStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/AnimeIdCacheStorage.kt
@@ -1,0 +1,7 @@
+package com.nuvio.app.features.tmdb
+
+internal expect object AnimeIdCacheStorage {
+    fun loadPayload(): String?
+    fun savePayload(payload: String)
+    fun clear()
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/AnimeIdResolver.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/AnimeIdResolver.kt
@@ -1,0 +1,323 @@
+package com.nuvio.app.features.tmdb
+
+import co.touchlab.kermit.Logger
+import com.nuvio.app.core.time.EpisodeReleaseDatePlatform
+import com.nuvio.app.features.addons.httpGetText
+import io.ktor.http.encodeURLParameter
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.sync.withPermit
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal interface AnimeIdMappingCache {
+    suspend fun get(source: String, id: String): CachedAnimeTmdbMapping?
+    suspend fun putSuccess(source: String, id: String, tmdbId: Int)
+    suspend fun putMiss(source: String, id: String)
+    suspend fun putFailure(source: String, id: String)
+    suspend fun clear()
+}
+
+internal data class CachedAnimeTmdbMapping(
+    val tmdbId: Int?,
+    val expiresAtMs: Long,
+    val missCount: Int,
+)
+
+internal class AnimeIdResolver(
+    private val lookupTmdbId: suspend (source: String, id: String) -> Int?,
+    private val cache: AnimeIdMappingCache,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default),
+) {
+    private val log = Logger.withTag("AnimeIdResolver")
+    private val inFlightMutex = Mutex()
+    private val inFlight = mutableMapOf<String, Deferred<Int?>>()
+    private val requestSemaphore = Semaphore(MAX_CONCURRENT_REQUESTS)
+    private val cacheGeneration = atomic(0L)
+
+    fun supports(rawId: String): Boolean = parseArmRequest(rawId) != null
+
+    suspend fun resolveTmdbId(rawId: String): Int? {
+        val request = parseArmRequest(rawId) ?: return null
+        return resolveRequest(request)
+    }
+
+    suspend fun prefetchTmdbIds(rawIds: Collection<String>) {
+        val requests = rawIds
+            .mapNotNull(::parseArmRequest)
+            .distinctBy { it.cacheKey }
+        if (requests.isEmpty()) return
+
+        withTimeoutOrNull(REQUEST_TIMEOUT_MS) {
+            coroutineScope {
+                requests.map { request -> async { resolveRequest(request) } }.awaitAll()
+            }
+        }
+    }
+
+    suspend fun clearCache() {
+        cacheGeneration.incrementAndGet()
+        val pending = inFlightMutex.withLock {
+            inFlight.values.toList().also { inFlight.clear() }
+        }
+        pending.forEach { it.cancel() }
+        cache.clear()
+    }
+
+    internal fun parseArmRequest(rawId: String): AnimeIdRequest? {
+        val normalized = rawId.trim().substringBefore('/').lowercase()
+        val rawParts = normalized.split(':').filter(String::isNotBlank)
+        val parts = if (rawParts.firstOrNull() in setOf("movie", "series", "tv")) {
+            rawParts.drop(1)
+        } else {
+            rawParts
+        }
+        if (parts.size < 2) return null
+
+        val source = when (parts.first()) {
+            "mal", "myanimelist", "my-anime-list" -> "myanimelist"
+            "anilist", "ani-list" -> "anilist"
+            "kitsu" -> "kitsu"
+            "anidb", "ani-db" -> "anidb"
+            "animeplanet", "anime-planet" -> "anime-planet"
+            "animecountdown", "anime-countdown" -> "animecountdown"
+            "animenewsnetwork", "anime-news-network", "ann" -> "animenewsnetwork"
+            "anisearch", "ani-search" -> "anisearch"
+            "livechart", "live-chart" -> "livechart"
+            else -> return null
+        }
+        val id = parts.drop(1).firstOrNull { part ->
+            if (source == "anime-planet") part.isNotBlank() else part.all(Char::isDigit)
+        } ?: return null
+        return AnimeIdRequest(source = source, id = id)
+    }
+
+    private suspend fun resolveRequest(request: AnimeIdRequest): Int? {
+        cache.get(request.source, request.id)?.let { return it.tmdbId }
+
+        val deferred = inFlightMutex.withLock {
+            inFlight[request.cacheKey] ?: createRequest(request).also { created ->
+                inFlight[request.cacheKey] = created
+            }
+        }
+        deferred.start()
+        return deferred.await()
+    }
+
+    private fun createRequest(request: AnimeIdRequest): Deferred<Int?> {
+        val requestGeneration = cacheGeneration.value
+        return scope.async(start = CoroutineStart.LAZY) {
+            fetchAndCache(request, requestGeneration)
+        }.also { deferred ->
+            deferred.invokeOnCompletion {
+                scope.launch {
+                    inFlightMutex.withLock {
+                        if (inFlight[request.cacheKey] === deferred) {
+                            inFlight.remove(request.cacheKey)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun fetchAndCache(request: AnimeIdRequest, requestGeneration: Long): Int? =
+        try {
+            withTimeout(REQUEST_TIMEOUT_MS) {
+                requestSemaphore.withPermit {
+                    val tmdbId = lookupTmdbId(request.source, request.id)
+                    if (cacheGeneration.value == requestGeneration) {
+                        if (tmdbId != null) {
+                            cache.putSuccess(request.source, request.id, tmdbId)
+                        } else {
+                            cache.putMiss(request.source, request.id)
+                        }
+                    }
+                    tmdbId
+                }
+            }
+        } catch (timeout: TimeoutCancellationException) {
+            log.w { "ARM mapping timed out for ${request.cacheKey}" }
+            if (cacheGeneration.value == requestGeneration) {
+                cache.putFailure(request.source, request.id)
+            }
+            null
+        } catch (cancelled: CancellationException) {
+            throw cancelled
+        } catch (error: Exception) {
+            log.w { "ARM mapping failed for ${request.cacheKey}: ${error.message}" }
+            if (cacheGeneration.value == requestGeneration) {
+                cache.putFailure(request.source, request.id)
+            }
+            null
+        }
+
+    internal data class AnimeIdRequest(val source: String, val id: String) {
+        val cacheKey: String = "$source:$id"
+    }
+
+    private companion object {
+        const val MAX_CONCURRENT_REQUESTS = 4
+        const val REQUEST_TIMEOUT_MS = 30_000L
+    }
+}
+
+internal object AnimeIdResolution {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val resolver = AnimeIdResolver(
+        lookupTmdbId = { source, id ->
+            val url = buildString {
+                append("https://arm.haglund.dev/api/v2/ids?source=")
+                append(source.encodeURLParameter())
+                append("&id=")
+                append(id.encodeURLParameter())
+                append("&include=themoviedb")
+            }
+            json.decodeFromString<ArmTmdbResponse>(httpGetText(url)).themoviedb
+        },
+        cache = PersistentAnimeIdMappingCache,
+    )
+
+    fun supports(rawId: String): Boolean = resolver.supports(rawId)
+
+    suspend fun resolveTmdbId(rawId: String): Int? = resolver.resolveTmdbId(rawId)
+
+    suspend fun prefetchTmdbIds(rawIds: Collection<String>) = resolver.prefetchTmdbIds(rawIds)
+
+    suspend fun clearCache() = resolver.clearCache()
+}
+
+private object PersistentAnimeIdMappingCache : AnimeIdMappingCache {
+    private val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+    private val mutex = Mutex()
+    private val entries = mutableMapOf<String, PersistedAnimeTmdbMapping>()
+    private var loaded = false
+
+    override suspend fun get(source: String, id: String): CachedAnimeTmdbMapping? = mutex.withLock {
+        ensureLoaded()
+        entries[cacheKey(source, id)]
+            ?.takeIf { it.expiresAtMs > EpisodeReleaseDatePlatform.nowEpochMs() }
+            ?.toCached()
+    }
+
+    override suspend fun putSuccess(source: String, id: String, tmdbId: Int) {
+        put(source, id, tmdbId, POSITIVE_TTL_MS, missCount = 0)
+    }
+
+    override suspend fun putMiss(source: String, id: String) = mutex.withLock {
+        ensureLoaded()
+        val key = cacheKey(source, id)
+        val missCount = ((entries[key]?.missCount ?: 0) + 1).coerceAtMost(3)
+        val ttl = when (missCount) {
+            1 -> FIRST_MISS_TTL_MS
+            2 -> SECOND_MISS_TTL_MS
+            else -> LATER_MISS_TTL_MS
+        }
+        entries[key] = persisted(source, id, tmdbId = null, ttlMs = ttl, missCount = missCount)
+        persist()
+    }
+
+    override suspend fun putFailure(source: String, id: String) = mutex.withLock {
+        ensureLoaded()
+        val key = cacheKey(source, id)
+        entries[key] = persisted(
+            source = source,
+            id = id,
+            tmdbId = null,
+            ttlMs = FAILURE_TTL_MS,
+            missCount = entries[key]?.missCount ?: 0,
+        )
+        persist()
+    }
+
+    override suspend fun clear() = mutex.withLock {
+        entries.clear()
+        loaded = true
+        AnimeIdCacheStorage.clear()
+    }
+
+    private suspend fun put(source: String, id: String, tmdbId: Int?, ttlMs: Long, missCount: Int) =
+        mutex.withLock {
+            ensureLoaded()
+            entries[cacheKey(source, id)] = persisted(source, id, tmdbId, ttlMs, missCount)
+            persist()
+        }
+
+    private fun ensureLoaded() {
+        if (loaded) return
+        loaded = true
+        val payload = AnimeIdCacheStorage.loadPayload() ?: return
+        val decoded = runCatching { json.decodeFromString<PersistedAnimeIdCache>(payload) }.getOrNull() ?: return
+        entries.putAll(decoded.entries.associateBy { cacheKey(it.source, it.id) })
+    }
+
+    private fun persist() {
+        AnimeIdCacheStorage.savePayload(
+            json.encodeToString(PersistedAnimeIdCache(entries = entries.values.toList())),
+        )
+    }
+
+    private fun persisted(
+        source: String,
+        id: String,
+        tmdbId: Int?,
+        ttlMs: Long,
+        missCount: Int,
+    ) = PersistedAnimeTmdbMapping(
+        source = source,
+        id = id,
+        tmdbId = tmdbId,
+        expiresAtMs = EpisodeReleaseDatePlatform.nowEpochMs() + ttlMs,
+        missCount = missCount,
+    )
+
+    private fun cacheKey(source: String, id: String): String = "$source:$id"
+
+    private fun PersistedAnimeTmdbMapping.toCached() = CachedAnimeTmdbMapping(
+        tmdbId = tmdbId,
+        expiresAtMs = expiresAtMs,
+        missCount = missCount,
+    )
+
+    private const val POSITIVE_TTL_MS = 30L * 24 * 60 * 60 * 1000
+    private const val FIRST_MISS_TTL_MS = 6L * 60 * 60 * 1000
+    private const val SECOND_MISS_TTL_MS = 12L * 60 * 60 * 1000
+    private const val LATER_MISS_TTL_MS = 24L * 60 * 60 * 1000
+    private const val FAILURE_TTL_MS = 15L * 60 * 1000
+}
+
+@Serializable
+private data class ArmTmdbResponse(
+    @SerialName("themoviedb") val themoviedb: Int? = null,
+)
+
+@Serializable
+private data class PersistedAnimeIdCache(
+    val entries: List<PersistedAnimeTmdbMapping> = emptyList(),
+)
+
+@Serializable
+private data class PersistedAnimeTmdbMapping(
+    val source: String,
+    val id: String,
+    val tmdbId: Int? = null,
+    val expiresAtMs: Long,
+    val missCount: Int = 0,
+)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -524,8 +524,8 @@ object TmdbMetadataService {
         if (!settings.enabled || !settings.hasApiKey) return meta
 
         val tmdbType = normalizeMetaType(meta.type)
-        val tmdbId = TmdbService.ensureTmdbId(meta.id, tmdbType)
-            ?: TmdbService.ensureTmdbId(fallbackItemId, tmdbType)
+        val tmdbId = TmdbService.ensureTmdbIdForEnrichment(meta.id, tmdbType)
+            ?: TmdbService.ensureTmdbIdForEnrichment(fallbackItemId, tmdbType)
             ?: return meta
 
         val needsEpisodes = (

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbService.kt
@@ -16,8 +16,6 @@ object TmdbService {
     private val cacheMutex = Mutex()
 
     suspend fun ensureTmdbId(videoId: String, mediaType: String): String? {
-        val apiKey = currentApiKey() ?: return null
-
         val normalized = videoId
             .removePrefix("tmdb:")
             .removePrefix("movie:")
@@ -30,7 +28,29 @@ object TmdbService {
         if (normalized.all(Char::isDigit)) return normalized
         if (!normalized.startsWith("tt", ignoreCase = true)) return null
 
+        val apiKey = currentApiKey() ?: return null
         return imdbToTmdb(imdbId = normalized, mediaType = mediaType, apiKey = apiKey)
+    }
+
+    suspend fun ensureTmdbIdForEnrichment(videoId: String, mediaType: String): String? =
+        if (AnimeIdResolution.supports(videoId)) {
+            AnimeIdResolution.resolveTmdbId(videoId)?.toString()
+        } else {
+            ensureTmdbId(videoId, mediaType)
+        }
+
+    fun canResolveForEnrichment(videoId: String): Boolean {
+        if (AnimeIdResolution.supports(videoId)) return true
+        val normalized = videoId
+            .removePrefix("tmdb:")
+            .removePrefix("movie:")
+            .removePrefix("series:")
+            .substringBefore(':')
+            .substringBefore('/')
+            .trim()
+        return normalized.isNotBlank() && (
+            normalized.all(Char::isDigit) || normalized.startsWith("tt", ignoreCase = true)
+        )
     }
 
     suspend fun tmdbToImdb(tmdbId: Int, mediaType: String): String? {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktRelatedRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/trakt/TraktRelatedRepository.kt
@@ -110,8 +110,10 @@ object TraktRelatedRepository {
 
         val tmdbId = resolveTmdbCandidate(meta.id)
             ?: resolveTmdbCandidate(fallbackItemId)
-            ?: TmdbService.ensureTmdbId(meta.id, meta.type)?.toIntOrNull()
-            ?: fallbackItemId?.let { TmdbService.ensureTmdbId(it, fallbackItemType ?: meta.type) }?.toIntOrNull()
+            ?: TmdbService.ensureTmdbIdForEnrichment(meta.id, meta.type)?.toIntOrNull()
+            ?: fallbackItemId?.let {
+                TmdbService.ensureTmdbIdForEnrichment(it, fallbackItemType ?: meta.type)
+            }?.toIntOrNull()
             ?: return null
 
         return resolveViaTraktSearch(type = type, tmdbId = tmdbId, headers = headers)

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/AnimeIdResolverTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/AnimeIdResolverTest.kt
@@ -1,0 +1,158 @@
+package com.nuvio.app.features.tmdb
+
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.yield
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AnimeIdResolverTest {
+    @Test
+    fun `resolves supported anime id through ARM`() = runBlocking {
+        val calls = mutableListOf<Pair<String, String>>()
+        val resolver = AnimeIdResolver(
+            lookupTmdbId = { source, id ->
+                calls += source to id
+                12345
+            },
+            cache = FakeAnimeIdMappingCache(),
+            scope = this,
+        )
+
+        assertEquals(12345, resolver.resolveTmdbId("series:mal:62322"))
+        assertEquals(listOf("myanimelist" to "62322"), calls)
+    }
+
+    @Test
+    fun `reuses a successful cached mapping`() = runBlocking {
+        var calls = 0
+        val resolver = AnimeIdResolver(
+            lookupTmdbId = { _, _ ->
+                calls += 1
+                777
+            },
+            cache = FakeAnimeIdMappingCache(),
+            scope = this,
+        )
+
+        assertEquals(777, resolver.resolveTmdbId("anilist:100"))
+        assertEquals(777, resolver.resolveTmdbId("anilist:100"))
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `concurrent requests share one ARM lookup`() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        var calls = 0
+        val resolver = AnimeIdResolver(
+            lookupTmdbId = { _, _ ->
+                calls += 1
+                started.complete(Unit)
+                release.await()
+                321
+            },
+            cache = FakeAnimeIdMappingCache(),
+            scope = this,
+        )
+
+        val direct = async { resolver.resolveTmdbId("kitsu:55") }
+        started.await()
+        val prefetch = launch { resolver.prefetchTmdbIds(listOf("series:kitsu:55")) }
+        yield()
+        release.complete(Unit)
+
+        assertEquals(321, direct.await())
+        prefetch.join()
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `cancelled caller does not cancel shared mapping`() = runBlocking {
+        val started = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        var calls = 0
+        val resolver = AnimeIdResolver(
+            lookupTmdbId = { _, _ ->
+                calls += 1
+                started.complete(Unit)
+                release.await()
+                654
+            },
+            cache = FakeAnimeIdMappingCache(),
+            scope = this,
+        )
+
+        val cancelledCaller = launch { resolver.resolveTmdbId("mal:99") }
+        started.await()
+        cancelledCaller.cancelAndJoin()
+        val survivingCaller = async { resolver.resolveTmdbId("mal:99") }
+        release.complete(Unit)
+
+        assertEquals(654, survivingCaller.await())
+        assertEquals(1, calls)
+    }
+
+    @Test
+    fun `prefetch ignores ordinary non anime ids`() = runBlocking {
+        var calls = 0
+        val resolver = AnimeIdResolver(
+            lookupTmdbId = { _, _ ->
+                calls += 1
+                null
+            },
+            cache = FakeAnimeIdMappingCache(),
+            scope = this,
+        )
+
+        resolver.prefetchTmdbIds(listOf("tt1234567", "tmdb:123", "series:example-show"))
+
+        assertEquals(0, calls)
+        assertNull(resolver.resolveTmdbId("tt1234567"))
+    }
+
+    @Test
+    fun `supports the same ARM sources as TV`() {
+        val resolver = AnimeIdResolver(
+            lookupTmdbId = { _, _ -> null },
+            cache = FakeAnimeIdMappingCache(),
+        )
+
+        assertTrue(resolver.supports("mal:1"))
+        assertTrue(resolver.supports("series:anilist:2"))
+        assertTrue(resolver.supports("kitsu:3"))
+        assertTrue(resolver.supports("anidb:4"))
+        assertTrue(resolver.supports("anime-planet:some-show"))
+        assertTrue(resolver.supports("ann:5"))
+        assertTrue(resolver.supports("livechart:6"))
+        assertFalse(resolver.supports("imdb:tt1234567"))
+    }
+}
+
+private class FakeAnimeIdMappingCache : AnimeIdMappingCache {
+    private val values = mutableMapOf<String, CachedAnimeTmdbMapping>()
+
+    override suspend fun get(source: String, id: String): CachedAnimeTmdbMapping? = values["$source:$id"]
+
+    override suspend fun putSuccess(source: String, id: String, tmdbId: Int) {
+        values["$source:$id"] = CachedAnimeTmdbMapping(tmdbId, Long.MAX_VALUE, missCount = 0)
+    }
+
+    override suspend fun putMiss(source: String, id: String) {
+        values["$source:$id"] = CachedAnimeTmdbMapping(null, Long.MAX_VALUE, missCount = 1)
+    }
+
+    override suspend fun putFailure(source: String, id: String) {
+        values["$source:$id"] = CachedAnimeTmdbMapping(null, Long.MAX_VALUE, missCount = 0)
+    }
+
+    override suspend fun clear() {
+        values.clear()
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbServiceAnimeIdTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbServiceAnimeIdTest.kt
@@ -1,0 +1,23 @@
+package com.nuvio.app.features.tmdb
+
+import kotlinx.coroutines.runBlocking
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class TmdbServiceAnimeIdTest {
+    @Test
+    fun `anime ids are limited to enrichment resolution`() = runBlocking {
+        assertNull(TmdbService.ensureTmdbId("mal:62322", "series"))
+        assertTrue(TmdbService.canResolveForEnrichment("mal:62322"))
+        assertFalse(TmdbService.canResolveForEnrichment("series:addon-title"))
+    }
+
+    @Test
+    fun `existing tmdb ids still resolve without an ARM lookup`() = runBlocking {
+        assertEquals("298994", TmdbService.ensureTmdbId("tmdb:298994", "series"))
+        assertEquals("298994", TmdbService.ensureTmdbId("series:298994", "series"))
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/tmdb/AnimeIdCacheStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/tmdb/AnimeIdCacheStorage.ios.kt
@@ -1,0 +1,18 @@
+package com.nuvio.app.features.tmdb
+
+import platform.Foundation.NSUserDefaults
+
+internal actual object AnimeIdCacheStorage {
+    private const val PAYLOAD_KEY = "nuvio_anime_tmdb_mappings_v1"
+
+    actual fun loadPayload(): String? =
+        NSUserDefaults.standardUserDefaults.stringForKey(PAYLOAD_KEY)
+
+    actual fun savePayload(payload: String) {
+        NSUserDefaults.standardUserDefaults.setObject(payload, forKey = PAYLOAD_KEY)
+    }
+
+    actual fun clear() {
+        NSUserDefaults.standardUserDefaults.removeObjectForKey(PAYLOAD_KEY)
+    }
+}


### PR DESCRIPTION
## Summary

Mobile now resolves supported anime catalog IDs through Anime Relations Mapping before TMDB and MDBList enrichment.

Metadata using MAL, AniList, Kitsu, AniDB, Anime Planet, AnimeCountdown, Anime News Network, AniSearch, or LiveChart IDs can obtain a canonical TMDB ID without depending on an addon specific alias. The original addon content ID is never replaced.

ARM resolution is restricted to enrichment methods. Normal playback, stream lookup, addon routing, and the existing `ensureTmdbId` behavior do not use ARM. MDBList follows the same path as Android TV: ARM resolves the canonical TMDB ID, TMDB supplies the IMDb external ID, and the existing IMDb based MDBList request remains unchanged.

Successful mappings are cached for 30 days. Confirmed misses retry after 6, 12, then 24 hours, while network failures retry after 15 minutes. Requests are deduplicated, limited to four concurrent lookups, and capped at 30 seconds. Android stores the cache in SharedPreferences and iOS stores the same payload in NSUserDefaults.

This supersedes #1615. That PR depended on AIO Metadata's nonstandard `imdb_id` field and only worked for addons exposing the same custom alias. This implementation does not add or preserve alias fields and follows the same provider independent premise as NuvioMedia/NuvioTV#2907.

The release date behavior from #1558 is unchanged.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Mobile only understood IMDb and numeric TMDB IDs for enrichment. Anime catalogs commonly use IDs from MAL, AniList, Kitsu, and other anime databases, so TMDB details, episode ratings, MDBList ratings, and related title resolution remained unavailable when no custom IMDb alias was present.

The previous alias fallback did not solve the general problem because `imdb_id` is not part of the official Stremio meta contract. Resolving only supported anime ID formats through ARM fixes the missing enrichment without changing addon IDs or broadening normal playback ID handling.

## Issue or approval

Fixes #1679

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- ARM is used only for metadata enrichment.
- Addon content IDs are never replaced or rewritten.
- No alias fields are added to catalog or metadata models.
- Normal stream lookup, playback IDs, and addon routing are unchanged.
- Existing IMDb and numeric TMDB behavior is unchanged.
- Ordinary non anime IDs never call ARM.
- TMDB settings, metadata precedence, release date selection, episode availability, and UI are unchanged.
- Android and iOS use the same shared resolver and cache policy.
- No artwork, layout, or loading behavior changes are included.

## Testing

- `./gradlew -Pnuvio.android.distribution=full :composeApp:testAndroidHostTest`
- 660 tests passed with zero failures, errors, or skipped tests.
- `./gradlew -Pnuvio.android.distribution=full :composeApp:compileCommonMainKotlinMetadata :composeApp:compileIosMainKotlinMetadata :androidApp:compileFullDebugKotlin`
- `./gradlew :androidApp:assembleFullDebug`
- Installed the full Mobile debug build on an NVIDIA Shield TV 2019 running Android 11.
- Verified supported anime IDs resolve through ARM for TMDB enrichment.
- Verified MDBList follows ARM to TMDB to IMDb and retains its existing IMDb request format.
- Verified successful mappings are reused from persistent cache.
- Verified concurrent requests share one ARM lookup and caller cancellation does not cancel shared work.
- Verified normal `ensureTmdbId` rejects anime IDs, keeping ARM out of playback and stream paths.
- Verified ordinary addon IDs, existing IMDb IDs, and numeric TMDB IDs retain their previous behavior.

Native iOS binaries cannot be produced on Windows, but the shared and iOS metadata compilation paths pass and the iOS cache uses the existing NSUserDefaults platform pattern.

### Tester APK

[NuvioMobile ARM enrichment test build](https://gofile.io/d/kVtdiB)

## Screenshots / Video (UI changes only)

No UI layout change. These screenshots from #1615 still demonstrate the missing and restored enrichment result. The implementation producing the result is now provider independent and does not rely on the old alias fallback.

### Before

<img width="3840" height="2160" alt="BeforeMobile" src="https://github.com/user-attachments/assets/b67277ff-7931-4b66-bbda-ece4da7ef7b0" />

### After

<img width="3840" height="2160" alt="AfterMobile" src="https://github.com/user-attachments/assets/7317b1c1-3631-443b-b7c6-c892f33408a9" />

## Breaking changes

None.

## Linked issues

Fixes #1679

Supersedes #1615 and its alias specific issue #1614.

Android TV counterpart: NuvioMedia/NuvioTV#2906 and NuvioMedia/NuvioTV#2907

Related Mobile release date behavior: #1558
