### PR TITLE
CW flicker, image cache revalidation, Simkl anime movies watched status

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -434,6 +434,9 @@ kotlin {
             implementation("io.coil-kt.coil3:coil-network-ktor3:${libs.versions.coil.get()}") {
                 exclude(group = "org.jetbrains.skiko", module = "skiko")
             }
+            implementation("io.coil-kt.coil3:coil-network-cache-control:${libs.versions.coil.get()}") {
+                exclude(group = "org.jetbrains.skiko", module = "skiko")
+            }
             implementation("io.coil-kt.coil3:coil-svg:${libs.versions.coil.get()}") {
                 exclude(group = "org.jetbrains.skiko", module = "skiko")
             }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -446,6 +446,11 @@ fun App(
             .memoryCachePolicy(CachePolicy.ENABLED)
             .components {
                 add(SvgDecoder.Factory())
+                add(
+                    coil3.network.ktor3.KtorNetworkFetcherFactory(
+                        cacheStrategy = { coil3.network.cachecontrol.CacheControlCacheStrategy() },
+                    )
+                )
             }
             .configurePlatformImageLoader()
             .build()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -1796,12 +1796,16 @@ private fun ContinueWatchingItem.withFallbackMetadata(
             hasPlaceholderHomeTitle() && fallbackTitle != null -> fallbackTitle
             else -> title
         },
-        subtitle = subtitle.takeIf { it.isNotBlank() }
-            ?: fallback?.subtitle?.takeIf { it.isNotBlank() }.orEmpty(),
+        subtitle = when {
+            subtitle.isBlank() -> fallback?.subtitle?.takeIf { it.isNotBlank() }.orEmpty()
+            fallback?.subtitle.isNullOrBlank() -> subtitle
+            else -> fallback.subtitle
+        },
         imageUrl = imageUrl.orNonBlank(fallback?.imageUrl),
         logo = logo.orNonBlank(fallback?.logo),
         poster = poster.orNonBlank(fallback?.poster),
         background = background.orNonBlank(fallback?.background),
+        videoId = fallback?.videoId?.takeIf { it.isNotBlank() } ?: videoId,
         episodeTitle = episodeTitle.orNonBlank(fallback?.episodeTitle),
         episodeThumbnail = episodeThumbnail.orNonBlank(fallback?.episodeThumbnail),
         pauseDescription = pauseDescription.orNonBlank(fallback?.pauseDescription),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeContinueWatchingSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/HomeContinueWatchingSection.kt
@@ -290,7 +290,11 @@ private fun HomeContinueWatchingSectionContent(
     key(dataSourceKey) {
         val disintegration = remember {
             ScopedDisintegrationTracker<WatchProgressSource, String, ContinueWatchingItem>(
-                itemKey = ContinueWatchingItem::videoId,
+                itemKey = { item ->
+                    val season = item.seasonNumber ?: -1
+                    val episode = item.episodeNumber ?: -1
+                    "${item.parentMetaId}:$season:$episode"
+                },
             )
         }
         val displayEntries = disintegration.sync(dataSourceKey, items)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklProjections.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklProjections.kt
@@ -28,7 +28,7 @@ internal fun SimklSyncSnapshot.toSimklWatchedProjection(): SimklWatchedProjectio
     entries.forEach { entry ->
         val media = entry.media ?: return@forEach
         val contentId = media.canonicalContentId() ?: return@forEach
-        val contentType = if (entry.mediaType == SimklMediaType.MOVIES) "movie" else "series"
+        val contentType = if (entry.isMovieEntry()) "movie" else "series"
         val title = media.title?.takeIf(String::isNotBlank) ?: contentId
         val poster = entry.resolvedPosterUrl()
         val trackingProviderItemId = media.simklTrackingProviderItemId()
@@ -37,7 +37,7 @@ internal fun SimklSyncSnapshot.toSimklWatchedProjection(): SimklWatchedProjectio
             ?: parseSimklUtcEpochMs(entry.addedToWatchlistAt)
             ?: 0L
 
-        if (entry.mediaType == SimklMediaType.MOVIES) {
+        if (entry.isMovieEntry()) {
             if (entry.lastWatchedAt != null || entry.status == SimklListStatus.COMPLETED) {
                 watchedItems += WatchedItem(
                     id = contentId,
@@ -150,7 +150,7 @@ internal fun SimklSyncSnapshot.animeAlternateWatchedKeys(): Set<String> {
 internal fun SimklSyncSnapshot.movieAlternateWatchedKeys(): Set<String> {
     val extraKeys = linkedSetOf<String>()
     entries.forEach { entry ->
-        if (entry.mediaType != SimklMediaType.MOVIES) return@forEach
+        if (!entry.isMovieEntry()) return@forEach
         if (entry.lastWatchedAt == null && entry.status != SimklListStatus.COMPLETED) return@forEach
         val media = entry.media ?: return@forEach
         val contentId = media.canonicalContentId() ?: return@forEach
@@ -379,7 +379,8 @@ internal fun parseSimklUtcEpochMs(value: String?): Long? {
 internal fun SimklPlaybackSession.toWatchProgressEntry(): WatchProgressEntry? {
     val media = media ?: return null
     val parentId = media.canonicalContentId() ?: return null
-    val isMovie = mediaType == SimklMediaType.MOVIES
+    val isMovie = mediaType == SimklMediaType.MOVIES ||
+        (mediaType == SimklMediaType.ANIME && episode == null)
     val season = episode?.tvdbSeason ?: episode?.season
     val episodeNumber = episode?.tvdbNumber ?: episode?.number
     if (!isMovie && episodeNumber == null) return null

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklProjections.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklProjections.kt
@@ -115,6 +115,7 @@ internal fun SimklSyncSnapshot.animeAlternateWatchedKeys(): Set<String> {
     val extraKeys = linkedSetOf<String>()
     entries.forEach { entry ->
         if (entry.mediaType != SimklMediaType.ANIME) return@forEach
+        if (entry.isMovieEntry()) return@forEach
         val media = entry.media ?: return@forEach
         val contentId = media.canonicalContentId() ?: return@forEach
         val contentType = "series"

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklScrobbleReconciliation.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklScrobbleReconciliation.kt
@@ -32,15 +32,17 @@ private fun SimklSyncSnapshot.withPausedScrobble(
         .mergeMissing(existingEntry?.media)
         .mergeMissing(existingSession?.media)
     val mediaType = existingEntry?.mediaType ?: result.mediaType
+    val isAnimeMovie = mediaType == SimklMediaType.ANIME &&
+        (existingEntry?.animeType == "movie" || result.episode == null)
     val session = SimklPlaybackSession(
         id = result.playbackId ?: existingSession?.id,
         progress = result.progress,
         pausedAt = committedAt,
-        type = if (mediaType == SimklMediaType.MOVIES) "movie" else "episode",
+        type = if (mediaType == SimklMediaType.MOVIES || isAnimeMovie) "movie" else "episode",
         episode = result.episode?.mergeMissing(existingSession?.episode),
         show = media.takeIf { mediaType == SimklMediaType.SHOWS },
-        anime = media.takeIf { mediaType == SimklMediaType.ANIME },
-        movie = media.takeIf { mediaType == SimklMediaType.MOVIES },
+        anime = media.takeIf { mediaType == SimklMediaType.ANIME && !isAnimeMovie },
+        movie = media.takeIf { mediaType == SimklMediaType.MOVIES || isAnimeMovie },
     )
     return copy(
         playback = playback.filterNot { candidate ->
@@ -56,11 +58,13 @@ private fun SimklSyncSnapshot.withCompletedScrobble(
     val updatedEntries = entries.toMutableList()
     val index = updatedEntries.indexOfMatchingEntry(result)
     val existing = updatedEntries.getOrNull(index)
-    val updated = when (result.mediaType) {
-        SimklMediaType.MOVIES -> existing
+    val updated = when {
+        result.mediaType == SimklMediaType.MOVIES ||
+            (result.mediaType == SimklMediaType.ANIME &&
+                (existing?.animeType == "movie" || result.episode == null)) -> existing
             ?.withWatchedMovie(result, committedAt)
             ?: result.toWatchedMovieEntry(committedAt)
-        SimklMediaType.SHOWS, SimklMediaType.ANIME -> existing
+        else -> existing
             ?.withWatchedEpisode(result, committedAt)
             ?: result.toWatchedSeriesEntry(committedAt)
     }
@@ -81,7 +85,8 @@ private fun SimklLibraryEntry.withWatchedMovie(
     result: SimklScrobbleResult,
     committedAt: String,
 ): SimklLibraryEntry = copy(
-    mediaType = SimklMediaType.MOVIES,
+    mediaType = result.mediaType,
+    animeType = if (result.mediaType == SimklMediaType.ANIME) "movie" else animeType,
     lastWatchedAt = committedAt,
     status = SimklListStatus.COMPLETED,
     movie = result.media.mergeMissing(media),
@@ -90,7 +95,8 @@ private fun SimklLibraryEntry.withWatchedMovie(
 
 private fun SimklScrobbleResult.toWatchedMovieEntry(committedAt: String): SimklLibraryEntry =
     SimklLibraryEntry(
-        mediaType = SimklMediaType.MOVIES,
+        mediaType = mediaType,
+        animeType = if (mediaType == SimklMediaType.ANIME) "movie" else null,
         lastWatchedAt = committedAt,
         status = SimklListStatus.COMPLETED,
         movie = media,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklSyncModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklSyncModels.kt
@@ -80,6 +80,11 @@ data class SimklLibraryEntry(
     fun stableKey(): String? = media?.ids?.stableMediaId()?.let { id ->
         "${mediaType.apiValue}:$id"
     }
+
+    /** True when this entry represents a movie — either a regular movie or an anime movie. */
+    fun isMovieEntry(): Boolean =
+        mediaType == SimklMediaType.MOVIES ||
+            (mediaType == SimklMediaType.ANIME && animeType == "movie")
 }
 
 @Serializable

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,6 +59,7 @@ compottie = { module = "io.github.alexzhirkevich:compottie", version.ref = "comp
 coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
 coil-gif = { module = "io.coil-kt.coil3:coil-gif", version.ref = "coil" }
 coil-network-ktor3 = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+coil-network-cache-control = { module = "io.coil-kt.coil3:coil-network-cache-control", version.ref = "coil" }
 coil-svg = { module = "io.coil-kt.coil3:coil-svg", version.ref = "coil" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-atomicfu = { module = "org.jetbrains.kotlinx:atomicfu", version.ref = "atomicfu" }


### PR DESCRIPTION
## Summary

- Fix CW item flicker caused by unstable LazyList key (videoId changes during enrichment)
- Use composite key (parentMetaId:season:episode) instead of videoId for item identity
- Preserve cached videoId, episodeTitle, and subtitle from disk cache to prevent UI jumps on startup
- Add coil-network-cache-control with CacheControlCacheStrategy so remote images respect server Cache-Control headers
- Fix Simkl anime movies not marked as watched (anime entries with `anime_type: "movie"` were excluded from watched badge resolution and scrobble reconciliation)

## PR type

- [x] Behavior bug/regression fix

## Why

- CW in-progress items flickered on every app launch because Simkl projection emits synthetic videoId (tt-based) which gets replaced by enriched videoId (mal-based). Compose treated this as item removal + addition
- Subtitle jumped from "S1E52" to "Title" because episodeTitle wasn't restored from cache
- Remote images with dynamic URLs (e.g. BetterPosters) never revalidated because Coil cached indefinitely without respecting Cache-Control
- Simkl anime movies (type `ANIME` + `animeType == "movie"`) were never included in watched movie resolution or scrobble reconciliation because the code filtered strictly on `SimklMediaType.MOVIES`

## Issue or approval

- No linked issue - CW flicker reported by users in Discord, anime movie bug discovered during internal testing with Simkl ID 39079 (Spirited Away)

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change Simkl sync logic or projection pipeline beyond anime movie inclusion
- Does not alter next-up resolution pipeline
- Cache-control only affects network image revalidation, not Coil disk cache eviction
- Anime movie fix: only adds `isMovieEntry()` helper and updates filtering conditions

## Testing

- Built and installed on physical device (Xiaomi, Android)
- Verified CW no longer flickers on app launch with Simkl
- Verified clicking in-progress item sends request with enriched videoId (mal:) not synthetic (tt:)
- Verified subtitle shows episode title from cache immediately without jump
- Verified BetterPosters URL returns cache-control: max-age=3600 and will revalidate after TTL
- Verified `isMovieEntry()` returns true for ANIME + animeType "movie"
- Confirmed watched projection emits watched items for anime movies
- Confirmed scrobble reconciliation creates movie-style entries for anime movies
- Confirmed playback sessions for anime movies get type "movie" and correct contentType

## Screenshots / Video (UI changes only)

- Before: in-progress card disappears and reappears on launch
- After: card stays stable, no animation/flicker

## Breaking changes

None.

## Linked issues

No linked issue - user reports in Discord about CW flickering with Simkl tracking. Anime movie bug found during internal testing.
