### PR TITLE
fix: keep unaired next-up visible on release day

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watching/domain/WatchingPolicies.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watching/domain/WatchingPolicies.kt
@@ -58,7 +58,7 @@ internal fun shouldSurfaceNextEpisode(
             todayIsoDate = todayIsoDate,
             releasedDate = releasedDate,
         ) ?: return false
-        if (!showUnairedNextUp || daysUntilRelease <= 0) return false
+        if (!showUnairedNextUp || daysUntilRelease < 0) return false
         return !isSeasonRollover || daysUntilRelease <= UpcomingNextSeasonWindowDays
     }
     if (!isSeasonRollover) {

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/watching/domain/WatchingPoliciesTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/watching/domain/WatchingPoliciesTest.kt
@@ -115,6 +115,20 @@ class WatchingPoliciesTest {
     }
 
     @Test
+    fun shouldSurfaceNextEpisode_keeps_unavailable_episode_visible_on_release_day() {
+        assertTrue(
+            shouldSurfaceNextEpisode(
+                watchedSeasonNumber = 1,
+                candidateSeasonNumber = 1,
+                todayIsoDate = "2026-07-12",
+                releasedDate = "2026-07-12T20:00:00Z",
+                showUnairedNextUp = true,
+                available = false,
+            ),
+        )
+    }
+
+    @Test
     fun shouldSurfaceNextEpisode_keeps_unavailable_phantom_episode_hidden() {
         assertFalse(
             shouldSurfaceNextEpisode(


### PR DESCRIPTION
## Summary

Fixed Continue Watching hiding unavailable upcoming episodes on their release date.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

shouldSurfaceNextEpisode() previously rejected unavailable episodes when daysUntilRelease == 0.

This caused episodes to be shown two days before release, hidden on the release date, and shown again after the metadata provider marked them available after the airing time.

## Issue or approval

Fixes #1684 

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.


## Scope boundaries

This PR only changes the unavailable next-up release-day condition.

## Testing

Added a regression test for an unavailable episode on its release date.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1684 
