### PR TITLE
fix(player): avoid ExoPlayer reloads when switching addon subtitles

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -82,6 +82,14 @@ import java.net.HttpURLConnection
 import java.net.URL
 
 private const val TAG = "NuvioPlayer"
+
+private const val ADDON_SUBTITLE_TRACK_ID_PREFIX = "nuvio-addon-subtitle:"
+
+private fun buildAddonSubtitleTrackId(subtitle: AddonSubtitle): String {
+    val urlHash = subtitle.url.hashCode().toUInt().toString(16)
+    return "$ADDON_SUBTITLE_TRACK_ID_PREFIX${subtitle.id}:$urlHash"
+}
+
 private const val PLAYER_DIAGNOSTIC_TAG = "NuvioPlayerDiag"
 
 private class PlaybackDiagnostics {
@@ -456,6 +464,7 @@ private fun ExoPlayerSurface(
     }
 
     val pendingSubtitleTrackIndex = remember { mutableListOf<Int>() }
+    val pendingAddonSubtitleTrackId = remember { mutableListOf<String>() }
     val pendingAudioTrackSelection = remember { mutableListOf<TrackSelectionSnapshot>() }
     var currentSubtitleStyle by remember { mutableStateOf(SubtitleStyleState.DEFAULT) }
     var subtitleSelectionJob by remember { mutableStateOf<Job?>(null) }
@@ -627,6 +636,13 @@ private fun ExoPlayerSurface(
             override fun onTracksChanged(tracks: androidx.media3.common.Tracks) {
                 Log.d(TAG, "onTracksChanged: ${tracks.groups.size} groups total")
                 exoPlayer.logCurrentTracks("onTracksChanged")
+
+                pendingAddonSubtitleTrackId.firstOrNull()?.let { trackId ->
+                    if (exoPlayer.selectAddonSubtitleTrack(trackId)) {
+                        pendingAddonSubtitleTrackId.clear()
+                        Log.d(TAG, "onTracksChanged: applied pending addon subtitle trackId=$trackId")
+                    }
+                }
                 pendingAudioTrackSelection.firstOrNull()?.let { selection ->
                     if (tracks.groups.any { it.type == C.TRACK_TYPE_AUDIO }) {
                         pendingAudioTrackSelection.clear()
@@ -761,6 +777,29 @@ private fun ExoPlayerSurface(
                     exoPlayer.logCurrentTracks("after selectSubtitleTrack")
                 }
 
+override fun selectSubtitleTrackPreservingExternal(index: Int) {
+                    selectedExternalSubtitleMimeType = null
+
+                    if (index < 0) {
+                        exoPlayer.trackSelectionParameters =
+                        exoPlayer.trackSelectionParameters
+                        .buildUpon()
+                        .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, true)
+                        .clearOverridesOfType(C.TRACK_TYPE_TEXT)
+                        .build()
+                        return
+                    }
+
+                    exoPlayer.trackSelectionParameters =
+                    exoPlayer.trackSelectionParameters
+                    .buildUpon()
+                    .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+                    .clearOverridesOfType(C.TRACK_TYPE_TEXT)
+                    .build()
+
+                    exoPlayer.selectTrackByIndex(C.TRACK_TYPE_TEXT, index)
+                }
+
                 override fun setSubtitleUri(url: String) {
                     Log.d(TAG, "setSubtitleUri: url=$url")
                     subtitleSelectionJob?.cancel()
@@ -804,7 +843,88 @@ private fun ExoPlayerSurface(
                     }
                 }
 
+                override fun selectAddonSubtitle(subtitle: AddonSubtitle) {
+                                    val trackId = buildAddonSubtitleTrackId(subtitle)
+
+                                    if (exoPlayer.selectAddonSubtitleTrack(trackId)) {
+                                        selectedExternalSubtitleMimeType =
+                                        exoPlayer.currentMediaItem
+                                        ?.localConfiguration
+                                        ?.subtitleConfigurations
+                                        ?.firstOrNull { it.id == trackId }
+                                        ?.mimeType
+
+                                        Log.d(TAG, "selectAddonSubtitle: switched without media reload trackId=$trackId")
+                                        return
+                                    }
+
+                                    subtitleSelectionJob?.cancel()
+                                    subtitleSelectionJob = coroutineScope.launch {
+                                        val currentMediaItem =
+                                        exoPlayer.currentMediaItem ?: run {
+                                            Log.e(
+                                            TAG,
+                                            "selectAddonSubtitle: currentMediaItem is null, aborting",
+                                            )
+                                            return@launch
+                                        }
+
+                                        val currentPosition = exoPlayer.currentPosition
+                                        val playWhenReady = exoPlayer.playWhenReady
+
+                                        preserveAudioSelectionForReload("selectAddonSubtitle")
+
+                                        val resolvedMime =
+                                        withContext(Dispatchers.IO) {
+                                            resolveSubtitleMimeType(subtitle.url)
+                                        }
+
+                                        selectedExternalSubtitleMimeType = resolvedMime
+
+                                        val subtitleConfig =
+                                        MediaItem.SubtitleConfiguration.Builder(Uri.parse(subtitle.url))
+                                        .setId(trackId)
+                                        .setMimeType(resolvedMime)
+                                        .setLanguage(subtitle.language)
+                                        .setLabel(subtitle.display)
+                                        .setSelectionFlags(C.SELECTION_FLAG_DEFAULT)
+                                        .setRoleFlags(C.ROLE_FLAG_SUBTITLE)
+                                        .build()
+
+                                        val existingConfigs =
+                                        currentMediaItem.localConfiguration?.subtitleConfigurations.orEmpty()
+
+                                        val newConfigs =
+                                        existingConfigs
+                                        .filterNot { it.id == trackId }
+                                        .plus(subtitleConfig)
+
+                                        pendingAddonSubtitleTrackId.clear()
+                                        pendingAddonSubtitleTrackId.add(trackId)
+
+                                        val newMediaItem =
+                                        currentMediaItem
+                                        .buildUpon()
+                                        .setSubtitleConfigurations(newConfigs)
+                                        .build()
+
+                                        exoPlayer.trackSelectionParameters =
+                                        exoPlayer.trackSelectionParameters
+                                        .buildUpon()
+                                        .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+                                        .clearOverridesOfType(C.TRACK_TYPE_TEXT)
+                                        .build()
+
+                                        exoPlayer.setPlaybackMediaItem(newMediaItem, currentPosition)
+                                        exoPlayer.prepare()
+                                        exoPlayer.playWhenReady = playWhenReady
+
+                                        Log.d(TAG, "selectAddonSubtitle: attached trackId=$trackId and refreshed media")
+                                    }
+                                }
+
                 override fun clearExternalSubtitle() {
+                    pendingAddonSubtitleTrackId.clear()
                     Log.d(TAG, "clearExternalSubtitle called")
                     subtitleSelectionJob?.cancel()
                     selectedExternalSubtitleMimeType = null
@@ -822,6 +942,7 @@ private fun ExoPlayerSurface(
                 }
 
                 override fun clearExternalSubtitleAndSelect(trackIndex: Int) {
+                    pendingAddonSubtitleTrackId.clear()
                     Log.d(TAG, "clearExternalSubtitleAndSelect: trackIndex=$trackIndex")
                     subtitleSelectionJob?.cancel()
                     selectedExternalSubtitleMimeType = null
@@ -1791,6 +1912,7 @@ private fun ExoPlayer.extractSubtitleTracks(context: Context): List<SubtitleTrac
     for (group in currentTracks.groups) {
         if (group.type != C.TRACK_TYPE_TEXT) continue
         val format = group.mediaTrackGroup.getFormat(0)
+        if (format.id?.startsWith(ADDON_SUBTITLE_TRACK_ID_PREFIX) == true) continue
         val hasForcedSelectionFlag = (format.selectionFlags and C.SELECTION_FLAG_FORCED) != 0
         tracks.add(
             SubtitleTrack(
@@ -1812,6 +1934,27 @@ private fun ExoPlayer.extractSubtitleTracks(context: Context): List<SubtitleTrac
     return tracks
 }
 
+private fun ExoPlayer.selectAddonSubtitleTrack(trackId: String): Boolean {
+    for (group in currentTracks.groups) {
+        if (group.type != C.TRACK_TYPE_TEXT) continue
+
+        val format = group.mediaTrackGroup.getFormat(0)
+        if (format.id != trackId) continue
+
+        trackSelectionParameters = trackSelectionParameters
+            .buildUpon()
+            .setTrackTypeDisabled(C.TRACK_TYPE_TEXT, false)
+            .setOverrideForType(
+                TrackSelectionOverride(group.mediaTrackGroup, listOf(0))
+            )
+            .build()
+
+        return true
+    }
+
+    return false
+}
+
 private fun ExoPlayer.selectTrackByIndex(trackType: Int, targetIndex: Int): Boolean {
     return selectTrackByPredicate(trackType, "index=$targetIndex") { idx, _ ->
         idx == targetIndex
@@ -1829,6 +1972,12 @@ private fun ExoPlayer.selectTrackByPredicate(
     for (group in currentTracks.groups) {
         if (group.type != trackType) continue
         val format = group.mediaTrackGroup.getFormat(0)
+        if (
+            trackType == C.TRACK_TYPE_TEXT &&
+            format.id?.startsWith(ADDON_SUBTITLE_TRACK_ID_PREFIX) == true
+        ) {
+            continue
+        }
         if (!predicate(idx, format)) {
             idx++
             continue

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerEngine.kt
@@ -16,8 +16,16 @@ interface PlayerEngineController {
     fun selectAudioTrack(index: Int)
     fun selectSubtitleTrack(index: Int)
     fun setSubtitleUri(url: String)
+
+    fun selectAddonSubtitle(subtitle: AddonSubtitle) {
+        setSubtitleUri(subtitle.url)
+    }
     fun clearExternalSubtitle()
     fun clearExternalSubtitleAndSelect(trackIndex: Int)
+
+    fun selectSubtitleTrackPreservingExternal(index: Int) {
+        clearExternalSubtitleAndSelect(index)
+    }
     fun applySubtitleStyle(style: SubtitleStyleState) {}
     fun setSubtitleDelayMs(delayMs: Int) {}
     fun configureIosVideoOutput(settings: PlayerSettingsUiState) {}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -462,7 +462,7 @@ private fun PlayerScreenRuntime.RenderPlayerModals(displayedPositionMs: Long) {
             useCustomSubtitles = false
             persistInternalSubtitlePreference(subtitleTracks.firstOrNull { it.index == index })
             if (wasCustom) {
-                playerController?.clearExternalSubtitleAndSelect(index)
+                playerController?.selectSubtitleTrackPreservingExternal(index)
             } else {
                 playerController?.selectSubtitleTrack(index)
             }
@@ -472,7 +472,7 @@ private fun PlayerScreenRuntime.RenderPlayerModals(displayedPositionMs: Long) {
             selectedSubtitleIndex = -1
             useCustomSubtitles = true
             persistAddonSubtitlePreference(addon)
-            playerController?.setSubtitleUri(addon.url)
+            playerController?.selectAddonSubtitle(addon)
         },
         onFetchAddonSubtitles = { fetchAddonSubtitlesForActiveItem() },
         onSubtitleStyleChanged = PlayerSettingsRepository::setSubtitleStyle,


### PR DESCRIPTION
## Summary

Fix ExoPlayer addon subtitle switching so previously attached addon subtitle tracks can be selected directly without rebuilding and preparing the media item again.

Previously selected addon subtitle tracks now stay attached to the current media item and can be selected again through ExoPlayer track selection without triggering another media reload.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Switching addon subtitles in ExoPlayer could rebuild and prepare the media item again, causing a noticeable loading interruption.

This was especially noticeable when switching back to an addon subtitle that had already been selected before.

This change keeps previously attached addon subtitle tracks on the current media item and reuses them directly when possible.

## Issue or approval

Fixes #974

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR only changes addon subtitle switching behavior for ExoPlayer.

It intentionally does not:
- change MPV subtitle switching
- change the subtitle UI
- change subtitle ordering
- change persisted subtitle scoping behavior from PR #1582
- include unrelated player refactors or cleanup

## Testing

Tested manually on Android with ExoPlayer.

Flows tested:
- Addon A -> B -> A -> B
- Addon -> internal subtitle -> addon
- Addon -> Off -> addon
- Playback position remains preserved
- Play/pause state remains preserved
- Audio selection remains preserved
- Returning to an already attached addon subtitle no longer causes a repeated media reload

Build command:

`.\gradlew.bat :androidApp:assembleFullDebug`

Result: successful.

Validation:

`git diff --check`

Result: no whitespace errors.

## Screenshots / Video (UI changes only)

No UI elements were changed, but the behavior difference is shown below.

### Before


https://github.com/user-attachments/assets/41efacc0-a337-43de-b134-a91bd7ecf92f



### After


https://github.com/user-attachments/assets/6eb998b5-81e5-4646-967e-50ad86de2c32



## Breaking changes

None.

## Linked issues

Fixes #974