### PR TITLE
fix: watched badge flickering and memory leak from bulk meta cache

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsRepository.kt
@@ -193,7 +193,7 @@ object MetaDetailsRepository {
         _uiState.value = MetaDetailsUiState()
     }
 
-    suspend fun fetch(type: String, id: String): MetaDetails? {
+    suspend fun fetch(type: String, id: String, cacheResult: Boolean = true): MetaDetails? {
         val requestKey = "$type:$id"
         cachedMetaByRequestKey[requestKey]?.let { return it.baseMeta }
 
@@ -205,13 +205,17 @@ object MetaDetailsRepository {
                 tryFetchMeta(manifest, type, metaLookupId, includeMdbList = false)
             }
             if (result != null) {
-                cachedMetaByRequestKey[requestKey] = CachedMetaEntry(baseMeta = result)
+                if (cacheResult) {
+                    cachedMetaByRequestKey[requestKey] = CachedMetaEntry(baseMeta = result)
+                }
                 return result
             }
         }
 
         return tryFetchTmdbFallbackMeta(type = type, id = id)?.also { result ->
-            cachedMetaByRequestKey[requestKey] = CachedMetaEntry(baseMeta = result)
+            if (cacheResult) {
+                cachedMetaByRequestKey[requestKey] = CachedMetaEntry(baseMeta = result)
+            }
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/notifications/EpisodeReleaseNotificationsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/notifications/EpisodeReleaseNotificationsRepository.kt
@@ -436,6 +436,7 @@ object EpisodeReleaseNotificationsRepository {
             MetaDetailsRepository.fetch(
                 type = trackedShow.contentType,
                 id = trackedShow.contentId,
+                cacheResult = false,
             )
         }.onFailure { error ->
             log.w { "Failed to resolve metadata for ${trackedShow.contentType}:${trackedShow.contentId}: ${error.message}" }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklApplicationAdapters.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklApplicationAdapters.kt
@@ -42,19 +42,9 @@ object SimklWatchedSyncAdapter : TrackingWatchedProvider {
     }
 
     override suspend fun pullFullyWatchedSeriesKeys(profileId: Int): Set<String>? {
-        if (profileId != ProfileRepository.activeProfileId) return null
-        SimklSyncRepository.refresh(
-            intent = TrackingRefreshIntent.AUTOMATIC,
-            origin = SimklRefreshOrigin.WATCHED_SERIES,
-        )
-        val snapshot = SimklSyncRepository.state.value.snapshot
-        val projection = snapshot.toSimklWatchedProjection()
-        SimklWatchDiagnostics.logProjection(
-            stage = "fully-watched-pull",
-            snapshot = snapshot,
-            projection = projection,
-        )
-        return projection.fullyWatchedSeriesKeys
+        // Simkl "completed" = all episodes watched; Nuvio "completed" = all
+        // *available* episodes watched. Let local revalidation decide.
+        return null
     }
 
     override suspend fun pullExtraWatchedKeys(profileId: Int): Set<String> {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watched/WatchedBadgeBulkResolver.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watched/WatchedBadgeBulkResolver.kt
@@ -60,7 +60,7 @@ suspend fun resolveWatchedBadgesBulk(
         for (contentId in touchedSeriesIds) {
             semaphore.withPermit {
                 val meta = try {
-                    MetaDetailsRepository.fetch(type = "series", id = contentId)
+                    MetaDetailsRepository.fetch(type = "series", id = contentId, cacheResult = false)
                 } catch (e: CancellationException) {
                     throw e
                 } catch (_: Throwable) {


### PR DESCRIPTION
## Summary

Two fixes:
1. Stop using Simkl's COMPLETED status for fully-watched badge state. Simkl defines "completed" as all episodes watched (including unaired), but Nuvio defines it as all *available* episodes watched. This mismatch caused badge flickering in both directions: badges appearing when they shouldn't (anime with unwatched seasons) and disappearing when they should stay (ongoing series with all aired episodes watched).
2. Prevent unbounded memory growth from bulk MetaDetailsRepository cache. Badge resolution and release notification checks were fetching meta for hundreds/thousands of series and permanently caching every result. Added `cacheResult` parameter to `fetch()` so bulk callers opt out of caching.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

**Badge flickering:** Simkl's COMPLETED status is incompatible with Nuvio's badge logic. Every Simkl sync pull overwrote the local revalidation result, causing the badge to flicker back and forth. Examples:
- Anime: Simkl marks season 1 COMPLETED (12 eps) while Nuvio sees s1+s2 (25 eps) under one IMDB ID - badge keeps reappearing
- Ongoing series: user watched all 2 aired episodes, Nuvio shows badge, but Simkl says NOT completed (expects 12) - badge keeps disappearing

**Memory leak:** `MetaDetailsRepository.cachedMetaByRequestKey` grew without bound. Users with thousands of watched items had `resolveWatchedBadgesBulk` fetching meta for every watched series and caching permanently. Similarly, `EpisodeReleaseNotificationsRepository` cached meta for every library series. This caused RAM usage to grow by hundreds of MB over a session.

## Issue or approval

- Badge flickering reported by Simkl users
- Memory issues reported by users with large watch history since v0.4.17 (when badge resolution was introduced)

## Reproduction steps

**Badge flickering:**
1. Connect Simkl tracking
2. Have a series where Simkl's completion logic disagrees with Nuvio's
3. Open home screen - badge state is incorrect or flickers
4. Switch away from app and back - badge reappears/disappears

**Memory leak:**
1. Have 1000+ watched series with Simkl or Trakt tracking
2. Open home screen (triggers badge resolution)
3. Observe RAM growing by hundreds of MB as meta is fetched and never released

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- SimklWatchedSyncAdapter: pullFullyWatchedSeriesKeys returns null
- MetaDetailsRepository.fetch: added optional `cacheResult` parameter (default true, preserving existing behavior)
- WatchedBadgeBulkResolver: passes `cacheResult = false`
- EpisodeReleaseNotificationsRepository: passes `cacheResult = false`
- CW metadata enrichment cache is preserved (max 64 items, useful for display)
- Trakt provider behavior unchanged
- Interactive fetch calls (details screen, player, deeplinks) still cache normally

## Testing

- Verified badge no longer reappears after app loses/regains focus
- Verified badge no longer flickers on anime with partially watched seasons
- Verified ongoing series with all available episodes watched keeps badge correctly
- Verified fully watched series still get badge via local revalidation
- Verified Simkl watched episode markers still work correctly
- Verified details screen still loads instantly from cache on second visit
- Verified CW items still display enriched metadata correctly

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

- Simkl users reporting watched checkmark flickering and reappearing on home screen
- Users with large watch history reporting high memory usage since v0.4.17
