### PR TITLE
feat(player): add playback speed selection sheet, OSD toast integration, and dynamic speedometer icon

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlaybackSpeedModal.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlaybackSpeedModal.kt
@@ -1,0 +1,146 @@
+package com.nuvio.app.features.player
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Check
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.nuvio.app.core.ui.nuvio
+import kotlin.math.abs
+
+private data class PlaybackSpeedOption(
+    val speed: Float,
+    val label: String,
+)
+
+private val playbackSpeedOptions = listOf(
+    PlaybackSpeedOption(0.25f, "0.25x"),
+    PlaybackSpeedOption(0.5f, "0.5x"),
+    PlaybackSpeedOption(0.75f, "0.75x"),
+    PlaybackSpeedOption(1.0f, "1x (Normal)"),
+    PlaybackSpeedOption(1.25f, "1.25x"),
+    PlaybackSpeedOption(1.5f, "1.5x"),
+    PlaybackSpeedOption(1.75f, "1.75x"),
+    PlaybackSpeedOption(2.0f, "2x"),
+)
+
+@Composable
+fun PlaybackSpeedModal(
+    visible: Boolean,
+    currentSpeed: Float,
+    onSpeedSelected: (Float) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    PlayerOverlayScaffold(
+        visible = visible,
+        onDismiss = onDismiss,
+        modifier = modifier,
+        contentPadding = PaddingValues(start = 44.dp, end = 44.dp, top = 28.dp, bottom = 64.dp),
+    ) {
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val railWidth = minOf(maxWidth, 444.dp)
+            val railMaxHeight = (maxHeight - 64.dp).coerceAtLeast(120.dp).coerceAtMost(620.dp)
+
+            Column(
+                modifier = Modifier
+                    .width(railWidth)
+                    .fillMaxHeight()
+                    .align(Alignment.BottomStart),
+                verticalArrangement = Arrangement.Bottom,
+            ) {
+                Text(
+                    text = "Playback Speed",
+                    color = Color.White,
+                    style = MaterialTheme.typography.headlineMedium,
+                    modifier = Modifier.padding(bottom = 8.dp),
+                )
+
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = railMaxHeight),
+                    verticalArrangement = Arrangement.spacedBy(6.dp),
+                    contentPadding = PaddingValues(vertical = 8.dp),
+                ) {
+                    items(playbackSpeedOptions, key = { it.speed }) { option ->
+                        val isSelected = abs(currentSpeed - option.speed) < 0.05f
+                        PlaybackSpeedRow(
+                            option = option,
+                            isSelected = isSelected,
+                            onClick = {
+                                onSpeedSelected(option.speed)
+                                onDismiss()
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PlaybackSpeedRow(
+    option: PlaybackSpeedOption,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val tokens = MaterialTheme.nuvio
+    val primaryColor = if (isSelected) tokens.colors.onAccent else Color.White
+    val backgroundColor = if (isSelected) tokens.colors.accent else Color.White.copy(alpha = 0.07f)
+
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(backgroundColor)
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = option.label,
+            color = primaryColor,
+            style = MaterialTheme.typography.titleMedium,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f, fill = false),
+        )
+
+        if (isSelected) {
+            Icon(
+                imageVector = Icons.Rounded.Check,
+                contentDescription = null,
+                tint = primaryColor,
+                modifier = Modifier.size(20.dp),
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerControls.kt
@@ -1,5 +1,18 @@
 package com.nuvio.app.features.player
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.spring
+import androidx.compose.foundation.Canvas
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.ClipOp
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.drawscope.clipPath
+import androidx.compose.ui.graphics.drawscope.rotate
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
@@ -35,6 +48,7 @@ import androidx.compose.material.icons.rounded.Speed
 import androidx.compose.material.icons.rounded.SwapHoriz
 import androidx.compose.material.icons.rounded.VideoLibrary
 import com.nuvio.app.core.ui.NuvioLoadingIndicator
+import com.nuvio.app.core.ui.nuvio
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
@@ -548,9 +562,19 @@ private fun ProgressControls(
                         painter = aspectRatioPainter,
                         onClick = onResizeModeClick,
                     )
+                    val isSpeedActive = kotlin.math.abs(playbackSnapshot.playbackSpeed - 1.0f) > 0.05f
+                    val speedActiveColor = if (isSpeedActive) MaterialTheme.nuvio.colors.accent else Color.White
+
                     PlayerActionPillButton(
                         label = formatPlaybackSpeedLabel(playbackSnapshot.playbackSpeed),
-                        icon = Icons.Rounded.Speed,
+                        customIcon = {
+                            SpeedometerGaugeIcon(
+                                speed = playbackSnapshot.playbackSpeed,
+                                modifier = Modifier.size(20.dp),
+                                tint = speedActiveColor,
+                            )
+                        },
+                        labelColor = speedActiveColor,
                         onClick = onSpeedClick,
                     )
                     PlayerActionPillButton(
@@ -707,11 +731,122 @@ private fun TimePill(
 }
 
 @Composable
+internal fun SpeedometerGaugeIcon(
+    speed: Float,
+    modifier: Modifier = Modifier,
+    tint: Color = Color.White,
+) {
+    val rotationDeg = when {
+        speed <= 0.25f -> -102f
+        speed <= 0.50f -> -68f
+        speed <= 0.75f -> -34f
+        speed <= 1.00f -> 0f
+        speed <= 1.25f -> 34f
+        speed <= 1.50f -> 68f
+        speed <= 1.75f -> 85f
+        else -> 102f
+    }
+    val animatedRotation by animateFloatAsState(
+        targetValue = rotationDeg,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+    )
+
+    Canvas(modifier = modifier) {
+        val scale = size.width / 24f
+        val strokePx = 2.2f * scale
+
+        val centerX = 12.0f * scale
+        val centerY = 13.5f * scale
+        val radius = 8.0f * scale
+
+        val arcTopLeft = Offset(centerX - radius, centerY - radius)
+        val arcSize = Size(radius * 2f, radius * 2f)
+
+        val rad = animatedRotation * (PI.toFloat() / 180f)
+        val cosA = cos(rad)
+        val sinA = sin(rad)
+
+        fun rotX(px: Float, py: Float): Float = centerX + (px - centerX) * cosA - (py - centerY) * sinA
+        fun rotY(px: Float, py: Float): Float = centerY + (px - centerX) * sinA + (py - centerY) * cosA
+
+        val p1x = 9.3f * scale;  val p1y = 1.5f * scale
+        val p2x = 14.7f * scale; val p2y = 1.5f * scale
+        val p3x = 14.7f * scale; val p3y = 9.0f * scale
+        val p4x = 9.3f * scale;  val p4y = 9.0f * scale
+
+        val maskPath = androidx.compose.ui.graphics.Path().apply {
+            moveTo(rotX(p1x, p1y), rotY(p1x, p1y))
+            lineTo(rotX(p2x, p2y), rotY(p2x, p2y))
+            lineTo(rotX(p3x, p3y), rotY(p3x, p3y))
+            lineTo(rotX(p4x, p4y), rotY(p4x, p4y))
+            close()
+        }
+
+        clipPath(maskPath, clipOp = ClipOp.Difference) {
+            val tubPath = androidx.compose.ui.graphics.Path().apply {
+                moveTo(4.0f * scale, 13.5f * scale)
+                cubicTo(
+                    4.0f * scale, 16.8f * scale,
+                    6.0f * scale, 18.8f * scale,
+                    8.8f * scale, 18.8f * scale
+                )
+                lineTo(15.2f * scale, 18.8f * scale)
+                cubicTo(
+                    18.0f * scale, 18.8f * scale,
+                    20.0f * scale, 16.8f * scale,
+                    20.0f * scale, 13.5f * scale
+                )
+            }
+            drawPath(
+                path = tubPath,
+                color = tint,
+                style = Stroke(width = strokePx, cap = StrokeCap.Round, join = androidx.compose.ui.graphics.StrokeJoin.Round),
+            )
+
+            drawArc(
+                color = tint,
+                startAngle = 180f,
+                sweepAngle = 180f,
+                useCenter = false,
+                topLeft = arcTopLeft,
+                size = arcSize,
+                style = Stroke(width = strokePx, cap = StrokeCap.Round),
+            )
+        }
+
+        rotate(degrees = animatedRotation, pivot = Offset(centerX, centerY)) {
+            val needlePath = androidx.compose.ui.graphics.Path().apply {
+                moveTo(10.9f * scale, 13.5f * scale)
+                lineTo(11.5f * scale, 4.8f * scale)
+                cubicTo(
+                    11.8f * scale, 4.2f * scale,
+                    12.2f * scale, 4.2f * scale,
+                    12.5f * scale, 4.8f * scale
+                )
+                lineTo(13.1f * scale, 13.5f * scale)
+                close()
+            }
+            drawPath(
+                path = needlePath,
+                color = tint,
+            )
+            drawCircle(
+                color = tint,
+                radius = 2.0f * scale,
+                center = Offset(centerX, centerY),
+            )
+        }
+    }
+}
+
+@Composable
 private fun PlayerActionPillButton(
     label: String,
     onClick: () -> Unit,
     icon: ImageVector? = null,
     painter: Painter? = null,
+    customIcon: (@Composable () -> Unit)? = null,
+    labelColor: Color = Color.White,
 ) {
     Row(
         modifier = Modifier
@@ -722,24 +857,26 @@ private fun PlayerActionPillButton(
         verticalAlignment = Alignment.CenterVertically,
     ) {
         when {
+            customIcon != null -> customIcon()
+
             painter != null -> Icon(
                 painter = painter,
                 contentDescription = label,
-                tint = Color.White,
+                tint = labelColor,
                 modifier = Modifier.size(18.dp),
             )
 
             icon != null -> Icon(
                 imageVector = icon,
                 contentDescription = label,
-                tint = Color.White,
+                tint = labelColor,
                 modifier = Modifier.size(18.dp),
             )
         }
         Text(
             text = label,
             style = MaterialTheme.nuvioTypeScale.labelSm,
-            color = Color.White,
+            color = labelColor,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             softWrap = false,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerOverlays.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerOverlays.kt
@@ -338,12 +338,21 @@ internal fun GestureFeedbackPill(
                 .background(iconBackgroundColor),
             contentAlignment = Alignment.Center,
         ) {
-            Icon(
-                imageVector = icon,
-                contentDescription = null,
-                tint = iconTint,
-                modifier = Modifier.size(16.dp),
-            )
+            if (feedback.icon == GestureFeedbackIcon.Speed) {
+                val speedVal = messageText.replace("x", "").replace(" ", "").toFloatOrNull() ?: 1.0f
+                SpeedometerGaugeIcon(
+                    speed = speedVal,
+                    modifier = Modifier.size(18.dp),
+                    tint = iconTint,
+                )
+            } else {
+                Icon(
+                    imageVector = icon,
+                    contentDescription = null,
+                    tint = iconTint,
+                    modifier = Modifier.size(16.dp),
+                )
+            }
         }
         Text(
             text = messageText,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenModalHosts.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenModalHosts.kt
@@ -44,6 +44,10 @@ internal fun PlayerScreenModalHosts(
     onAutoSyncCueSelected: (SubtitleSyncCue) -> Unit,
     onAutoSyncReload: () -> Unit,
     onSubtitleModalDismissed: () -> Unit,
+    showPlaybackSpeedModal: Boolean = false,
+    currentPlaybackSpeed: Float = 1.0f,
+    onSpeedSelected: (Float) -> Unit = {},
+    onPlaybackSpeedModalDismissed: () -> Unit = {},
     showVideoSettingsModal: Boolean,
     playerSettings: PlayerSettingsUiState,
     onVideoSettingsChanged: () -> Unit,
@@ -120,6 +124,13 @@ internal fun PlayerScreenModalHosts(
         selectedIndex = selectedAudioIndex,
         onTrackSelected = onAudioTrackSelected,
         onDismiss = onAudioModalDismissed,
+    )
+
+    PlaybackSpeedModal(
+        visible = showPlaybackSpeedModal,
+        currentSpeed = currentPlaybackSpeed,
+        onSpeedSelected = onSpeedSelected,
+        onDismiss = onPlaybackSpeedModalDismissed,
     )
 
     SubtitleModal(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeState.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeState.kt
@@ -180,6 +180,7 @@ internal class PlayerScreenRuntime(
 
     var showAudioModal by mutableStateOf(false)
     var showSubtitleModal by mutableStateOf(false)
+    var showPlaybackSpeedModal by mutableStateOf(false)
     var showVideoSettingsModal by mutableStateOf(false)
     var audioTracks by mutableStateOf<List<AudioTrack>>(emptyList())
     var subtitleTracks by mutableStateOf<List<SubtitleTrack>>(emptyList())

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -267,7 +267,7 @@ private fun PlayerScreenRuntime.RenderPlayerControls(displayedPositionMs: Long, 
             onSeekBack = { seekBy(-10_000L) },
             onSeekForward = { seekBy(10_000L) },
             onResizeModeClick = { cycleResizeMode() },
-            onSpeedClick = { cyclePlaybackSpeed() },
+            onSpeedClick = { showPlaybackSpeedModal = true },
             onSubtitleClick = {
                 refreshTracks()
                 showSubtitleModal = true
@@ -482,6 +482,13 @@ private fun PlayerScreenRuntime.RenderPlayerModals(displayedPositionMs: Long) {
         onAutoSyncCueSelected = { cue -> applySubtitleAutoSyncCue(cue) },
         onAutoSyncReload = { loadSubtitleAutoSyncCues(force = true) },
         onSubtitleModalDismissed = { showSubtitleModal = false },
+        showPlaybackSpeedModal = showPlaybackSpeedModal,
+        currentPlaybackSpeed = playbackSnapshot.playbackSpeed,
+        onSpeedSelected = { speed ->
+            playerController?.setPlaybackSpeed(speed)
+            showGestureMessage(formatPlaybackSpeedLabel(speed))
+        },
+        onPlaybackSpeedModalDismissed = { showPlaybackSpeedModal = false },
         showVideoSettingsModal = showVideoSettingsModal,
         playerSettings = playerSettingsUiState,
         onVideoSettingsChanged = {


### PR DESCRIPTION
## Summary

- **Playback Speed Selector Sheet**: Adds a dedicated bottom sheet modal for playback speed selection supporting speeds from 0.25x to 2.0x (in 0.25x increments).
- **Dynamic Speedometer Gauge Icon**: Implements a 1:1 Compose Canvas vector gauge icon featuring real-time needle rotation (-102° at 0.25x to +102° at 2.0x), curved tub base, center pivot at (12, 13.5), and rotated cutout mask.
- **Gesture OSD Toast Integration**: Integrates the dynamic speedometer gauge icon into the hold-to-fast-forward gesture feedback toast (`GestureFeedbackPill`).
- **Active State Accent Highlight**: Automatically highlights the speed control pill in theme accent color whenever custom speed (≠ 1.0x) is selected.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

**Provides a reference implementation for feature request #1720 for maintainer evaluation.** Improves mobile player usability during video playback by expanding the speed selection range (0.25x to 2.0x) via a dedicated bottom sheet, while establishing 1:1 design and feature parity with NuvioDesktop.

## Issue or approval

Linked to Feature Request #1720. **Submitted for maintainer evaluation and review. A companion PR for NuvioDesktop is also ready to share full 1:1 design and feature parity across both platforms.**

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change submitted for maintainer review & approval
- [ ] Behavior change submitted for maintainer review & approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [ ] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [ ] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Intentionally limited to player speed controls, bottom sheet speed modal selection, gesture OSD toast integration, and gauge icon rendering. Does not touch player engine core logic, stream fetching, audio/subtitle selection, or unrelated UI controls.

## Testing

- **Device / OS**: Android Physical Device (Android 14)
- **Commands**: Executed `./gradlew compileCommonMainKotlinMetadata` and `./gradlew assembleFullDebug`.
- **Manual Flows**: Installed via ADB (`com.nuviodebug.com`). Tested opening the playback speed sheet, selecting speeds from 0.25x through 2.0x, hold-to-fast-forward gesture OSD toast rendering, needle rotation animations, and action pill accent highlight.

## Screenshots / Video

https://github.com/user-attachments/assets/37038946-da12-4797-8aad-b91d10deb985

## Breaking changes

None.

## Linked issues

Linked to #1720 
