### PR TITLE
Simplify mobile sign in actions

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-bg/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-bg/strings.xml
@@ -312,13 +312,11 @@
     <string name="compose_auth_create_account">Създай акаунт</string>
     <string name="compose_auth_dont_have_account">Нямате акаунт? </string>
     <string name="compose_auth_email">Имейл</string>
-    <string name="compose_auth_or_separator">  или  </string>
     <string name="compose_auth_password">Парола</string>
     <string name="compose_auth_sign_in_subtitle">Влезте, за да получите достъп до библиотеката и напредъка си</string>
     <string name="compose_auth_sign_in">Влез</string>
     <string name="compose_auth_sign_up_subtitle">Регистрирайте се, за да синхронизирате данните си между устройствата</string>
     <string name="compose_auth_sign_up">Регистрирай се</string>
-    <string name="compose_auth_store_locally">Данните ви ще се съхраняват само локално</string>
     <string name="compose_auth_tagline"> потоквай всичко, навсякъде</string>
     <string name="compose_auth_welcome_back">Добре дошли отново</string>
     <string name="compose_catalog_subtitle_library">Библиотека</string>

--- a/composeApp/src/commonMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-cs/strings.xml
@@ -319,13 +319,11 @@
     <string name="compose_auth_create_account">Vytvořit účet</string>
     <string name="compose_auth_dont_have_account">Nemáte účet? </string>
     <string name="compose_auth_email">E-mail</string>
-    <string name="compose_auth_or_separator">  nebo  </string>
     <string name="compose_auth_password">Heslo</string>
     <string name="compose_auth_sign_in_subtitle">Přihlaste se pro přístup ke své knihovně a postupu</string>
     <string name="compose_auth_sign_in">Přihlásit se</string>
     <string name="compose_auth_sign_up_subtitle">Zaregistrujte se pro synchronizaci dat napříč zařízeními</string>
     <string name="compose_auth_sign_up">Zaregistrovat se</string>
-    <string name="compose_auth_store_locally">Vaše data budou uložena pouze lokálně</string>
     <string name="compose_auth_tagline">Sledujte svou knihovnu kdekoliv</string>
     <string name="compose_auth_terms_prefix">Registrací souhlasím s</string>
     <string name="compose_auth_terms_link">Podmínkami</string>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -285,13 +285,11 @@
     <string name="compose_auth_create_account">Konto erstellen</string>
     <string name="compose_auth_dont_have_account">Du hast kein Konto? </string>
     <string name="compose_auth_email">E-Mail</string>
-    <string name="compose_auth_or_separator">  oder  </string>
     <string name="compose_auth_password">Passwort</string>
     <string name="compose_auth_sign_in_subtitle">Melde dich an, um auf deine Bibliothek und Fortschritt zuzugreifen</string>
     <string name="compose_auth_sign_in">Anmelden</string>
     <string name="compose_auth_sign_up_subtitle">Registriere dich, um deine Daten geräteübergreifend zu synchronisieren</string>
     <string name="compose_auth_sign_up">Registrieren</string>
-    <string name="compose_auth_store_locally">Deine Daten werden nur lokal gespeichert</string>
     <string name="compose_auth_tagline">Streame alles, überall</string>
     <string name="compose_auth_welcome_back">Willkommen zurück</string>
     <string name="compose_catalog_subtitle_library">Bibliothek</string>

--- a/composeApp/src/commonMain/composeResources/values-el/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-el/strings.xml
@@ -129,13 +129,11 @@
     <string name="compose_auth_create_account">Δημιουργία λογαριασμού</string>
     <string name="compose_auth_dont_have_account">Δεν έχετε λογαριασμό; </string>
     <string name="compose_auth_email">Ηλεκτρονικό ταχυδρομείο</string>
-    <string name="compose_auth_or_separator">  ή  </string>
     <string name="compose_auth_password">Κωδικός</string>
     <string name="compose_auth_sign_in_subtitle">Συνδεθείτε για να αποκτήσετε πρόσβαση στη βιβλιοθήκη και την πρόοδό σας</string>
     <string name="compose_auth_sign_in">Σύνδεση</string>
     <string name="compose_auth_sign_up_subtitle">Εγγραφείτε για να συγχρονίσετε τα δεδομένα σας σε όλες τις συσκευές</string>
     <string name="compose_auth_sign_up">Εγγραφή</string>
-    <string name="compose_auth_store_locally">Τα δεδομένα σας θα αποθηκευτούν μόνο τοπικά</string>
     <string name="compose_auth_tagline">Ροή παντού, πάντα</string>
     <string name="compose_auth_welcome_back">Καλώς ορίσατε ξανά</string>
     <string name="compose_catalog_subtitle_library">Βιβλιοθήκη</string>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -319,13 +319,11 @@
     <string name="compose_auth_create_account">Crear cuenta</string>
     <string name="compose_auth_dont_have_account">¿No tienes una cuenta? </string>
     <string name="compose_auth_email">Correo electrónico</string>
-    <string name="compose_auth_or_separator">  o  </string>
     <string name="compose_auth_password">Contraseña</string>
     <string name="compose_auth_sign_in_subtitle">Inicia sesión para acceder a tu biblioteca y progreso</string>
     <string name="compose_auth_sign_in">Iniciar sesión</string>
     <string name="compose_auth_sign_up_subtitle">Regístrate para sincronizar tus datos entre dispositivos</string>
     <string name="compose_auth_sign_up">Registrarse</string>
-    <string name="compose_auth_store_locally">Tus datos solo se almacenarán localmente</string>
     <string name="compose_auth_tagline">Transmite todo, en todas partes</string>
     <string name="compose_auth_terms_prefix">Al registrarme, acepto las</string>
     <string name="compose_auth_terms_link">Términos</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -311,13 +311,11 @@
     <string name="compose_auth_create_account">Créer un compte</string>
     <string name="compose_auth_dont_have_account">Pas encore de compte ? </string>
     <string name="compose_auth_email">Adresse e-mail</string>
-    <string name="compose_auth_or_separator">  ou  </string>
     <string name="compose_auth_password">Mot de passe</string>
     <string name="compose_auth_sign_in_subtitle">Connectez-vous pour accéder à votre bibliothèque et votre progression</string>
     <string name="compose_auth_sign_in">Se connecter</string>
     <string name="compose_auth_sign_up_subtitle">Inscrivez-vous pour synchroniser vos données entre appareils</string>
     <string name="compose_auth_sign_up">S’inscrire</string>
-    <string name="compose_auth_store_locally">Vos données seront uniquement stockées localement</string>
     <string name="compose_auth_tagline">Regardez tout, partout</string>
     <string name="compose_auth_terms_prefix">En m’inscrivant, j’accepte les</string>
     <string name="compose_auth_terms_link">Conditions d’utilisation</string>

--- a/composeApp/src/commonMain/composeResources/values-he/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-he/strings.xml
@@ -166,13 +166,11 @@
     <string name="compose_auth_create_account">צור חשבון</string>
     <string name="compose_auth_dont_have_account">אין לך חשבון? </string>
     <string name="compose_auth_email">אימייל</string>
-    <string name="compose_auth_or_separator">  או  </string>
     <string name="compose_auth_password">סיסמה</string>
     <string name="compose_auth_sign_in_subtitle">התחבר כדי לגשת לספרייה ולהתקדמות שלך</string>
     <string name="compose_auth_sign_in">התחברות</string>
     <string name="compose_auth_sign_up_subtitle">הירשם כדי לסנכרן את הנתונים שלך בין מכשירים</string>
     <string name="compose_auth_sign_up">הרשמה</string>
-    <string name="compose_auth_store_locally">הנתונים שלך יישמרו מקומית בלבד</string>
     <string name="compose_auth_tagline">צפה בספרייה שלך, בכל מקום</string>
     <string name="compose_auth_terms_prefix">בהרשמה, אני מסכים ל</string>
     <string name="compose_auth_terms_link">תנאי השימוש</string>

--- a/composeApp/src/commonMain/composeResources/values-hu/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-hu/strings.xml
@@ -294,13 +294,11 @@
     <string name="compose_auth_create_account">Fiók létrehozása</string>
     <string name="compose_auth_dont_have_account">Nincs még fiókod? </string>
     <string name="compose_auth_email">E-mail</string>
-    <string name="compose_auth_or_separator">  vagy  </string>
     <string name="compose_auth_password">Jelszó</string>
     <string name="compose_auth_sign_in_subtitle">Jelentkezz be a könyvtárad és a megtekintési előzményeid eléréséhez</string>
     <string name="compose_auth_sign_in">Bejelentkezés</string>
     <string name="compose_auth_sign_up_subtitle">Regisztrálj az adataid eszközök közötti szinkronizálásához</string>
     <string name="compose_auth_sign_up">Regisztráció</string>
-    <string name="compose_auth_store_locally">Az adataid csak helyileg lesznek tárolva</string>
     <string name="compose_auth_tagline">Streamelj mindent, bárhol</string>
     <string name="compose_auth_welcome_back">Üdvözlünk újra!</string>
     <string name="compose_catalog_subtitle_library">Könyvtár</string>

--- a/composeApp/src/commonMain/composeResources/values-id/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-id/strings.xml
@@ -302,13 +302,11 @@
     <string name="compose_auth_create_account">Buat Akun</string>
     <string name="compose_auth_dont_have_account">Belum punya akun? </string>
     <string name="compose_auth_email">Email</string>
-    <string name="compose_auth_or_separator">  atau  </string>
     <string name="compose_auth_password">Kata Sandi</string>
     <string name="compose_auth_sign_in_subtitle">Masuk untuk mengakses pustaka dan progres Anda</string>
     <string name="compose_auth_sign_in">Masuk</string>
     <string name="compose_auth_sign_up_subtitle">Daftar untuk menyinkronkan data Anda di semua perangkat</string>
     <string name="compose_auth_sign_up">Daftar</string>
-    <string name="compose_auth_store_locally">Data Anda hanya akan disimpan secara lokal</string>
     <string name="compose_auth_tagline">Streaming semua, di mana saja</string>
     <string name="compose_auth_welcome_back">Selamat Datang Kembali</string>
     <string name="compose_catalog_subtitle_library">Pustaka</string>

--- a/composeApp/src/commonMain/composeResources/values-in/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-in/strings.xml
@@ -302,13 +302,11 @@
     <string name="compose_auth_create_account">Buat Akun</string>
     <string name="compose_auth_dont_have_account">Belum punya akun? </string>
     <string name="compose_auth_email">Email</string>
-    <string name="compose_auth_or_separator">  atau  </string>
     <string name="compose_auth_password">Kata Sandi</string>
     <string name="compose_auth_sign_in_subtitle">Masuk untuk mengakses pustaka dan progres Anda</string>
     <string name="compose_auth_sign_in">Masuk</string>
     <string name="compose_auth_sign_up_subtitle">Daftar untuk menyinkronkan data Anda di semua perangkat</string>
     <string name="compose_auth_sign_up">Daftar</string>
-    <string name="compose_auth_store_locally">Data Anda hanya akan disimpan secara lokal</string>
     <string name="compose_auth_tagline">Streaming semua, di mana saja</string>
     <string name="compose_auth_welcome_back">Selamat Datang Kembali</string>
     <string name="compose_catalog_subtitle_library">Pustaka</string>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -134,13 +134,11 @@
   <string name="compose_auth_create_account">Crea account</string>
   <string name="compose_auth_dont_have_account">Non hai un account? </string>
   <string name="compose_auth_email">Email</string>
-  <string name="compose_auth_or_separator">  o  </string>
   <string name="compose_auth_password">Password</string>
   <string name="compose_auth_sign_in_subtitle">Accedi per accedere alla tua libreria e ai tuoi progressi</string>
   <string name="compose_auth_sign_in">Accedi</string>
   <string name="compose_auth_sign_up_subtitle">Registrati per sincronizzare i tuoi dati su più dispositivi</string>
   <string name="compose_auth_sign_up">Registrati</string>
-  <string name="compose_auth_store_locally">I tuoi dati verranno salvati solo localmente</string>
   <string name="compose_auth_tagline">Tutto in streaming, ovunque</string>
   <string name="compose_auth_welcome_back">Bentornato</string>
   <string name="compose_catalog_subtitle_library">Libreria</string>

--- a/composeApp/src/commonMain/composeResources/values-ja/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ja/strings.xml
@@ -319,13 +319,11 @@
     <string name="compose_auth_create_account">アカウントを作成</string>
     <string name="compose_auth_dont_have_account">アカウントをお持ちでないですか？ </string>
     <string name="compose_auth_email">メールアドレス</string>
-    <string name="compose_auth_or_separator">  または  </string>
     <string name="compose_auth_password">パスワード</string>
     <string name="compose_auth_sign_in_subtitle">サインインしてライブラリと視聴進捗にアクセス</string>
     <string name="compose_auth_sign_in">サインイン</string>
     <string name="compose_auth_sign_up_subtitle">サインアップしてデバイス間でデータを同期</string>
     <string name="compose_auth_sign_up">サインアップ</string>
-    <string name="compose_auth_store_locally">データはこのデバイスにのみ保存されます</string>
     <string name="compose_auth_tagline">いつでも、どこでも、すべてをストリーム</string>
     <string name="compose_auth_terms_prefix">サインアップにより、</string>
     <string name="compose_auth_terms_link">利用規約</string>

--- a/composeApp/src/commonMain/composeResources/values-nb/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nb/strings.xml
@@ -300,13 +300,11 @@
     <string name="compose_auth_create_account">Opprett konto</string>
     <string name="compose_auth_dont_have_account">Har du ikke konto? </string>
     <string name="compose_auth_email">E-post</string>
-    <string name="compose_auth_or_separator">  eller  </string>
     <string name="compose_auth_password">Passord</string>
     <string name="compose_auth_sign_in_subtitle">Logg inn for å få tilgang til biblioteket og fremdriften din</string>
     <string name="compose_auth_sign_in">Logg inn</string>
     <string name="compose_auth_sign_up_subtitle">Registrer deg for å synkronisere data på tvers av enheter</string>
     <string name="compose_auth_sign_up">Registrer deg</string>
-    <string name="compose_auth_store_locally">Dataene dine vil kun lagres lokalt</string>
     <string name="compose_auth_tagline">Strøm alt, overalt</string>
     <string name="compose_auth_welcome_back">Velkommen tilbake</string>
     <string name="compose_catalog_subtitle_library">Bibliotek</string>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -320,13 +320,11 @@
     <string name="compose_auth_create_account">Account aanmaken</string>
     <string name="compose_auth_dont_have_account">Heb je nog geen account? </string>
     <string name="compose_auth_email">E-mail</string>
-    <string name="compose_auth_or_separator">  of  </string>
     <string name="compose_auth_password">Wachtwoord</string>
     <string name="compose_auth_sign_in_subtitle">Log in om toegang te krijgen tot je bibliotheek en voortgang</string>
     <string name="compose_auth_sign_in">Inloggen</string>
     <string name="compose_auth_sign_up_subtitle">Registreer om je gegevens te synchroniseren tussen apparaten</string>
     <string name="compose_auth_sign_up">Registreren</string>
-    <string name="compose_auth_store_locally">Je gegevens worden alleen lokaal opgeslagen</string>
     <string name="compose_auth_tagline">Bekijk je bibliotheek, overal</string>
     <string name="compose_auth_terms_prefix">Door je te registreren ga je akkoord met de</string>
     <string name="compose_auth_terms_link">Voorwaarden</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -302,13 +302,11 @@
     <string name="compose_auth_create_account">Utwórz konto</string>
     <string name="compose_auth_dont_have_account">Nie masz konta? </string>
     <string name="compose_auth_email">E-mail</string>
-    <string name="compose_auth_or_separator">  lub  </string>
     <string name="compose_auth_password">Hasło</string>
     <string name="compose_auth_sign_in_subtitle">Zaloguj się, aby uzyskać dostęp do biblioteki i postępu</string>
     <string name="compose_auth_sign_in">Zaloguj się</string>
     <string name="compose_auth_sign_up_subtitle">Zarejestruj się, aby synchronizować dane między urządzeniami</string>
     <string name="compose_auth_sign_up">Zarejestruj się</string>
-    <string name="compose_auth_store_locally">Twoje dane będą przechowywane tylko lokalnie</string>
     <string name="compose_auth_tagline">Streamuj wszystko, wszędzie</string>
     <string name="compose_auth_welcome_back">Witaj ponownie</string>
     <string name="compose_catalog_subtitle_library">Biblioteka</string>

--- a/composeApp/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -301,13 +301,11 @@
     <string name="compose_auth_create_account">Criar Conta</string>
     <string name="compose_auth_dont_have_account">Não tem uma conta? </string>
     <string name="compose_auth_email">E-mail</string>
-    <string name="compose_auth_or_separator">  ou  </string>
     <string name="compose_auth_password">Senha</string>
     <string name="compose_auth_sign_in_subtitle">Faça login para acessar sua biblioteca e progresso</string>
     <string name="compose_auth_sign_in">Entrar</string>
     <string name="compose_auth_sign_up_subtitle">Cadastre-se para sincronizar seus dados entre dispositivos</string>
     <string name="compose_auth_sign_up">Cadastrar</string>
-    <string name="compose_auth_store_locally">Seus dados serão armazenados apenas localmente</string>
     <string name="compose_auth_tagline">Assista tudo, em qualquer lugar</string>
     <string name="compose_auth_welcome_back">Bem-vindo de Volta</string>
     <string name="compose_catalog_subtitle_library">Biblioteca</string>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -318,13 +318,11 @@
     <string name="compose_auth_create_account">Criar conta</string>
     <string name="compose_auth_dont_have_account">Não tens uma conta? </string>
     <string name="compose_auth_email">E-mail</string>
-    <string name="compose_auth_or_separator">  ou  </string>
     <string name="compose_auth_password">Palavra-passe</string>
     <string name="compose_auth_sign_in_subtitle">Inicia sessão para acederes à tua biblioteca e progresso</string>
     <string name="compose_auth_sign_in">Iniciar sessão</string>
     <string name="compose_auth_sign_up_subtitle">Regista-te para sincronizares os teus dados entre dispositivos</string>
     <string name="compose_auth_sign_up">Registar</string>
-    <string name="compose_auth_store_locally">Os teus dados serão guardados apenas localmente</string>
     <string name="compose_auth_tagline">Tudo em streaming, em qualquer lugar</string>
     <string name="compose_auth_welcome_back">Olá novamente</string>
     <string name="compose_catalog_subtitle_library">Biblioteca</string>

--- a/composeApp/src/commonMain/composeResources/values-ro/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ro/strings.xml
@@ -319,13 +319,11 @@
     <string name="compose_auth_create_account">Creează cont</string>
     <string name="compose_auth_dont_have_account">Nu ai un cont? </string>
     <string name="compose_auth_email">E-mail</string>
-    <string name="compose_auth_or_separator">  sau  </string>
     <string name="compose_auth_password">Parolă</string>
     <string name="compose_auth_sign_in_subtitle">Autentifică-te pentru a-ți accesa biblioteca și progresul</string>
     <string name="compose_auth_sign_in">Autentificare</string>
     <string name="compose_auth_sign_up_subtitle">Înregistrează-te pentru a-ți sincroniza datele pe toate dispozitivele</string>
     <string name="compose_auth_sign_up">Înregistrare</string>
-    <string name="compose_auth_store_locally">Datele tale vor fi stocate doar local</string>
     <string name="compose_auth_tagline">Urmărește-ți biblioteca, oriunde</string>
     <string name="compose_auth_terms_prefix">Prin înregistrare, sunt de acord cu</string>
     <string name="compose_auth_terms_link">Termenii</string>

--- a/composeApp/src/commonMain/composeResources/values-sk/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-sk/strings.xml
@@ -311,13 +311,11 @@
     <string name="compose_auth_create_account">Vytvoriť účet</string>
     <string name="compose_auth_dont_have_account">Nemáte účet?</string>
     <string name="compose_auth_email">E-mail</string>
-    <string name="compose_auth_or_separator">alebo</string>
     <string name="compose_auth_password">Heslo</string>
     <string name="compose_auth_sign_in_subtitle">Prihláste sa pre prístup k vašej knižnici a postupu</string>
     <string name="compose_auth_sign_in">Prihlásiť sa</string>
     <string name="compose_auth_sign_up_subtitle">Zaregistrujte sa a synchronizujte dáta naprieč zariadeniami</string>
     <string name="compose_auth_sign_up">Zaregistrovať sa</string>
-    <string name="compose_auth_store_locally">Vaše dáta budú uložené iba lokálne</string>
     <string name="compose_auth_tagline">Streamujte všetko, všade</string>
     <string name="compose_auth_welcome_back">Vitajte späť</string>
     <string name="compose_catalog_subtitle_library">Knižnica</string>

--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -320,13 +320,11 @@
     <string name="compose_auth_create_account">Hesap oluştur</string>
     <string name="compose_auth_dont_have_account">Hesabın yok mu? </string>
     <string name="compose_auth_email">E-posta</string>
-    <string name="compose_auth_or_separator">  veya  </string>
     <string name="compose_auth_password">Şifre</string>
     <string name="compose_auth_sign_in_subtitle">Kitaplığına ve izleme ilerlemene ulaşmak için giriş yap</string>
     <string name="compose_auth_sign_in">Giriş yap</string>
     <string name="compose_auth_sign_up_subtitle">Verilerini cihazlar arasında eşitlemek için kayıt ol</string>
     <string name="compose_auth_sign_up">Kayıt ol</string>
-    <string name="compose_auth_store_locally">Verilerin sadece bu cihazda saklanacak</string>
     <string name="compose_auth_tagline">Her şeyi, her yerde izle</string>
     <string name="compose_auth_terms_prefix">Kayıt olarak şunları kabul ediyorum:</string>
     <string name="compose_auth_terms_link">Kullanım Koşulları</string>

--- a/composeApp/src/commonMain/composeResources/values-vi/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-vi/strings.xml
@@ -318,13 +318,11 @@
     <string name="compose_auth_create_account">Tạo tài khoản</string>
     <string name="compose_auth_dont_have_account">Chưa có tài khoản? </string>
     <string name="compose_auth_email">Email</string>
-    <string name="compose_auth_or_separator"> hoặc </string>
     <string name="compose_auth_password">Mật khẩu</string>
     <string name="compose_auth_sign_in_subtitle">Đăng nhập để đồng bộ thư viện và tiến trình xem</string>
     <string name="compose_auth_sign_in">Đăng nhập</string>
     <string name="compose_auth_sign_up_subtitle">Tạo tài khoản để đồng bộ trên mọi thiết bị</string>
     <string name="compose_auth_sign_up">Đăng ký</string>
-    <string name="compose_auth_store_locally">Dữ liệu chỉ được lưu trên thiết bị này</string>
     <string name="compose_auth_tagline">Mang thư viện phim theo bạn mọi nơi</string>
     <string name="compose_auth_terms_prefix">Khi đăng ký, tôi đồng ý với</string>
     <string name="compose_auth_terms_link">Điều khoản sử dụng</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -332,13 +332,11 @@
     <string name="compose_auth_create_account">Create Account</string>
     <string name="compose_auth_dont_have_account">Don't have an account? </string>
     <string name="compose_auth_email">Email</string>
-    <string name="compose_auth_or_separator">  or  </string>
     <string name="compose_auth_password">Password</string>
     <string name="compose_auth_sign_in_subtitle">Sign in to access your library and progress</string>
     <string name="compose_auth_sign_in">Sign In</string>
     <string name="compose_auth_sign_up_subtitle">Sign up to sync your data across devices</string>
     <string name="compose_auth_sign_up">Sign Up</string>
-    <string name="compose_auth_store_locally">Your data will only be stored locally</string>
     <string name="compose_auth_tagline">Watch your library, anywhere</string>
     <string name="compose_auth_terms_prefix">By signing up, I agree to the</string>
     <string name="compose_auth_terms_link">Terms</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/auth/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/auth/AuthScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -94,13 +93,11 @@ import nuvio.composeapp.generated.resources.compose_auth_continue_without_accoun
 import nuvio.composeapp.generated.resources.compose_auth_create_account
 import nuvio.composeapp.generated.resources.compose_auth_dont_have_account
 import nuvio.composeapp.generated.resources.compose_auth_email
-import nuvio.composeapp.generated.resources.compose_auth_or_separator
 import nuvio.composeapp.generated.resources.compose_auth_password
 import nuvio.composeapp.generated.resources.compose_auth_sign_in
 import nuvio.composeapp.generated.resources.compose_auth_sign_in_subtitle
 import nuvio.composeapp.generated.resources.compose_auth_sign_up
 import nuvio.composeapp.generated.resources.compose_auth_sign_up_subtitle
-import nuvio.composeapp.generated.resources.compose_auth_store_locally
 import nuvio.composeapp.generated.resources.compose_auth_tagline
 import nuvio.composeapp.generated.resources.compose_auth_terms_link
 import nuvio.composeapp.generated.resources.compose_auth_terms_prefix
@@ -117,9 +114,6 @@ private val AuthFieldBackgroundMobile = Color.White.copy(alpha = 0.035f)
 private val AuthFieldBorder = Color.White.copy(alpha = 0.08f)
 private val AuthPaneBackground = Color.White.copy(alpha = 0.022f)
 private val AuthPaneBorder = Color.White.copy(alpha = 0.07f)
-private val AuthDividerColor = Color.White.copy(alpha = 0.10f)
-private val AuthSecondaryButtonBackground = Color.White.copy(alpha = 0.05f)
-private val AuthSecondaryButtonBorder = Color.White.copy(alpha = 0.09f)
 
 private data class AuthFormMetrics(
     val fieldHeight: Dp,
@@ -129,9 +123,6 @@ private data class AuthFormMetrics(
     val primaryTop: Dp,
     val primaryHeight: Dp,
     val toggleTop: Dp,
-    val dividerTop: Dp,
-    val secondaryTop: Dp,
-    val secondaryHeight: Dp,
     val fieldBackground: Color,
 )
 
@@ -143,9 +134,6 @@ private val MobileAuthFormMetrics = AuthFormMetrics(
     primaryTop = 22.dp,
     primaryHeight = 54.dp,
     toggleTop = 18.dp,
-    dividerTop = 28.dp,
-    secondaryTop = 24.dp,
-    secondaryHeight = 54.dp,
     fieldBackground = AuthFieldBackgroundMobile,
 )
 
@@ -157,9 +145,6 @@ private val LargeAuthFormMetrics = AuthFormMetrics(
     primaryTop = 24.dp,
     primaryHeight = 56.dp,
     toggleTop = 18.dp,
-    dividerTop = 30.dp,
-    secondaryTop = 26.dp,
-    secondaryHeight = 56.dp,
     fieldBackground = AuthFieldBackground,
 )
 
@@ -174,9 +159,6 @@ private fun largeAuthFormMetrics(scale: Float): AuthFormMetrics = LargeAuthFormM
     primaryTop = 24.dp * scale,
     primaryHeight = 56.dp * scale,
     toggleTop = 18.dp * scale,
-    dividerTop = 30.dp * scale,
-    secondaryTop = 26.dp * scale,
-    secondaryHeight = 56.dp * scale,
 )
 
 @Composable
@@ -349,7 +331,7 @@ private fun AuthMobileLayout(
                 .fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            AuthBrandLockup(logoHeight = 38.dp)
+            AuthBrandLockup(logoHeight = 38.dp, showTagline = false)
 
             Spacer(modifier = Modifier.height(64.dp))
 
@@ -518,6 +500,7 @@ private fun AuthLargeLayout(
 @Composable
 private fun AuthBrandLockup(
     logoHeight: Dp,
+    showTagline: Boolean = true,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -526,16 +509,18 @@ private fun AuthBrandLockup(
             contentDescription = null,
             modifier = Modifier.height(logoHeight),
         )
-        Spacer(modifier = Modifier.height(14.dp))
-        Text(
-            text = stringResource(Res.string.compose_auth_tagline),
-            style = MaterialTheme.typography.bodyMedium.copy(
-                color = AuthTextSecondary,
-                fontSize = 14.sp,
-                lineHeight = 20.sp,
-                fontWeight = FontWeight.Normal,
-            ),
-        )
+        if (showTagline) {
+            Spacer(modifier = Modifier.height(14.dp))
+            Text(
+                text = stringResource(Res.string.compose_auth_tagline),
+                style = MaterialTheme.typography.bodyMedium.copy(
+                    color = AuthTextSecondary,
+                    fontSize = 14.sp,
+                    lineHeight = 20.sp,
+                    fontWeight = FontWeight.Normal,
+                ),
+            )
+        }
     }
 }
 
@@ -679,32 +664,12 @@ private fun AuthForm(
             onToggleAuthMode = onToggleAuthMode,
         )
 
-        Spacer(modifier = Modifier.height(metrics.dividerTop))
+        Spacer(modifier = Modifier.height(24.dp * scale))
 
-        AuthDivider(scale = scale)
-
-        Spacer(modifier = Modifier.height(metrics.secondaryTop))
-
-        AuthSecondaryButton(
+        AuthTextAction(
             text = stringResource(Res.string.compose_auth_continue_without_account),
             enabled = !isLoading,
-            height = metrics.secondaryHeight,
-            scale = scale,
             onClick = onContinueWithoutAccount,
-        )
-
-        Spacer(modifier = Modifier.height(14.dp))
-
-        Text(
-            text = stringResource(Res.string.compose_auth_store_locally),
-            modifier = Modifier.fillMaxWidth(),
-            style = MaterialTheme.typography.bodyMedium.copy(
-                color = AuthTextMuted,
-                fontSize = (13f * scale).sp,
-                lineHeight = (18f * scale).sp,
-                fontWeight = FontWeight.Normal,
-            ),
-            textAlign = TextAlign.Center,
         )
     }
 }
@@ -934,65 +899,27 @@ private fun AuthModeToggle(
 }
 
 @Composable
-private fun AuthDivider(scale: Float) {
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .height(1.dp)
-                .background(AuthDividerColor),
-        )
-        Text(
-            text = stringResource(Res.string.compose_auth_or_separator).trim(),
-            modifier = Modifier.padding(horizontal = 16.dp),
-            style = MaterialTheme.typography.bodyMedium.copy(
-                color = AuthTextMuted,
-                fontSize = (13f * scale).sp,
-                lineHeight = (18f * scale).sp,
-                fontWeight = FontWeight.Normal,
-            ),
-        )
-        Box(
-            modifier = Modifier
-                .weight(1f)
-                .height(1.dp)
-                .background(AuthDividerColor),
-        )
-    }
-}
-
-@Composable
-private fun AuthSecondaryButton(
+private fun AuthTextAction(
     text: String,
     enabled: Boolean,
-    height: Dp,
-    scale: Float,
     onClick: () -> Unit,
 ) {
-    Button(
-        onClick = onClick,
+    Box(
         modifier = Modifier
             .fillMaxWidth()
-            .height(height),
-        enabled = enabled,
-        shape = RoundedCornerShape(16.dp),
-        border = BorderStroke(1.dp, AuthSecondaryButtonBorder),
-        contentPadding = PaddingValues(0.dp),
-        colors = ButtonDefaults.buttonColors(
-            containerColor = AuthSecondaryButtonBackground,
-            contentColor = AuthTextPrimary,
-            disabledContainerColor = AuthSecondaryButtonBackground.copy(alpha = 0.45f),
-            disabledContentColor = AuthTextPrimary.copy(alpha = 0.55f),
-        ),
+            .height(48.dp),
+        contentAlignment = Alignment.Center,
     ) {
         Text(
             text = text,
-            style = MaterialTheme.typography.titleMedium.copy(
-                fontSize = (15f * scale).sp,
-                lineHeight = (21f * scale).sp,
+            modifier = Modifier
+                .clip(RoundedCornerShape(8.dp))
+                .clickable(enabled = enabled, onClick = onClick)
+                .padding(horizontal = 12.dp, vertical = 8.dp),
+            style = MaterialTheme.typography.bodyMedium.copy(
+                color = if (enabled) AuthTextPrimary else AuthTextPrimary.copy(alpha = 0.55f),
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
                 fontWeight = FontWeight.Medium,
             ),
             textAlign = TextAlign.Center,

--- a/tvosApp/Documentation/SIGN_IN_QUIET_REDESIGN_2026-08-11.md
+++ b/tvosApp/Documentation/SIGN_IN_QUIET_REDESIGN_2026-08-11.md
@@ -1,0 +1,29 @@
+# Sign-in quiet redesign receipt
+
+Date reviewed: 2026-08-11 UTC
+Scope: `composeApp/src/commonMain/kotlin/com/nuvio/app/features/auth/AuthScreen.kt` and shared Compose resources.
+
+## Applied guidance
+
+- Material buttons: label text should be very brief, ideally 1 to 3 words, and stay on one line. Source: https://m3.material.io/components/buttons/guidelines
+- Material buttons: filled style is for one important action on a page; outlined/text styles are lower emphasis. Source: https://m3.material.io/components/buttons/guidelines
+- Material writing: UI text should use sentence case and scannable wording. Source: https://m3.material.io/foundations/content-design/style-guide/ux-writing-best-practices
+- WCAG 3.3.2: labels and instructions are required, but too much instruction can be as harmful as too little. Source: https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html
+- WCAG 2.5.8: pointer targets should be at least 24 by 24 CSS pixels or have sufficient spacing. Source: https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum
+- Google Identity: sign-in calls to action should use clear `Sign in`, `Sign up`, or `Continue with` wording when a provider is involved. Source: https://developers.google.com/identity/branding-guidelines
+- Apple developer pages were requested and search snippets confirmed the relevant HIG pages, but the pages currently redirect to themselves and could not be opened. Sources attempted: https://developer.apple.com/design/human-interface-guidelines/buttons and https://developer.apple.com/design/human-interface-guidelines/writing
+
+## Change
+
+- Removed the mobile brand tagline from the auth lockup.
+- Removed the decorative `or` divider from the form.
+- Removed the full-width anonymous continuation button and its separate local-storage disclaimer.
+- Kept anonymous continuation as a low-emphasis text action, `Continue Without Account`, with a 48.dp target.
+- Kept the primary account action as the single filled button.
+
+## Verification
+
+- `:composeApp:compileKotlinIosSimulatorArm64`: passed.
+- `:composeApp:linkDebugFrameworkIosSimulatorArm64`: passed.
+- `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Debug -destination platform=iOS Simulator,id=7A85E485-B869-4335-9721-64927C592766 CODE_SIGNING_ALLOWED=NO build`: passed.
+- Screenshot reviewed: `build/auth-quiet-mobile.png`.


### PR DESCRIPTION
## Summary

Reduce text density and competing actions on the mobile sign-in screen.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The mobile sign-in screen presented repeated context copy, a long secondary button, an `or` divider, and a separate local-storage disclaimer. This made the first screen dense and reduced the visual weight of the actual sign-in action.

## Issue or approval

Fixes #1727.

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the shared mobile auth screen and its removed string resources are changed. The Apple TV port is intentionally excluded.

## Testing

- `./gradlew :composeApp:compileKotlinIosSimulatorArm64`
- `./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64`
- `xcodebuild -project iosApp/iosApp.xcodeproj -scheme iosApp -configuration Debug -destination platform=iOS Simulator,id=7A85E485-B869-4335-9721-64927C592766 CODE_SIGNING_ALLOWED=NO build`
- Reviewed a simulator screenshot of the finished screen.

## Screenshots / Video

After screenshot: `build/auth-quiet-mobile.png` in the local working evidence. I can attach it in a review comment if useful.

## Breaking changes

None.

## Linked issues

Fixes #1727.
