### PR TITLE
fix: change mark as watched icon to eye icon

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PosterActionSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PosterActionSheet.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -34,7 +35,7 @@ fun NuvioWatchedBadge(
         contentAlignment = Alignment.Center,
     ) {
         Icon(
-            imageVector = Icons.Default.Check,
+            imageVector = Icons.Default.Visibility,
             contentDescription = stringResource(Res.string.episodes_cd_watched),
             tint = tokens.colors.onAccent,
             modifier = Modifier.size(NuvioTokens.Icon.xs),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -37,6 +37,8 @@ import androidx.compose.material.icons.filled.CheckCircleOutline
 import androidx.compose.material.icons.filled.DoneAll
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.PlaylistAddCheckCircle
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import com.nuvio.app.core.ui.NuvioLoadingIndicator
@@ -2010,9 +2012,9 @@ private fun ConfiguredMetaSections(
                                 stringResource(Res.string.hero_mark_watched)
                             },
                             icon = if (isWatched) {
-                                Icons.Default.CheckCircle
+                                Icons.Default.Visibility
                             } else {
-                                Icons.Default.CheckCircleOutline
+                                Icons.Default.VisibilityOff
                             },
                             isActive = isWatched,
                             onClick = onWatchedClick,


### PR DESCRIPTION
## Summary

Changed the watch status icon to use an eye icon instead of the checkmark to avoid ambiguity with the watchlist button.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [X] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The current checkmark icon for watch status creates visual confusion and ambiguity with the watchlist button. Changing it to an eye icon clearly distinguishes watched status from watchlist state, resolving the UI confusion.

## Issue or approval

Fixes #1746

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [ ] No UI change
- [X] No behavior change
- [X] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [X] I have read and understood `CONTRIBUTING.md`.
- [X] This PR is small, focused, and limited to one problem.
- [X] This PR is not cosmetic-only.
- [X] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [X] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [X] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [X] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [X] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

This PR only updates the watch status icon representation. It does not alter underlying state logic, user preferences, or any other UI component layout.

## Testing

Tested on iOS Simulator / Physical Device:
- Verified that toggling watch status updates the icon state correctly between active/inactive.
- Confirmed no layout shifts or regressions in neighboring UI components.

## Screenshots / Video (UI changes only)

| Before | After |
| :---: | :---: |
| <img width="250" alt="image" src="https://github.com/user-attachments/assets/e97631d6-fe00-473d-a4e1-2856b3cda9d4" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/1ff217b6-0f6d-403e-8dff-ec608757e75d" /> |
| <img width="250"  alt="image" src="https://github.com/user-attachments/assets/576b154f-3642-4e40-8651-d37f9135cb0c" /> | <img width="250" alt="image" src="https://github.com/user-attachments/assets/fc6444d1-17aa-4b17-bbd1-9628b120ed96" /> |
| <img width="220" alt="image" src="https://github.com/user-attachments/assets/3b4039f0-795f-4752-9f3a-3218f1f43c36" /> | <img width="220" alt="image" src="https://github.com/user-attachments/assets/eec58e54-bdc2-4ee5-9b9e-96366708e679" /> |

## Breaking changes

<!-- Any breaking behavior/config/schema changes? If none, write: None. -->
None

## Linked issues

Closes #1746. 