### PR TITLE
Simkl: let anime by a separate type

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryDisplaySettings.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryDisplaySettings.kt
@@ -170,7 +170,7 @@ internal fun buildLibraryVerticalProjection(
         }
     }
     val availableTypes = deduplicatedEntries.values
-        .map { entry -> entry.item.type.normalizedLibraryType() }
+        .map { entry -> (entry.item.mediaCategory ?: entry.item.type).normalizedLibraryType() }
         .filter { it.isNotBlank() }
         .distinct()
         .sorted()
@@ -178,7 +178,7 @@ internal fun buildLibraryVerticalProjection(
         ?.normalizedLibraryType()
         ?.takeIf { it in availableTypes }
     val filteredEntries = deduplicatedEntries.values.filter { entry ->
-        effectiveType == null || entry.item.type.normalizedLibraryType() == effectiveType
+        effectiveType == null || (entry.item.mediaCategory ?: entry.item.type).normalizedLibraryType() == effectiveType
     }
     val entryByKey = filteredEntries.associateBy { entry -> libraryDisplayItemKey(entry.item) }
     val sortedEntries = sortLibraryItems(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/library/LibraryModels.kt
@@ -25,6 +25,9 @@ data class LibraryItem(
     val imdbId: String? = null,
     val tmdbId: Int? = null,
     val traktId: Int? = null,
+    /** Original media category from the tracking provider (e.g. "anime").
+     *  Used for UI filtering while [type] stays as "movie"/"series" for meta addon compatibility. */
+    val mediaCategory: String? = null,
     override val trackingProviderId: String? = null,
     override val trackingProviderItemId: String? = null,
     override val trackingSourceUrl: String? = null,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklLibraryProjection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklLibraryProjection.kt
@@ -115,6 +115,7 @@ private fun SimklLibraryEntry.toLibraryItem(
         listKeys = setOf(listKey),
         imdbId = media.ids.idValue("imdb"),
         tmdbId = media.ids.idValue("tmdb")?.toIntOrNull(),
+        mediaCategory = if (mediaType == SimklMediaType.ANIME) "anime" else null,
         trackingProviderId = TrackingProviderId.SIMKL.storageId,
         trackingProviderItemId = simklId?.let { "simkl:$it" },
         trackingSourceUrl = buildSimklSourceUrl(mediaType, media),


### PR DESCRIPTION
## Summary

Add `mediaCategory` field to `LibraryItem` and set it to "anime" for Simkl anime entries. Library type filter uses `mediaCategory` when present, showing Anime as a separate tab alongside Movies/Series.

Matching change added in NuvioTV: https://github.com/NuvioMedia/NuvioTV/pull/3064

## PR type

- [x] Critical bug fix

## Why

Simkl anime entries were merged into Movies/Series tabs with no way to filter them separately. Users expect Anime as its own category in the library.

## Issue or approval

Part of NuvioTV/NuvioMedia/NuvioTV#3064.

## Reproduction steps

1. Connect Simkl account with anime in library
2. Open Library -> type filter only shows Movies / Series
3. After fix -> Anime appears as separate filter option

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only Simkl sets `mediaCategory`. Trakt anime (if any) is unchanged.
- `LibraryItem.type` remains "movie"/"series" for meta addon compatibility.

## Testing

- Verified Simkl anime entries appear under "Anime" type filter
- Verified Movies/Series tabs no longer contain anime entries
- Verified navigation from anime library item -> detail uses correct type (movie/series) for meta addons

## Screenshots / Video

Not a UI change (uses existing type filter chips).

## Breaking changes

None. `mediaCategory` is nullable with default null - no serialization break.

## Linked issues

https://github.com/NuvioMedia/NuvioTV/pull/3064
