### PR TITLE
Fix anime movies for Simkl

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklPlaybackReconciliation.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklPlaybackReconciliation.kt
@@ -7,7 +7,7 @@ internal fun SimklSyncSnapshot.reconcileWatchedPlayback(): SimklSyncSnapshot {
     if (playback.isEmpty()) return this
     val watchedItems = toSimklWatchedProjection().items
     val retainedPlayback = playback.filterNot { session ->
-        session.toWatchProgressEntry()?.let { progress ->
+        session.toWatchProgressEntry(entries)?.let { progress ->
             entries.any { entry -> entry.hidesPlayback(progress) } ||
                 watchedItems.any { watched -> watched.supersedes(progress) }
         } == true

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklProjections.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklProjections.kt
@@ -165,7 +165,7 @@ internal fun SimklSyncSnapshot.movieAlternateWatchedKeys(): Set<String> {
 
 internal fun SimklSyncSnapshot.toSimklProgressEntries(): List<WatchProgressEntry> =
     playback
-        .mapNotNull(SimklPlaybackSession::toWatchProgressEntry)
+        .mapNotNull { session -> session.toWatchProgressEntry(entries) }
         .groupBy(WatchProgressEntry::progressKey)
         .mapNotNull { (_, candidates) -> candidates.maxByOrNull(WatchProgressEntry::lastUpdatedEpochMs) }
         .sortedByDescending(WatchProgressEntry::lastUpdatedEpochMs)
@@ -377,11 +377,19 @@ internal fun parseSimklUtcEpochMs(value: String?): Long? {
     return (((days * 24L + hour) * 60L + minute) * 60L + second) * 1_000L + millis
 }
 
-internal fun SimklPlaybackSession.toWatchProgressEntry(): WatchProgressEntry? {
+internal fun SimklPlaybackSession.toWatchProgressEntry(
+    libraryEntries: List<SimklLibraryEntry> = emptyList()
+): WatchProgressEntry? {
     val media = media ?: return null
     val parentId = media.canonicalContentId() ?: return null
+    val isAnimeMovie = mediaType == SimklMediaType.ANIME && libraryEntries.any { entry ->
+        entry.mediaType == SimklMediaType.ANIME &&
+            entry.animeType == "movie" &&
+            entry.media?.toTrackingExternalIds()?.sharesIdentityWith(media.toTrackingExternalIds()) == true
+    }
     val isMovie = mediaType == SimklMediaType.MOVIES ||
-        (mediaType == SimklMediaType.ANIME && episode == null)
+        (mediaType == SimklMediaType.ANIME && episode == null) ||
+        isAnimeMovie
     val season = episode?.tvdbSeason ?: episode?.season
     val episodeNumber = episode?.tvdbNumber ?: episode?.number
     if (!isMovie && episodeNumber == null) return null
@@ -478,6 +486,13 @@ private fun daysInMonths(year: Int): IntArray = if (year.isLeapYear()) {
  */
 internal fun TrackingMediaReference.resolveAnimeEpisodeForSimkl(): TrackingMediaReference {
     if (kind != TrackingMediaKind.ANIME) return this
+    if (episode == null) {
+        val videoId = catalog?.videoId
+        val parsed = videoId?.let { parseSimklAnimeVideoId(it) }
+        if (parsed?.episodeNumber == null) {
+            return copy(episode = TrackingEpisode(season = null, number = 1))
+        }
+    }
     val videoId = catalog?.videoId ?: return stripAnimeIdsIfSeasoned()
     val parsed = parseSimklAnimeVideoId(videoId) ?: return stripAnimeIdsIfSeasoned()
     val videoEpisodeNumber = parsed.episodeNumber ?: return stripAnimeIdsIfSeasoned()

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tracking/TrackingMedia.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tracking/TrackingMedia.kt
@@ -116,11 +116,10 @@ fun parseTrackingExternalIds(rawValue: String?): TrackingExternalIds {
 
 fun trackingMediaKind(contentType: String, ids: TrackingExternalIds = TrackingExternalIds()): TrackingMediaKind {
     val normalized = contentType.trim().lowercase()
+    val hasAnimeIds = ids.mal != null || ids.anidb != null || ids.anilist != null || ids.kitsu != null
     return when {
+        hasAnimeIds || normalized == "anime" -> TrackingMediaKind.ANIME
         normalized in setOf("movie", "film") -> TrackingMediaKind.MOVIE
-        normalized == "anime" || ids.mal != null || ids.anidb != null || ids.anilist != null || ids.kitsu != null -> {
-            TrackingMediaKind.ANIME
-        }
         else -> TrackingMediaKind.SHOW
     }
 }


### PR DESCRIPTION
## Summary

Mirror of [NuvioTV#3123](https://github.com/NuvioMedia/NuvioTV/pull/3123): fix anime-movie Simkl scrobble and Continue Watching classification.

Content with anime IDs (MAL/Kitsu/AniDB/AniList) and contentType "movie" was treated as MOVIE kind, causing Simkl to reject scrobbles with 404 id_err. Also fixes anime-movie from Simkl playback being classified as "series" in Continue Watching.

## PR type

- [ ] Translation/localization only
- [x] Critical bug fix

## Why

Same as NuvioTV/NuvioTV#3123:
1. trackingMediaKind() prioritized contentType "movie" over anime ID presence. Anime movies sent to Simkl with "movie" wrapper -> rejected with 404.
2. Anime movies without episode in videoId failed resolveAnimeEpisodeForSimkl and hit require crash.
3. SimklPlaybackSession.toWatchProgressEntry() classified anime-movies as series because Simkl always returns episode!=null for anime, but didn't check animeType=="movie".

## Issue or approval

Mirror of https://github.com/NuvioMedia/NuvioTV/pull/3123

## Reproduction steps

Bug 1-2: Play OVA/Special episode that is an anime movie in meta addon -> Simkl scrobble fails with 404 or no_scrobble_item
Bug 3: Have anime-movie in Simkl playback -> appears in CW as series instead of movie


## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- trackingMediaKind: anime IDs priority over contentType.
- resolveAnimeEpisodeForSimkl: episode=1 fallback for anime without episode in videoId.
- SimklProjections.toWatchProgressEntry: accepts libraryEntries param, checks animeType=="movie".
- SimklPlaybackReconciliation: passes entries to toWatchProgressEntry.
- No UI, player, or navigation changes.

## Testing

- Verified anime movie scrobbles to Simkl without 404
- Verified regular anime series scrobble still works
- Verified western movie (IMDB only) still scrobbles as movie kind
- Verified anime-movie in Simkl playback shows as movie in CW
- Tested on Android phone

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Mirror of https://github.com/NuvioMedia/NuvioTV/pull/3123
