### PR TITLE
fix: per-episode rating from addon metadata is never parsed

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsModels.kt
@@ -93,6 +93,7 @@ data class MetaVideo(
     val episode: Int? = null,
     val overview: String? = null,
     val runtime: Int? = null,
+    val rating: Double? = null,
     val streams: List<StreamItem> = emptyList(),
 )
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsParser.kt
@@ -235,6 +235,7 @@ internal object MetaDetailsParser {
                 episode = video.int("episode"),
                 overview = video.string("overview") ?: video.string("description"),
                 runtime = video.int("runtime"),
+                rating = video.string("rating")?.trim()?.toDoubleOrNull()?.takeIf { it > 0.0 },
                 streams = video.embeddedStreams(),
             )
         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
@@ -319,7 +319,7 @@ fun DetailSeriesContent(
                                     video = episode,
                                     fallbackImage = meta.background ?: meta.poster,
                                     progressEntry = progressByVideoId[episodeVideoId],
-                                    imdbRating = episode.seasonEpisodeKey()?.let { episodeRatings[it] },
+                                    imdbRating = episode.seasonEpisodeKey()?.let { episodeRatings[it] } ?: episode.rating,
                                     isWatched = progressByVideoId[episodeVideoId]?.isEffectivelyCompleted == true ||
                                         WatchingState.isEpisodeWatched(
                                             watchedKeys = watchedKeys,
@@ -651,7 +651,7 @@ private fun EpisodeHorizontalRow(
                 video = episode,
                 fallbackImage = fallbackImage,
                 progressEntry = progressByVideoId[episodeVideoId],
-                imdbRating = episode.seasonEpisodeKey()?.let { episodeRatings[it] },
+                imdbRating = episode.seasonEpisodeKey()?.let { episodeRatings[it] } ?: episode.rating,
                 isWatched = progressByVideoId[episodeVideoId]?.isEffectivelyCompleted == true ||
                     WatchingState.isEpisodeWatched(
                         watchedKeys = watchedKeys,


### PR DESCRIPTION
## Summary

`MetaDetailsParser.videos()` builds every `MetaVideo` without reading `rating`, so a per-episode rating sent by a metadata addon is discarded. This adds the field, parses it, and falls back to it on the episode cards when the episode-ratings repository has no entry.

## PR type

- [x] Reproducible bug fix

## Why

Cinemeta and the TMDB addon both send `rating` on `meta.videos[]` — Cinemeta on all 67 videos of Breaking Bad, and the TMDB addon with real values such as `"rating": "8.519"`. The parser reads `runtime`, `overview`, `thumbnail` and the rest of the video object but not `rating`, so the value arrives and is dropped.

Episode ratings can then only come from `ImdbEpisodeRatingsRepository`, which needs an IMDb or TMDB id. That covers most series, so the gap only shows up with addons that use their own ids: no id resolves, `getEpisodeRatings` returns an empty map, and the cards stay blank even though the addon sent a rating for every episode.

It is also total in a build from source — `composeApp/build.gradle.kts:130-131` defaults both rating API URLs to an empty string, so the repository returns nothing for any series.

## Issue or approval

Fixes https://github.com/NuvioMedia/NuvioTV/issues/3129 — same defect, same fix.

No separate mobile issue: @skoruppa asked for this in NuvioMedia/NuvioTV#3139 after reviewing the Android TV change. Desktop is NuvioMedia/NuvioDesktop#392 with PR NuvioMedia/NuvioDesktop#443.

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression

The rating badge already exists and already renders whenever the repository has a value. This only fills it when the repository has none, so nothing about the layout changes.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Three files, four lines. Deliberately not included:

- No change to `ImdbEpisodeRatingsRepository` or to how the repository is called. It keeps priority — `episodeRatings[it] ?: episode.rating` reads the addon value only where the repository returned nothing, so any series it covers is unaffected.
- No new UI, no layout or styling changes.
- No change to rating formatting. `formatEpisodeRating` already rounds to one decimal, so the three-decimal values TMDB sends render as `8.5`.
- Android TV is NuvioMedia/NuvioTV#3139 and desktop is NuvioMedia/NuvioDesktop#443. Nothing here depends on either.

## Testing

`:composeApp:compileAndroidMain` passes with no new warnings.

The parser and model files here are identical to desktop's, where I built and ran the same change with `:composeApp:run` on Windows 11:

- Breaking Bad — no ratings before, ratings from Cinemeta after.
- Stranger Things — no ratings before or after. Cinemeta sends `"rating": "0"` for all 70 of its videos, and the existing `imdbRating?.takeIf { it > 0.0 }` in both card composables keeps them blank, so unrated series are unaffected.
- An addon using its own ids — ratings shown where none could appear before from any source.

I checked metadata display only, not playback.

## Screenshots / Video

Before, on the 0.4.7 release APK. One Pace Premium sends a `rating` for every
episode and the cards are blank:

<img width="1920" height="1080" alt="Before" src="https://github.com/user-attachments/assets/b1e3586b-62ac-4146-b004-45a32b9a62b9" />

After, same addon on a build with the change:

<img width="1920" height="1080" alt="After" src="https://github.com/user-attachments/assets/d33e84e4-ea09-4a48-8c70-02ee0bb9a74c" />

Stranger Things on the patched build. Cinemeta sends `"rating": "0"` for all 70
of its videos and the existing `takeIf { it > 0.0 }` keeps them blank, so series
without ratings are unchanged:

<img width="1920" height="1080" alt="Unrated series unaffected" src="https://github.com/user-attachments/assets/fb772a47-701a-42c1-ad06-b79e3b678aa2" />


## Breaking changes

None. `rating` is a new nullable field with a default, `MetaVideo` is constructed in one place, and the addon value is only read where the repository returned nothing.

## Linked issues

Fixes https://github.com/NuvioMedia/NuvioTV/issues/3129