### PR TITLE
fix(simkl): anime movies scrobbled as wrong title from CW

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklProjections.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklProjections.kt
@@ -227,10 +227,12 @@ internal fun SimklSyncSnapshot.enrichMediaReference(reference: TrackingMediaRefe
         candidate.media?.toTrackingExternalIds()?.sharesIdentityWith(reference.ids) == true
     } ?: return reference
     val media = entry.media ?: return reference
-    val kind = when (entry.mediaType) {
-        SimklMediaType.MOVIES -> TrackingMediaKind.MOVIE
-        SimklMediaType.SHOWS -> TrackingMediaKind.SHOW
-        SimklMediaType.ANIME -> TrackingMediaKind.ANIME
+    val kind = when {
+        entry.mediaType == SimklMediaType.MOVIES -> TrackingMediaKind.MOVIE
+        entry.mediaType == SimklMediaType.ANIME && entry.animeType == "movie" -> TrackingMediaKind.MOVIE
+        entry.mediaType == SimklMediaType.SHOWS -> TrackingMediaKind.SHOW
+        entry.mediaType == SimklMediaType.ANIME -> TrackingMediaKind.ANIME
+        else -> TrackingMediaKind.SHOW
     }
     return reference.copy(
         kind = kind,
@@ -382,11 +384,14 @@ internal fun SimklPlaybackSession.toWatchProgressEntry(
 ): WatchProgressEntry? {
     val media = media ?: return null
     val parentId = media.canonicalContentId() ?: return null
-    val isAnimeMovie = mediaType == SimklMediaType.ANIME && libraryEntries.any { entry ->
-        entry.mediaType == SimklMediaType.ANIME &&
-            entry.animeType == "movie" &&
-            entry.media?.toTrackingExternalIds()?.sharesIdentityWith(media.toTrackingExternalIds()) == true
-    }
+    val isAnimeMovie = mediaType == SimklMediaType.ANIME && (
+        type == "movie" ||
+        libraryEntries.any { entry ->
+            entry.mediaType == SimklMediaType.ANIME &&
+                entry.animeType == "movie" &&
+                entry.media?.toTrackingExternalIds()?.sharesIdentityWith(media.toTrackingExternalIds()) == true
+        }
+    )
     val isMovie = mediaType == SimklMediaType.MOVIES ||
         (mediaType == SimklMediaType.ANIME && episode == null) ||
         isAnimeMovie


### PR DESCRIPTION
## Summary

Fix Simkl scrobbling for anime movies sending wrong data (e.g. "Howl's Moving Castle" scrobbled as "Roar") when playing from Continue Watching

Two fixes:
- `enrichMediaReference` now treats anime entries with `animeType == "movie"` as `TrackingMediaKind.MOVIE` instead of `ANIME`, preventing the scrobble body from being sent in the `anime` field with an episode number.
- `toWatchProgress`/`toWatchProgressEntry` now checks the Simkl API `type` field (`"movie"`) on playback sessions to correctly identify anime movies even without a matching library entry.

Applied to both NuvioTV and NuvioMobile.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

When an anime movie is in Simkl playback (Continue Watching), it was being treated as an anime series. This caused:
1. `contentType = "series"` in WatchProgress instead of `"movie"`
2. `enrichMediaReference` set `kind = ANIME` which triggered `resolveAnimeEpisodeForSimkl` to inject `episode = 1`
3. The scrobble body sent `anime + episode 1` to Simkl API, which matched a wrong title

The root cause is that Simkl always returns an episode object for anime movies in playback sessions, and our code relied on `episode == null` or library entry lookup to detect anime movies - both unreliable.

## Issue or approval

No linked issue - bug reported and reproduced internally.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only changes Simkl scrobble/progress logic for anime movies.
- Does not change behavior for regular movies, shows, or anime series.
- Does not change CW display logic or stream link caching.
- No extra UI polish or behavior tweaks included.

## Testing

- Reproduced bug: played anime movie (Howl's Moving Castle) from CW, confirmed Simkl scrobbled "Roar".
- Applied fix, replayed same flow - Simkl now correctly scrobbles the anime movie.
- Verified regular anime series scrobbling still works (episode coordinates intact).
- Verified regular movie scrobbling unaffected.
- Tested on NuvioTV (Shield) and NuvioMobile (Android emulator).

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - bug reported and reproduced internally via Simkl playback session for anime movies.
