### PR TITLE
Respect corner radius for trailers and episodes

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import com.nuvio.app.core.ui.rememberPosterCardStyleUiState
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -874,7 +875,9 @@ private data class EpisodeHorizontalCardMetrics(
 
 @Composable
 private fun rememberEpisodeHorizontalCardMetrics(maxWidthDp: Float): EpisodeHorizontalCardMetrics {
-    return remember(maxWidthDp) {
+    val posterCardStyle = rememberPosterCardStyleUiState()
+    val userCornerRadius = posterCardStyle.cornerRadiusDp.dp
+    return remember(maxWidthDp, userCornerRadius) {
         when {
             maxWidthDp >= 1300f -> EpisodeHorizontalCardMetrics(
                 rowHorizontalPadding = 0.dp,
@@ -882,7 +885,7 @@ private fun rememberEpisodeHorizontalCardMetrics(maxWidthDp: Float): EpisodeHori
                 itemSpacing = 18.dp,
                 cardWidth = 420.dp,
                 cardHeight = 256.dp,
-                cornerRadius = 18.dp,
+                cornerRadius = userCornerRadius,
                 contentPadding = 16.dp,
                 contentBottomPadding = 18.dp,
                 titleTextSize = 18.sp,
@@ -905,7 +908,7 @@ private fun rememberEpisodeHorizontalCardMetrics(maxWidthDp: Float): EpisodeHori
                 itemSpacing = 16.dp,
                 cardWidth = 384.dp,
                 cardHeight = 236.dp,
-                cornerRadius = 16.dp,
+                cornerRadius = userCornerRadius,
                 contentPadding = 14.dp,
                 contentBottomPadding = 16.dp,
                 titleTextSize = 17.sp,
@@ -928,7 +931,7 @@ private fun rememberEpisodeHorizontalCardMetrics(maxWidthDp: Float): EpisodeHori
                 itemSpacing = 14.dp,
                 cardWidth = 340.dp,
                 cardHeight = 212.dp,
-                cornerRadius = 14.dp,
+                cornerRadius = userCornerRadius,
                 contentPadding = 12.dp,
                 contentBottomPadding = 14.dp,
                 titleTextSize = 16.sp,
@@ -951,7 +954,7 @@ private fun rememberEpisodeHorizontalCardMetrics(maxWidthDp: Float): EpisodeHori
                 itemSpacing = 12.dp,
                 cardWidth = 296.dp,
                 cardHeight = 184.dp,
-                cornerRadius = 14.dp,
+                cornerRadius = userCornerRadius,
                 contentPadding = 10.dp,
                 contentBottomPadding = 12.dp,
                 titleTextSize = 14.sp,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailTrailersSection.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailTrailersSection.kt
@@ -42,6 +42,7 @@ import coil3.compose.AsyncImage
 import com.nuvio.app.core.ui.NuvioCardDepthSurface
 import com.nuvio.app.core.ui.nuvioCardDepth
 import com.nuvio.app.core.ui.nuvioHorizontalScrollBleed
+import com.nuvio.app.core.ui.rememberPosterCardStyleUiState
 import com.nuvio.app.features.details.MetaTrailer
 import nuvio.composeapp.generated.resources.*
 import nuvio.composeapp.generated.resources.detail_tab_trailer
@@ -79,13 +80,15 @@ fun DetailTrailersSection(
     var menuExpanded by remember { mutableStateOf(false) }
 
     val selectedTrailers = grouped[selectedCategory].orEmpty()
+    val posterCardStyle = rememberPosterCardStyleUiState()
+    val userCornerRadius = posterCardStyle.cornerRadiusDp.dp
 
     Column(
         modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
         BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-            val sizing = trailerSectionSizing(maxWidth.value)
+            val sizing = trailerSectionSizing(maxWidth.value, userCornerRadius)
 
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -159,7 +162,7 @@ fun DetailTrailersSection(
         }
 
         BoxWithConstraints(modifier = Modifier.fillMaxWidth()) {
-            val sizing = trailerSectionSizing(maxWidth.value)
+            val sizing = trailerSectionSizing(maxWidth.value, userCornerRadius)
             LazyRow(
                 modifier = Modifier
                     .nuvioHorizontalScrollBleed(horizontalScrollPadding)
@@ -260,12 +263,12 @@ private data class TrailerSectionSizing(
     val metaFontSize: androidx.compose.ui.unit.TextUnit,
 )
 
-private fun trailerSectionSizing(maxWidthDp: Float): TrailerSectionSizing =
+private fun trailerSectionSizing(maxWidthDp: Float, userCornerRadius: androidx.compose.ui.unit.Dp = 16.dp): TrailerSectionSizing =
     when {
         maxWidthDp >= 1200f -> TrailerSectionSizing(
             cardWidth = 280.dp,
             cardSpacing = 16.dp,
-            cardRadius = 20.dp,
+            cardRadius = userCornerRadius,
             selectorRadius = 20.dp,
             selectorHorizontalPadding = 14.dp,
             selectorVerticalPadding = 8.dp,
@@ -277,7 +280,7 @@ private fun trailerSectionSizing(maxWidthDp: Float): TrailerSectionSizing =
         maxWidthDp >= 1024f -> TrailerSectionSizing(
             cardWidth = 260.dp,
             cardSpacing = 14.dp,
-            cardRadius = 18.dp,
+            cardRadius = userCornerRadius,
             selectorRadius = 18.dp,
             selectorHorizontalPadding = 12.dp,
             selectorVerticalPadding = 6.dp,
@@ -289,7 +292,7 @@ private fun trailerSectionSizing(maxWidthDp: Float): TrailerSectionSizing =
         maxWidthDp >= 768f -> TrailerSectionSizing(
             cardWidth = 240.dp,
             cardSpacing = 12.dp,
-            cardRadius = 16.dp,
+            cardRadius = userCornerRadius,
             selectorRadius = 16.dp,
             selectorHorizontalPadding = 10.dp,
             selectorVerticalPadding = 5.dp,
@@ -301,7 +304,7 @@ private fun trailerSectionSizing(maxWidthDp: Float): TrailerSectionSizing =
         else -> TrailerSectionSizing(
             cardWidth = 200.dp,
             cardSpacing = 12.dp,
-            cardRadius = 16.dp,
+            cardRadius = userCornerRadius,
             selectorRadius = 16.dp,
             selectorHorizontalPadding = 10.dp,
             selectorVerticalPadding = 5.dp,


### PR DESCRIPTION
## Summary

Poster card corner radius from user settings was not applied to episode cards and trailer cards in the detail view. Both used hardcoded values (14-18dp for episodes, 16-20dp for trailers) instead of reading from PosterCardStyleRepository.

Fixed:
- Detail view -> Episodes horizontal cards (hardcoded 14/16/18dp -> user setting)
- Detail view -> Trailer cards (hardcoded 16/18/20dp -> user setting)

## PR type

- [x] Critical bug fix

## Why

User-configurable poster card corner radius setting exists in Poster Customization settings but was ignored by episode cards and trailer cards in the detail screen. Both components used hardcoded per-breakpoint values, making the setting appear partially broken.

## Issue or approval

User setting "Poster Card Corner Radius" has no effect on episode thumbnails and trailer cards in detail view.

## Reproduction steps

1. Open Settings -> Poster Customization
2. Set corner radius to 0dp (sharp corners)
3. Open any series detail -> Episodes section - episode thumbnails still have rounded corners (bug)
4. Open any title detail -> Trailers section - trailer cards still have rounded corners (bug)
5. Home screen catalogs, search results, collections all correctly show sharp corners

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Episode badge corner radius (small pill overlays) left unchanged - those are not poster card radius
- Season selector chip radius left unchanged
- Trailer category selector pill radius left unchanged
- Only the main card/thumbnail corner radius is affected

## Testing

- Set corner radius to 0dp, verified sharp corners on:
  - Episode horizontal cards in series detail (fixed)
  - Trailer cards in detail view (fixed)
  - Home catalogs (was already working)
  - Search results (was already working)
- Set corner radius to 24dp, verified large rounding on all above
- Verified across breakpoints (phone portrait, tablet landscape)
- Built and installed full debug APK on physical device

## Screenshots / Video

 Before

<img height="300" alt="Screenshot_2026-08-25-11-48-42-227_com nuvio app" src="https://github.com/user-attachments/assets/d7dab8f0-b12a-470a-bb21-c2b02e375a02" />
<img height="300" alt="Screenshot_2026-08-25-11-48-39-511_com nuvio app" src="https://github.com/user-attachments/assets/bd02e978-de37-44e5-a1bb-64e8dd6d2a12" />

After
<img height="300" alt="Screenshot_2026-08-25-11-49-45-343_com nuviodebug com" src="https://github.com/user-attachments/assets/224c7b60-7177-4fb0-b7cb-a5f6c4a49940" />


## Breaking changes

None.

## Linked issues

Poster card corner radius setting not respected for episode and trailer cards in detail view.
Same fixes made for TV version in https://github.com/NuvioMedia/NuvioTV/pull/3190
