### PR TITLE
fallback CJK cast names and filmography titles to English/Romaji

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -79,16 +79,42 @@ object TmdbMetadataService {
                                 (person.originalName == null || containsCjkOrHangul(person.originalName))
                             )
                     )
-            val englishPerson = if (shouldFetchEnglishPerson) {
-                runCatching {
-                    fetch<TmdbPersonResponse>(
-                        endpoint = "person/$personId",
-                        query = mapOf("language" to "en"),
-                    )
-                }.getOrNull()
+            val shouldFetchEnglishCredits = language != "en" &&
+                !isCjkLanguage &&
+                personCreditsContainCjkTitles(credits)
+
+            val (englishPerson, englishCredits) = if (shouldFetchEnglishPerson || shouldFetchEnglishCredits) {
+                coroutineScope {
+                    val englishPersonDeferred = async {
+                        if (shouldFetchEnglishPerson) {
+                            runCatching {
+                                fetch<TmdbPersonResponse>(
+                                    endpoint = "person/$personId",
+                                    query = mapOf("language" to "en"),
+                                )
+                            }.getOrNull()
+                        } else {
+                            null
+                        }
+                    }
+                    val englishCreditsDeferred = async {
+                        if (shouldFetchEnglishCredits) {
+                            runCatching {
+                                fetch<TmdbPersonCombinedCreditsResponse>(
+                                    endpoint = "person/$personId/combined_credits",
+                                    query = mapOf("language" to "en"),
+                                )
+                            }.getOrNull()
+                        } else {
+                            null
+                        }
+                    }
+                    englishPersonDeferred.await() to englishCreditsDeferred.await()
+                }
             } else {
-                null
+                null to null
             }
+            val englishTitlesById = englishCreditTitlesById(englishCredits)
 
             val biography = if (person.biography.isNullOrBlank() && language != "en") {
                 englishPerson?.biography
@@ -99,10 +125,34 @@ object TmdbMetadataService {
             val preferCrew = preferCrewCredits ?: shouldPreferCrewCredits(person.knownForDepartment)
 
             val (castMovieCredits, crewMovieCredits, castTvCredits, crewTvCredits) = coroutineScope {
-                val castMovieDeferred = async { mapPersonMovieCreditsFromCast(credits?.cast.orEmpty()) }
-                val crewMovieDeferred = async { mapPersonMovieCreditsFromCrew(credits?.crew.orEmpty()) }
-                val castTvDeferred = async { mapPersonTvCreditsFromCast(credits?.cast.orEmpty()) }
-                val crewTvDeferred = async { mapPersonTvCreditsFromCrew(credits?.crew.orEmpty()) }
+                val castMovieDeferred = async {
+                    mapPersonMovieCreditsFromCast(
+                        cast = credits?.cast.orEmpty(),
+                        preferredLanguage = language,
+                        englishTitlesById = englishTitlesById,
+                    )
+                }
+                val crewMovieDeferred = async {
+                    mapPersonMovieCreditsFromCrew(
+                        crew = credits?.crew.orEmpty(),
+                        preferredLanguage = language,
+                        englishTitlesById = englishTitlesById,
+                    )
+                }
+                val castTvDeferred = async {
+                    mapPersonTvCreditsFromCast(
+                        cast = credits?.cast.orEmpty(),
+                        preferredLanguage = language,
+                        englishTitlesById = englishTitlesById,
+                    )
+                }
+                val crewTvDeferred = async {
+                    mapPersonTvCreditsFromCrew(
+                        crew = credits?.crew.orEmpty(),
+                        preferredLanguage = language,
+                        englishTitlesById = englishTitlesById,
+                    )
+                }
                 PersonCreditBuckets(
                     castMovieCredits = castMovieDeferred.await(),
                     crewMovieCredits = crewMovieDeferred.await(),
@@ -168,6 +218,8 @@ object TmdbMetadataService {
 
     private fun mapPersonMovieCreditsFromCast(
         cast: List<TmdbPersonCreditCast>,
+        preferredLanguage: String,
+        englishTitlesById: Map<Int, String>,
     ): List<MetaPreview> {
         val seen = mutableSetOf<Int>()
         return cast
@@ -175,7 +227,12 @@ object TmdbMetadataService {
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seen.add(credit.id)) return@mapNotNull null
-                val title = credit.title ?: credit.name ?: return@mapNotNull null
+                val title = resolvePersonName(
+                    localizedName = credit.title ?: credit.name,
+                    originalName = credit.originalTitle ?: credit.originalName,
+                    fallbackEnglishName = englishTitlesById[credit.id],
+                    preferredLanguage = preferredLanguage,
+                ) ?: return@mapNotNull null
                 val poster = buildImageUrl(credit.posterPath, "w500")
                     ?: buildImageUrl(credit.backdropPath, "w780")
                     ?: return@mapNotNull null
@@ -196,6 +253,8 @@ object TmdbMetadataService {
 
     private fun mapPersonMovieCreditsFromCrew(
         crew: List<TmdbPersonCreditCrew>,
+        preferredLanguage: String,
+        englishTitlesById: Map<Int, String>,
     ): List<MetaPreview> {
         val seen = mutableSetOf<Int>()
         return crew
@@ -203,7 +262,12 @@ object TmdbMetadataService {
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seen.add(credit.id)) return@mapNotNull null
-                val title = credit.title ?: credit.name ?: return@mapNotNull null
+                val title = resolvePersonName(
+                    localizedName = credit.title ?: credit.name,
+                    originalName = credit.originalTitle ?: credit.originalName,
+                    fallbackEnglishName = englishTitlesById[credit.id],
+                    preferredLanguage = preferredLanguage,
+                ) ?: return@mapNotNull null
                 val poster = buildImageUrl(credit.posterPath, "w500")
                     ?: buildImageUrl(credit.backdropPath, "w780")
                     ?: return@mapNotNull null
@@ -224,6 +288,8 @@ object TmdbMetadataService {
 
     private fun mapPersonTvCreditsFromCast(
         cast: List<TmdbPersonCreditCast>,
+        preferredLanguage: String,
+        englishTitlesById: Map<Int, String>,
     ): List<MetaPreview> {
         val seen = mutableSetOf<Int>()
         return cast
@@ -231,7 +297,12 @@ object TmdbMetadataService {
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seen.add(credit.id)) return@mapNotNull null
-                val title = credit.name ?: credit.title ?: return@mapNotNull null
+                val title = resolvePersonName(
+                    localizedName = credit.name ?: credit.title,
+                    originalName = credit.originalName ?: credit.originalTitle,
+                    fallbackEnglishName = englishTitlesById[credit.id],
+                    preferredLanguage = preferredLanguage,
+                ) ?: return@mapNotNull null
                 val poster = buildImageUrl(credit.posterPath, "w500")
                     ?: buildImageUrl(credit.backdropPath, "w780")
                     ?: return@mapNotNull null
@@ -252,6 +323,8 @@ object TmdbMetadataService {
 
     private fun mapPersonTvCreditsFromCrew(
         crew: List<TmdbPersonCreditCrew>,
+        preferredLanguage: String,
+        englishTitlesById: Map<Int, String>,
     ): List<MetaPreview> {
         val seen = mutableSetOf<Int>()
         return crew
@@ -259,7 +332,12 @@ object TmdbMetadataService {
             .sortedByDescending { it.voteAverage ?: 0.0 }
             .mapNotNull { credit ->
                 if (!seen.add(credit.id)) return@mapNotNull null
-                val title = credit.name ?: credit.title ?: return@mapNotNull null
+                val title = resolvePersonName(
+                    localizedName = credit.name ?: credit.title,
+                    originalName = credit.originalName ?: credit.originalTitle,
+                    fallbackEnglishName = englishTitlesById[credit.id],
+                    preferredLanguage = preferredLanguage,
+                ) ?: return@mapNotNull null
                 val poster = buildImageUrl(credit.posterPath, "w500")
                     ?: buildImageUrl(credit.backdropPath, "w780")
                     ?: return@mapNotNull null
@@ -1342,6 +1420,28 @@ internal fun normalizeTmdbLanguage(language: String?): String {
         "es-419" -> "es-MX"
         else -> normalized
     }
+}
+
+private fun personCreditsContainCjkTitles(credits: TmdbPersonCombinedCreditsResponse?): Boolean {
+    if (credits == null) return false
+    return credits.cast.any { containsCjkOrHangul(it.title ?: it.name ?: return@any false) } ||
+        credits.crew.any { containsCjkOrHangul(it.title ?: it.name ?: return@any false) }
+}
+
+private fun englishCreditTitlesById(credits: TmdbPersonCombinedCreditsResponse?): Map<Int, String> {
+    if (credits == null) return emptyMap()
+    val titles = linkedMapOf<Int, String>()
+    fun putTitle(id: Int, title: String?, name: String?) {
+        val text = title?.trim()?.takeIf { it.isNotBlank() }
+            ?: name?.trim()?.takeIf { it.isNotBlank() }
+            ?: return
+        if (!containsCjkOrHangul(text)) {
+            titles.putIfAbsent(id, text)
+        }
+    }
+    credits.cast.forEach { putTitle(it.id, it.title, it.name) }
+    credits.crew.forEach { putTitle(it.id, it.title, it.name) }
+    return titles
 }
 
 internal fun containsCjkOrHangul(text: String): Boolean {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -458,34 +458,57 @@ object TmdbMetadataService {
                 }
             }
 
-            val queryParams = buildMap {
-                put("language", language)
-                put("page", page.toString())
-                put("sort_by", sortBy)
-                when (mediaType) {
-                    TmdbEntityMediaType.MOVIE -> {
-                        put("with_companies", entityId.toString())
-                    }
-                    TmdbEntityMediaType.TV -> {
-                        if (entityKind == TmdbEntityKind.COMPANY) put("with_companies", entityId.toString())
-                        if (entityKind == TmdbEntityKind.NETWORK) put("with_networks", entityId.toString())
-                    }
-                }
-                if (voteCountFloor != null) put("vote_count.gte", voteCountFloor.toString())
-            }
-
             val endpoint = when (mediaType) {
                 TmdbEntityMediaType.MOVIE -> "discover/movie"
                 TmdbEntityMediaType.TV -> "discover/tv"
             }
 
-            val response = fetch<TmdbDiscoverResponse>(endpoint = endpoint, query = queryParams)
+            suspend fun loadDiscover(requestLanguage: String): TmdbDiscoverResponse? {
+                val queryParams = buildMap {
+                    put("language", requestLanguage)
+                    put("page", page.toString())
+                    put("sort_by", sortBy)
+                    when (mediaType) {
+                        TmdbEntityMediaType.MOVIE -> {
+                            put("with_companies", entityId.toString())
+                        }
+                        TmdbEntityMediaType.TV -> {
+                            if (entityKind == TmdbEntityKind.COMPANY) put("with_companies", entityId.toString())
+                            if (entityKind == TmdbEntityKind.NETWORK) put("with_networks", entityId.toString())
+                        }
+                    }
+                    if (voteCountFloor != null) put("vote_count.gte", voteCountFloor.toString())
+                }
+                return fetch<TmdbDiscoverResponse>(endpoint = endpoint, query = queryParams)
+            }
+
+            val response = loadDiscover(language)
             val results = response?.results.orEmpty()
             val totalPages = response?.totalPages ?: page
 
+            val isCjkLanguage = language.startsWith("ja") ||
+                language.startsWith("ko") ||
+                language.startsWith("zh")
+            val englishTitlesById = if (
+                language != "en" &&
+                !isCjkLanguage &&
+                discoverResultsContainCjkTitles(results)
+            ) {
+                englishDiscoverTitlesById(loadDiscover("en")?.results.orEmpty())
+            } else {
+                emptyMap()
+            }
+
             val mappedItems = results
                 .filter { it.id > 0 }
-                .mapNotNull { item -> mapEntityDiscoverResult(item, mediaType) }
+                .mapNotNull { item ->
+                    mapEntityDiscoverResult(
+                        result = item,
+                        mediaType = mediaType,
+                        preferredLanguage = language,
+                        englishTitlesById = englishTitlesById,
+                    )
+                }
                 .take(ENTITY_RAIL_MAX_ITEMS)
 
             TmdbEntityRailPageResult(
@@ -571,12 +594,15 @@ object TmdbMetadataService {
     private fun mapEntityDiscoverResult(
         result: TmdbDiscoverResult,
         mediaType: TmdbEntityMediaType,
+        preferredLanguage: String,
+        englishTitlesById: Map<Int, String>,
     ): MetaPreview? {
-        val title = result.title?.takeIf { it.isNotBlank() }
-            ?: result.name?.takeIf { it.isNotBlank() }
-            ?: result.originalTitle?.takeIf { it.isNotBlank() }
-            ?: result.originalName?.takeIf { it.isNotBlank() }
-            ?: return null
+        val title = resolvePersonName(
+            localizedName = result.title ?: result.name,
+            originalName = result.originalTitle ?: result.originalName,
+            fallbackEnglishName = englishTitlesById[result.id],
+            preferredLanguage = preferredLanguage,
+        ) ?: return null
 
         val poster = buildImageUrl(result.posterPath, "w500")
             ?: buildImageUrl(result.backdropPath, "w780")
@@ -1422,6 +1448,25 @@ internal fun normalizeTmdbLanguage(language: String?): String {
     }
 }
 
+internal fun discoverResultsContainCjkTitles(results: List<TmdbDiscoverResult>): Boolean {
+    return results.any { result ->
+        containsCjkOrHangul(result.title ?: result.name ?: return@any false)
+    }
+}
+
+internal fun englishDiscoverTitlesById(results: List<TmdbDiscoverResult>): Map<Int, String> {
+    val titles = linkedMapOf<Int, String>()
+    results.forEach { result ->
+        val text = result.title?.trim()?.takeIf { it.isNotBlank() }
+            ?: result.name?.trim()?.takeIf { it.isNotBlank() }
+            ?: return@forEach
+        if (!containsCjkOrHangul(text)) {
+            titles.putIfAbsent(result.id, text)
+        }
+    }
+    return titles
+}
+
 private fun personCreditsContainCjkTitles(credits: TmdbPersonCombinedCreditsResponse?): Boolean {
     if (credits == null) return false
     return credits.cast.any { containsCjkOrHangul(it.title ?: it.name ?: return@any false) } ||
@@ -2116,7 +2161,7 @@ private data class TmdbDiscoverResponse(
 )
 
 @Serializable
-private data class TmdbDiscoverResult(
+internal data class TmdbDiscoverResult(
     val id: Int,
     val title: String? = null,
     val name: String? = null,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -66,13 +66,32 @@ object TmdbMetadataService {
 
             if (person == null) return@withContext null
 
-            val biography = if (person.biography.isNullOrBlank() && language != "en") {
+            val isCjkLanguage = language.startsWith("ja") ||
+                language.startsWith("ko") ||
+                language.startsWith("zh")
+            val shouldFetchEnglishPerson = language != "en" &&
+                (
+                    person.biography.isNullOrBlank() ||
+                        (
+                            !isCjkLanguage &&
+                                person.name != null &&
+                                containsCjkOrHangul(person.name) &&
+                                (person.originalName == null || containsCjkOrHangul(person.originalName))
+                            )
+                    )
+            val englishPerson = if (shouldFetchEnglishPerson) {
                 runCatching {
                     fetch<TmdbPersonResponse>(
                         endpoint = "person/$personId",
                         query = mapOf("language" to "en"),
-                    )?.biography
+                    )
                 }.getOrNull()
+            } else {
+                null
+            }
+
+            val biography = if (person.biography.isNullOrBlank() && language != "en") {
+                englishPerson?.biography
             } else {
                 person.biography
             }?.takeIf { it.isNotBlank() }
@@ -94,7 +113,12 @@ object TmdbMetadataService {
 
             val detail = PersonDetail(
                 tmdbId = person.id ?: personId,
-                name = person.name ?: runBlocking { getString(Res.string.generic_unknown) },
+                name = resolvePersonName(
+                    localizedName = person.name,
+                    originalName = person.originalName,
+                    fallbackEnglishName = englishPerson?.name,
+                    preferredLanguage = language,
+                ) ?: runBlocking { getString(Res.string.generic_unknown) },
                 biography = biography,
                 birthday = person.birthday?.takeIf { it.isNotBlank() },
                 deathday = person.deathday?.takeIf { it.isNotBlank() },
@@ -840,14 +864,39 @@ object TmdbMetadataService {
         val details = response.first ?: return@withContext null
         val credits = response.second
         val images = response.third
+        val englishFallbackNames = fetchEnglishFallbackNames(
+            numericId = numericId,
+            mediaType = mediaType,
+            language = normalizedLanguage,
+            details = details,
+            credits = credits,
+        )
 
         val genres = details.genres.mapNotNull { it.name?.trim()?.takeIf(String::isNotBlank) }
         val description = details.overview?.trim()?.takeIf(String::isNotBlank)
         val releaseInfo = details.releaseDate ?: details.firstAirDate
         val localizedTitle = listOf(details.title, details.name).firstNotNullOfOrNull { it?.trim()?.takeIf(String::isNotBlank) }
-        val people = buildPeople(details = details, credits = credits, mediaType = mediaType)
-        val directors = buildDirectors(details = details, credits = credits, mediaType = mediaType)
-        val writers = buildWriters(credits = credits, mediaType = mediaType, hasDirectors = directors.isNotEmpty())
+        val people = buildPeople(
+            details = details,
+            credits = credits,
+            mediaType = mediaType,
+            preferredLanguage = normalizedLanguage,
+            englishFallbackNames = englishFallbackNames,
+        )
+        val directors = buildDirectors(
+            details = details,
+            credits = credits,
+            mediaType = mediaType,
+            preferredLanguage = normalizedLanguage,
+            englishFallbackNames = englishFallbackNames,
+        )
+        val writers = buildWriters(
+            credits = credits,
+            mediaType = mediaType,
+            hasDirectors = directors.isNotEmpty(),
+            preferredLanguage = normalizedLanguage,
+            englishFallbackNames = englishFallbackNames,
+        )
         val lastAirDate = details.lastAirDate?.trim()?.takeIf(String::isNotBlank)
             ?.takeIf { mediaType == "tv" }
         val enrichment = TmdbEnrichment(
@@ -888,6 +937,66 @@ object TmdbMetadataService {
         if (!enrichment.hasContent()) return@withContext null
         enrichmentCache[cacheKey] = enrichment
         enrichment
+    }
+
+    private suspend fun fetchEnglishFallbackNames(
+        numericId: Int,
+        mediaType: String,
+        language: String,
+        details: TmdbDetailsResponse,
+        credits: TmdbCreditsResponse?,
+    ): Map<Int, String> {
+        if (
+            language.startsWith("en") ||
+            language.startsWith("ja") ||
+            language.startsWith("ko") ||
+            language.startsWith("zh")
+        ) {
+            return emptyMap()
+        }
+        val needsFallback = credits?.cast.orEmpty().any { member ->
+            personNameNeedsEnglishFallback(member.name, member.originalName)
+        } || credits?.crew.orEmpty().any { member ->
+            personNameNeedsEnglishFallback(member.name, member.originalName)
+        } || details.createdBy.any { creator ->
+            personNameNeedsEnglishFallback(creator.name, creator.originalName)
+        }
+        if (!needsFallback) return emptyMap()
+
+        return runCatching {
+            val englishCredits = fetch<TmdbCreditsResponse>(
+                endpoint = "$mediaType/$numericId/credits",
+                query = mapOf("language" to "en-US"),
+            )
+            val englishTvDetails = if (mediaType == "tv" && details.createdBy.isNotEmpty()) {
+                fetch<TmdbDetailsResponse>(
+                    endpoint = "tv/$numericId",
+                    query = mapOf("language" to "en-US"),
+                )
+            } else {
+                null
+            }
+            buildMap {
+                englishCredits?.cast.orEmpty().forEach { member ->
+                    val id = member.id
+                    val name = member.name?.trim()?.takeIf { it.isNotBlank() }
+                    if (id != null && name != null) put(id, name)
+                }
+                englishCredits?.crew.orEmpty().forEach { member ->
+                    val id = member.id
+                    val name = member.name?.trim()?.takeIf { it.isNotBlank() }
+                    if (id != null && name != null) put(id, name)
+                }
+                englishTvDetails?.createdBy.orEmpty().forEach { creator ->
+                    val id = creator.id
+                    val name = creator.name?.trim()?.takeIf { it.isNotBlank() }
+                    if (id != null && name != null) put(id, name)
+                }
+            }
+        }.getOrElse { error ->
+            log.w(error) { "Failed to fetch English credits fallback for $numericId" }
+            emptyMap()
+        }
     }
 
     private suspend fun fetchEpisodeEnrichment(
@@ -1235,14 +1344,84 @@ internal fun normalizeTmdbLanguage(language: String?): String {
     }
 }
 
+internal fun containsCjkOrHangul(text: String): Boolean {
+    return text.any { ch ->
+        ch in '\u3040'..'\u30FF' ||  // Hiragana + Katakana
+            ch in '\u4E00'..'\u9FFF' ||  // CJK Unified Ideographs
+            ch in '\u3400'..'\u4DBF' ||  // CJK Extension A
+            ch in '\uAC00'..'\uD7AF' ||  // Hangul Syllables
+            ch in '\u1100'..'\u11FF' ||  // Hangul Jamo
+            ch in '\u3130'..'\u318F'     // Hangul Compatibility Jamo
+    }
+}
+
+internal fun resolvePersonName(
+    localizedName: String?,
+    originalName: String?,
+    fallbackEnglishName: String? = null,
+    preferredLanguage: String,
+): String? {
+    val name = localizedName?.trim()?.takeIf { it.isNotBlank() }
+    val original = originalName?.trim()?.takeIf { it.isNotBlank() }
+    val fallback = fallbackEnglishName?.trim()?.takeIf { it.isNotBlank() }
+
+    if (name == null) return original ?: fallback
+    val lang = preferredLanguage.lowercase()
+
+    if (lang.startsWith("ja") || lang.startsWith("ko") || lang.startsWith("zh")) {
+        return name
+    }
+
+    if (!containsCjkOrHangul(name)) {
+        return name
+    }
+
+    if (original != null && !containsCjkOrHangul(original)) {
+        return original
+    }
+
+    if (fallback != null && !containsCjkOrHangul(fallback)) {
+        return fallback
+    }
+
+    return fallback ?: original ?: name
+}
+
+private fun personNameNeedsEnglishFallback(name: String?, originalName: String?): Boolean {
+    return !name.isNullOrBlank() &&
+        containsCjkOrHangul(name) &&
+        (originalName.isNullOrBlank() || containsCjkOrHangul(originalName))
+}
+
+private fun resolvedPersonDisplayName(
+    localizedName: String?,
+    originalName: String?,
+    personId: Int?,
+    preferredLanguage: String,
+    englishFallbackNames: Map<Int, String>,
+): String? = resolvePersonName(
+    localizedName = localizedName,
+    originalName = originalName,
+    fallbackEnglishName = personId?.let { englishFallbackNames[it] },
+    preferredLanguage = preferredLanguage,
+)?.takeIf { it.isNotBlank() }
+
 private fun buildPeople(
     details: TmdbDetailsResponse,
     credits: TmdbCreditsResponse?,
     mediaType: String,
+    preferredLanguage: String,
+    englishFallbackNames: Map<Int, String>,
 ): List<MetaPerson> {
     val creators = if (mediaType == "tv") {
         details.createdBy.mapNotNull { creator ->
-            val name = creator.name?.trim()?.takeIf(String::isNotBlank) ?: return@mapNotNull null
+            val name = resolvedPersonDisplayName(
+                localizedName = creator.name,
+                originalName = creator.originalName,
+                personId = creator.id,
+                preferredLanguage = preferredLanguage,
+                englishFallbackNames = englishFallbackNames,
+            ) ?: return@mapNotNull null
             MetaPerson(
                 name = name,
                 role = runBlocking { getString(Res.string.person_role_creator) },
@@ -1257,7 +1436,13 @@ private fun buildPeople(
     val directors = credits?.crew.orEmpty()
         .filter { it.job.equals("Director", ignoreCase = true) }
         .mapNotNull { crew ->
-            val name = crew.name?.trim()?.takeIf(String::isNotBlank) ?: return@mapNotNull null
+            val name = resolvedPersonDisplayName(
+                localizedName = crew.name,
+                originalName = crew.originalName,
+                personId = crew.id,
+                preferredLanguage = preferredLanguage,
+                englishFallbackNames = englishFallbackNames,
+            ) ?: return@mapNotNull null
             MetaPerson(
                 name = name,
                 role = runBlocking { getString(Res.string.person_role_director) },
@@ -1272,7 +1457,13 @@ private fun buildPeople(
             job.contains("writer") || job.contains("screenplay")
         }
         .mapNotNull { crew ->
-            val name = crew.name?.trim()?.takeIf(String::isNotBlank) ?: return@mapNotNull null
+            val name = resolvedPersonDisplayName(
+                localizedName = crew.name,
+                originalName = crew.originalName,
+                personId = crew.id,
+                preferredLanguage = preferredLanguage,
+                englishFallbackNames = englishFallbackNames,
+            ) ?: return@mapNotNull null
             MetaPerson(
                 name = name,
                 role = runBlocking { getString(Res.string.person_role_writer) },
@@ -1283,7 +1474,13 @@ private fun buildPeople(
 
     val cast = credits?.cast.orEmpty()
         .mapNotNull { castMember ->
-            val name = castMember.name?.trim()?.takeIf(String::isNotBlank) ?: return@mapNotNull null
+            val name = resolvedPersonDisplayName(
+                localizedName = castMember.name,
+                originalName = castMember.originalName,
+                personId = castMember.id,
+                preferredLanguage = preferredLanguage,
+                englishFallbackNames = englishFallbackNames,
+            ) ?: return@mapNotNull null
             MetaPerson(
                 name = name,
                 role = castMember.character?.trim()?.takeIf(String::isNotBlank),
@@ -1306,16 +1503,34 @@ private fun buildDirectors(
     details: TmdbDetailsResponse,
     credits: TmdbCreditsResponse?,
     mediaType: String,
+    preferredLanguage: String,
+    englishFallbackNames: Map<Int, String>,
 ): List<String> {
     if (mediaType == "tv") {
         return details.createdBy
-            .mapNotNull { it.name?.trim()?.takeIf(String::isNotBlank) }
+            .mapNotNull { creator ->
+                resolvedPersonDisplayName(
+                    localizedName = creator.name,
+                    originalName = creator.originalName,
+                    personId = creator.id,
+                    preferredLanguage = preferredLanguage,
+                    englishFallbackNames = englishFallbackNames,
+                )
+            }
             .distinct()
     }
 
     return credits?.crew.orEmpty()
         .filter { it.job.equals("Director", ignoreCase = true) }
-        .mapNotNull { it.name?.trim()?.takeIf(String::isNotBlank) }
+        .mapNotNull { crew ->
+            resolvedPersonDisplayName(
+                localizedName = crew.name,
+                originalName = crew.originalName,
+                personId = crew.id,
+                preferredLanguage = preferredLanguage,
+                englishFallbackNames = englishFallbackNames,
+            )
+        }
         .distinct()
 }
 
@@ -1323,6 +1538,8 @@ private fun buildWriters(
     credits: TmdbCreditsResponse?,
     mediaType: String,
     hasDirectors: Boolean,
+    preferredLanguage: String,
+    englishFallbackNames: Map<Int, String>,
 ): List<String> {
     if (hasDirectors) {
         return emptyList()
@@ -1333,7 +1550,15 @@ private fun buildWriters(
             val job = crew.job?.lowercase().orEmpty()
             job.contains("writer") || job.contains("screenplay")
         }
-        .mapNotNull { it.name?.trim()?.takeIf(String::isNotBlank) }
+        .mapNotNull { crew ->
+            resolvedPersonDisplayName(
+                localizedName = crew.name,
+                originalName = crew.originalName,
+                personId = crew.id,
+                preferredLanguage = preferredLanguage,
+                englishFallbackNames = englishFallbackNames,
+            )
+        }
         .distinct()
 }
 
@@ -1512,6 +1737,7 @@ private data class TmdbProductionCountry(
 @Serializable
 private data class TmdbCreator(
     val name: String? = null,
+    @SerialName("original_name") val originalName: String? = null,
     val id: Int? = null,
     @SerialName("profile_path") val profilePath: String? = null,
 )
@@ -1526,6 +1752,7 @@ private data class TmdbCreditsResponse(
 private data class TmdbCastMember(
     val id: Int? = null,
     val name: String? = null,
+    @SerialName("original_name") val originalName: String? = null,
     val character: String? = null,
     @SerialName("profile_path") val profilePath: String? = null,
 )
@@ -1534,6 +1761,7 @@ private data class TmdbCastMember(
 private data class TmdbCrewMember(
     val id: Int? = null,
     val name: String? = null,
+    @SerialName("original_name") val originalName: String? = null,
     val job: String? = null,
     @SerialName("profile_path") val profilePath: String? = null,
 )
@@ -1650,6 +1878,7 @@ private data class TmdbEpisodeResponse(
 private data class TmdbPersonResponse(
     val id: Int? = null,
     val name: String? = null,
+    @SerialName("original_name") val originalName: String? = null,
     val biography: String? = null,
     val birthday: String? = null,
     val deathday: String? = null,
@@ -1670,6 +1899,8 @@ private data class TmdbPersonCreditCast(
     @SerialName("media_type") val mediaType: String? = null,
     val title: String? = null,
     val name: String? = null,
+    @SerialName("original_title") val originalTitle: String? = null,
+    @SerialName("original_name") val originalName: String? = null,
     val character: String? = null,
     @SerialName("poster_path") val posterPath: String? = null,
     @SerialName("backdrop_path") val backdropPath: String? = null,
@@ -1686,6 +1917,8 @@ private data class TmdbPersonCreditCrew(
     @SerialName("media_type") val mediaType: String? = null,
     val title: String? = null,
     val name: String? = null,
+    @SerialName("original_title") val originalTitle: String? = null,
+    @SerialName("original_name") val originalName: String? = null,
     val job: String? = null,
     @SerialName("poster_path") val posterPath: String? = null,
     @SerialName("backdrop_path") val backdropPath: String? = null,

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt
@@ -394,4 +394,47 @@ class TmdbMetadataServiceTest {
             ),
         )
     }
+
+    @Test
+    fun `network browse falls back CJK titles to English`() {
+        val localizedResults = listOf(
+            TmdbDiscoverResult(
+                id = 57775,
+                name = "ちびまる子ちゃん",
+                originalName = "ちびまる子ちゃん",
+                posterPath = "/maruko.jpg",
+                firstAirDate = "1990-01-07",
+            ),
+            TmdbDiscoverResult(
+                id = 37854,
+                name = "One Piece",
+                originalName = "ワンピース",
+                posterPath = "/op.jpg",
+                firstAirDate = "1999-10-20",
+            ),
+        )
+        val englishResults = listOf(
+            TmdbDiscoverResult(
+                id = 57775,
+                name = "Chibi Maruko-chan",
+                originalName = "ちびまる子ちゃん",
+                posterPath = "/maruko.jpg",
+            ),
+        )
+
+        assertTrue(discoverResultsContainCjkTitles(localizedResults))
+        val englishTitlesById = englishDiscoverTitlesById(englishResults)
+
+        val titles = localizedResults.associate { result ->
+            result.id to resolvePersonName(
+                localizedName = result.title ?: result.name,
+                originalName = result.originalTitle ?: result.originalName,
+                fallbackEnglishName = englishTitlesById[result.id],
+                preferredLanguage = "tr-TR",
+            )
+        }
+
+        assertEquals("Chibi Maruko-chan", titles[57775])
+        assertEquals("One Piece", titles[37854])
+    }
 }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt
@@ -6,6 +6,9 @@ import com.nuvio.app.features.details.MetaPerson
 import com.nuvio.app.features.details.MetaVideo
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class TmdbMetadataServiceTest {
     @Test
@@ -268,5 +271,97 @@ class TmdbMetadataServiceTest {
         assertEquals(base.director, result.director)
         assertEquals(base.cast, result.cast)
         assertEquals(base.productionCompanies, result.productionCompanies)
+    }
+
+    @Test
+    fun `containsCjkOrHangul detects Japanese Chinese and Korean scripts`() {
+        assertTrue(containsCjkOrHangul("田中敦子"))
+        assertTrue(containsCjkOrHangul("成龙"))
+        assertTrue(containsCjkOrHangul("김수현"))
+        assertFalse(containsCjkOrHangul("Atsuko Tanaka"))
+        assertFalse(containsCjkOrHangul("Scarlett Johansson"))
+    }
+
+    @Test
+    fun `resolvePersonName falls back Japanese names to Romaji for non-Japanese locales`() {
+        assertEquals(
+            "Atsuko Tanaka",
+            resolvePersonName("田中敦子", "Atsuko Tanaka", null, "tr-TR"),
+        )
+        assertEquals(
+            "Atsuko Tanaka",
+            resolvePersonName("田中敦子", "田中敦子", "Atsuko Tanaka", "de-DE"),
+        )
+    }
+
+    @Test
+    fun `resolvePersonName keeps Japanese names when user language is Japanese`() {
+        assertEquals(
+            "田中敦子",
+            resolvePersonName("田中敦子", "Atsuko Tanaka", "Atsuko Tanaka", "ja-JP"),
+        )
+    }
+
+    @Test
+    fun `resolvePersonName falls back Hangul names to Latin for non-Korean locales`() {
+        assertEquals(
+            "Kim Soo-hyun",
+            resolvePersonName("김수현", "Kim Soo-hyun", null, "de-DE"),
+        )
+        assertEquals(
+            "Kim Soo-hyun",
+            resolvePersonName("김수현", "김수현", "Kim Soo-hyun", "fr-FR"),
+        )
+    }
+
+    @Test
+    fun `resolvePersonName keeps Hangul when user language is Korean`() {
+        assertEquals(
+            "김수현",
+            resolvePersonName("김수현", "Kim Soo-hyun", "Kim Soo-hyun", "ko-KR"),
+        )
+    }
+
+    @Test
+    fun `resolvePersonName falls back Chinese hanzi to stage name for non-Chinese locales`() {
+        assertEquals(
+            "Jackie Chan",
+            resolvePersonName("成龙", "Jackie Chan", null, "es-ES"),
+        )
+        assertEquals(
+            "Jackie Chan",
+            resolvePersonName("成龙", "成龙", "Jackie Chan", "en-US"),
+        )
+    }
+
+    @Test
+    fun `resolvePersonName keeps hanzi when user language is Chinese`() {
+        assertEquals(
+            "成龙",
+            resolvePersonName("成龙", "Jackie Chan", "Jackie Chan", "zh-CN"),
+        )
+    }
+
+    @Test
+    fun `resolvePersonName leaves already-Latin names unchanged`() {
+        assertEquals(
+            "Scarlett Johansson",
+            resolvePersonName("Scarlett Johansson", "Scarlett Johansson", null, "tr-TR"),
+        )
+        assertEquals(
+            "Tom Hanks",
+            resolvePersonName("Tom Hanks", "Tom Hanks", null, "ja-JP"),
+        )
+    }
+
+    @Test
+    fun `resolvePersonName handles null and blank inputs`() {
+        assertEquals("Takuya Kimura", resolvePersonName(null, "Takuya Kimura", null, "tr-TR"))
+        assertEquals("Scarlett Johansson", resolvePersonName("Scarlett Johansson", null, null, "tr-TR"))
+        assertNull(resolvePersonName(null, null, null, "tr-TR"))
+        assertEquals(
+            "Takuya Kimura",
+            resolvePersonName("  木村拓哉  ", "Takuya Kimura", null, "fr-FR"),
+        )
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataServiceTest.kt
@@ -364,4 +364,34 @@ class TmdbMetadataServiceTest {
             resolvePersonName("  木村拓哉  ", "Takuya Kimura", null, "fr-FR"),
         )
     }
+
+    @Test
+    fun `resolvePersonName falls back CJK filmography titles to English`() {
+        assertEquals(
+            "Ghost in the Shell: Stand Alone Complex",
+            resolvePersonName(
+                "攻殻機動隊 STAND ALONE COMPLEX",
+                "攻殻機動隊 STAND ALONE COMPLEX",
+                "Ghost in the Shell: Stand Alone Complex",
+                "pl-PL",
+            ),
+        )
+        assertEquals(
+            "Make My Day",
+            resolvePersonName("Make My Day", "Make My Day", null, "pl-PL"),
+        )
+    }
+
+    @Test
+    fun `resolvePersonName keeps CJK filmography titles for Japanese locale`() {
+        assertEquals(
+            "攻殻機動隊 STAND ALONE COMPLEX",
+            resolvePersonName(
+                "攻殻機動隊 STAND ALONE COMPLEX",
+                "攻殻機動隊 STAND ALONE COMPLEX",
+                "Ghost in the Shell: Stand Alone Complex",
+                "ja-JP",
+            ),
+        )
+    }
 }


### PR DESCRIPTION
## Summary

Ports the NuvioTV TMDB CJK display-name fallback to mobile.

When TMDB returns cast, crew, creators, person names, or person-page filmography titles in native Japanese/Korean/Chinese script for a non-CJK metadata language, the app now prefers Latin `original_name` / Romaji, then English TMDB names and titles. `ja` / `ko` / `zh` locales keep native script. Latin titles such as `Make My Day` stay unchanged.

This matches NuvioTV https://github.com/NuvioMedia/NuvioTV/pull/3178 (cast, crew, creators, person names) and https://github.com/NuvioMedia/NuvioTV/pull/3192 (filmography poster labels).

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [x] Translation/localization only
- [ ] Approved larger or directional change

## Why

TMDB often returns Kanji, Hangul, or Hanzi for people and titles when the selected metadata language has no translation. Non-CJK users then see unreadable cast names on details and CJK labels under filmography posters. NuvioTV already fixed this in PRs 3178 and 3192; mobile still showed the original-script strings.

## Issue or approval

No NuvioMobile issue. Localization-only port of already merged NuvioTV PRs https://github.com/NuvioMedia/NuvioTV/pull/3178 and https://github.com/NuvioMedia/NuvioTV/pull/3192.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Limited to TMDB person-name and filmography-title resolution in `TmdbMetadataService` plus unit tests. Does not change collection-editor TMDB rows, addon titles, strings, or player logic.

## Testing

- `./gradlew :composeApp:testAndroidHostTest --tests com.nuvio.app.features.tmdb.TmdbMetadataServiceTest` passed, including CJK detection, `resolvePersonName` locale cases, and filmography title fallback.
- Manual on phone `24129PN74G` (debug `com.nuviodebug.com`): TMDB language set to a non-CJK locale, opened a Japanese person page (Atsuko Tanaka). Cast/person names use English/Romaji; filmography poster labels use English TMDB titles instead of CJK. Latin titles stay unchanged.

## Screenshots / Video

| Before | After |
|:------:|:-----:|
| <img width="1151" height="2560" alt="102590ab-4c81-42e8-914b-4bf494b43a7d" src="https://github.com/user-attachments/assets/67c526c3-ddda-4510-ad85-499d69a149d8" />| <img width="1151" height="2560" alt="0ff4fc1c-b615-4c31-9192-2273b135a4ed" src="https://github.com/user-attachments/assets/1213ac87-e80c-4e67-8e74-fb9113155499" />|

| Before | After |
|:------:|:-----:|
| <img width="1151" height="2560" alt="742bd2c3-7bdf-4b56-a342-beb72f5b9ad6" src="https://github.com/user-attachments/assets/60546a65-d603-49d7-855e-b16f002c83ba" />| <img width="1151" height="2560" alt="17dd203c-2b74-4151-b97d-eb3983d6d8e6" src="https://github.com/user-attachments/assets/a9583e89-7a60-41d1-bd3b-c36f47e45110" /> |


## Breaking changes

None.

## Linked issues

https://github.com/NuvioMedia/NuvioTV/pull/3178
https://github.com/NuvioMedia/NuvioTV/pull/3192