### PR TITLE
fix: Simkl anime type classification and landscape poster aspect ratio

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/catalog/CatalogScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/catalog/CatalogScreen.kt
@@ -415,7 +415,7 @@ private fun PosterShape.catalogAspectRatio(): Float =
     when (this) {
         PosterShape.Poster -> 0.68f
         PosterShape.Square -> 1f
-        PosterShape.Landscape -> 1.2f
+        PosterShape.Landscape -> 1.78f
     }
 
 private fun catalogGridColumnsForWidth(screenWidth: Dp): Int =

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/PosterGrid.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/components/PosterGrid.kt
@@ -174,5 +174,5 @@ private fun PosterShape.posterGridAspectRatio(): Float =
     when (this) {
         PosterShape.Poster -> 0.68f
         PosterShape.Square -> 1f
-        PosterShape.Landscape -> 1.2f
+        PosterShape.Landscape -> 1.78f
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklMutationReceipt.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklMutationReceipt.kt
@@ -37,6 +37,8 @@ internal data class SimklResolvedListMutation(
     val request: TrackingMediaReference,
     val status: SimklListStatus,
     val responseMedia: SimklMedia,
+    val resolvedMediaType: SimklMediaType? = null,
+    val animeType: String? = null,
 )
 
 internal data class SimklResolvedHistoryMutation(
@@ -68,6 +70,12 @@ internal fun SimklApiResponse.toListMutationReceipt(
                 val status = response.stringValue("to")?.toSimklListStatus()
                     ?: return@forEach
                 val responseMedia = response.toResponseMedia()
+                val animeType = response.stringValue("anime_type")
+                val resolvedMediaType = if (animeType != null) {
+                    SimklMediaType.ANIME
+                } else {
+                    response.stringValue("type")?.toSimklMediaType()
+                }
                 val index = unmatched.indexOfFirst { candidate ->
                     (candidate.kind == TrackingMediaKind.MOVIE) == expectedMovie &&
                         responseMedia.matchesTarget(candidate.toSimklMedia())
@@ -78,6 +86,8 @@ internal fun SimklApiResponse.toListMutationReceipt(
                             request = unmatched.removeAt(index),
                             status = status,
                             responseMedia = responseMedia,
+                            resolvedMediaType = resolvedMediaType,
+                            animeType = animeType,
                         ),
                     )
                 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklMutationReconciliation.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklMutationReconciliation.kt
@@ -29,10 +29,13 @@ private fun SimklSyncSnapshot.withListMutations(
         val media = mutation.responseMedia.mergeMissing(requestMedia)
         val index = updated.indexOfMatchingMedia(media)
         val existing = updated.getOrNull(index)
-        val mediaType = existing?.mediaType ?: mutation.request.kind.toSimklMediaType()
+        val mediaType = existing?.mediaType
+            ?: mutation.resolvedMediaType
+            ?: mutation.request.kind.toSimklMediaType()
         val mergedMedia = media.mergeMissing(existing?.media)
         val entry = (existing ?: SimklLibraryEntry()).copy(
             mediaType = mediaType,
+            animeType = mutation.animeType ?: existing?.animeType,
             localPosterUrl = existing?.localPosterUrl
                 ?: mutation.request.posterUrl?.trim()?.takeIf(String::isNotBlank),
             addedToWatchlistAt = existing?.addedToWatchlistAt ?: committedAt,


### PR DESCRIPTION
## Summary

Two fixes:

1. Simkl library: anime titles added from detail view are now correctly stored as anime (not series) by parsing the new `anime_type` field from Simkl API response.

2. Poster shape: landscape posters (posterShape: "landscape") in catalog and discover/search grids now render with correct 16:9 aspect ratio instead of the previous near-square 1.2:1.

## PR type

- [x] Critical bug fix

## Why

1. Simkl users adding anime to their library from the app saw it classified as "series" instead of "anime" - breaking their library organization.

2. Addons declaring posterShape "landscape" had their posters displayed with wrong proportions (almost square) in catalog and discover screens, making them look broken compared to other Stremio clients.

## Issue or approval

- Simkl anime classification broken when adding from detail view
- Landscape posterShape aspect ratio incorrect in catalog/discover grids

## Reproduction steps

**Simkl anime bug:**
1. Connect Simkl account
2. Open an anime title (e.g. from anime addon)
3. Add to Simkl library (Plan to Watch)
4. Check library -> item shows under "Series" instead of "Anime"

**Landscape posterShape bug:**
1. Install an addon that returns posterShape: "landscape" (e.g. a a TV addon)
2. Open catalog or discover/search
3. Posters appear almost square instead of 16:9 widescreen

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- Only landscape aspect ratio fixed (1.2 -> 1.78); poster and square ratios unchanged
- Simkl fix only affects local snapshot classification after add-to-list; no changes to sync or history endpoints
- Does not affect NuvioTV (separate PR)

## Testing

- Added anime to Simkl library from detail view -> verified local snapshot stores mediaType=ANIME
- Opened catalog with landscape posterShape addon -> cards now render 16:9
- Opened discover/search with same addon -> grid tiles render 16:9
- Verified poster (0.68) and square (1.0) aspect ratios unchanged
- Built and installed full debug APK on physical device

## Screenshots / Video

Be
<img width="300" alt="Screenshot_2026-08-25-22-15-33-593_com nuvio app" src="https://github.com/user-attachments/assets/23d705c6-0c93-4eac-9c06-ad9755d7dd95" />
fore:

After: 
<img width="300" alt="Screenshot_2026-08-25-22-15-24-652_com nuviodebug com" src="https://github.com/user-attachments/assets/96b953a4-07ae-484c-abd7-90c14cef149d" />

## Breaking changes

None.

## Linked issues

- Simkl anime type not respected when adding to library from detail view
- Landscape posterShape aspect ratio incorrect in catalog/discover grids
