### PR TITLE
Port NuvioTV fixes: YouTube extractor, trailer language, scrobble guard, aggregate credits

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
@@ -149,6 +149,7 @@ import com.nuvio.app.features.updater.rememberAppUpdaterController
 import com.nuvio.app.features.watched.WatchedRepository
 import com.nuvio.app.features.watching.application.WatchingActions
 import com.nuvio.app.features.watching.application.WatchingState
+import com.nuvio.app.features.watching.domain.isShortPlaceholderDuration
 import com.nuvio.app.features.watchprogress.ContinueWatchingItem
 import com.nuvio.app.features.watchprogress.ContinueWatchingPreferencesRepository
 import com.nuvio.app.features.watchprogress.ResumePromptRepository
@@ -610,6 +611,9 @@ internal fun MainAppContent(
         if (result != null && result.positionMs > 0L) {
             coroutineScope.launch {
                 val durationMs = result.durationMs
+                // Guard: debrid cache-sync placeholders and error clips report a short
+                // duration reaching completion. Skip scrobble + progress for those.
+                if (durationMs != null && isShortPlaceholderDuration(durationMs)) return@launch
                 val progressPercent = if (durationMs != null && durationMs > 0L) {
                     (result.positionMs.toFloat() / durationMs.toFloat() * 100f).coerceIn(0f, 100f)
                 } else {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/HeroTrailerSelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/HeroTrailerSelector.kt
@@ -4,6 +4,7 @@ internal fun selectHeroTrailer(trailers: List<MetaTrailer>): MetaTrailer? =
     trailers
         .asSequence()
         .filter { it.isPlayableYouTubeTrailerCandidate() }
+        .distinctBy { it.key }
         .maxWithOrNull(
             compareBy<MetaTrailer>(
                 { it.heroTrailerPriority() },

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsModels.kt
@@ -61,6 +61,7 @@ data class MetaTrailer(
     val publishedAt: String? = null,
     val seasonNumber: Int? = null,
     val displayName: String? = null,
+    val iso6391: String? = null,
 )
 
 data class MetaPerson(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklMutationReceipt.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/simkl/SimklMutationReceipt.kt
@@ -263,8 +263,10 @@ private fun JsonObject.objectValue(key: String): JsonObject? =
     runCatching { get(key)?.jsonObject }.getOrNull()
 
 private fun JsonObject.stringValue(key: String): String? =
-    runCatching { get(key)?.jsonPrimitive?.content }
+    runCatching { get(key)?.jsonPrimitive }
         .getOrNull()
+        ?.takeIf { primitive -> primitive !is kotlinx.serialization.json.JsonNull }
+        ?.content
         ?.trim()
         ?.takeIf(String::isNotEmpty)
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -1089,12 +1089,15 @@ object TmdbMetadataService {
             }
         }
 
+        val preferredLang = language.substringBefore('-').lowercase()
+
         val byCategory = linkedMapOf<String, MutableList<MetaTrailer>>()
         allVideos
             .asSequence()
             .filter { trailer ->
                 trailer.site.equals("YouTube", ignoreCase = true) && trailer.key.isNotBlank()
             }
+            .distinctBy { it.key }
             .forEach { trailer ->
                 byCategory.getOrPut(
                     trailer.type.ifBlank { runBlocking { getString(Res.string.generic_trailer) } },
@@ -1111,6 +1114,14 @@ object TmdbMetadataService {
                     }
                 }
                     .thenByDescending { it.seasonNumber ?: Int.MIN_VALUE }
+                    .thenBy {
+                        val lang = it.iso6391?.trim()?.lowercase()
+                        when {
+                            lang == preferredLang -> 0
+                            lang == "en" -> 1
+                            else -> 2
+                        }
+                    }
                     .thenByDescending { it.official }
                     .thenByDescending { it.publishedAt.orEmpty() }
             )
@@ -1476,6 +1487,7 @@ private data class TmdbVideoResult(
     val type: String? = null,
     val official: Boolean? = null,
     @SerialName("published_at") val publishedAt: String? = null,
+    @SerialName("iso_639_1") val iso6391: String? = null,
 )
 
 private fun TmdbVideoResult.toMetaTrailer(
@@ -1496,6 +1508,7 @@ private fun TmdbVideoResult.toMetaTrailer(
         publishedAt = publishedAt,
         seasonNumber = seasonNumber,
         displayName = displayName,
+        iso6391 = iso6391?.trim()?.takeIf { it.isNotBlank() },
     )
 }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/tmdb/TmdbMetadataService.kt
@@ -782,10 +782,17 @@ object TmdbMetadataService {
                 )
             }
             val credits = async {
-                fetch<TmdbCreditsResponse>(
-                    endpoint = "$mediaType/$numericId/credits",
-                    query = mapOf("language" to normalizedLanguage),
-                )
+                if (mediaType == "tv") {
+                    fetch<TmdbAggregateCreditsResponse>(
+                        endpoint = "tv/$numericId/aggregate_credits",
+                        query = mapOf("language" to normalizedLanguage),
+                    )?.toStandard()
+                } else {
+                    fetch<TmdbCreditsResponse>(
+                        endpoint = "movie/$numericId/credits",
+                        query = mapOf("language" to normalizedLanguage),
+                    )
+                }
             }
             val images = async {
                 fetch<TmdbImagesResponse>(
@@ -1533,6 +1540,62 @@ private data class TmdbCreator(
 private data class TmdbCreditsResponse(
     val cast: List<TmdbCastMember> = emptyList(),
     val crew: List<TmdbCrewMember> = emptyList(),
+)
+
+@Serializable
+private data class TmdbAggregateCreditsResponse(
+    val cast: List<TmdbAggregateCastMember> = emptyList(),
+    val crew: List<TmdbAggregateCrewMember> = emptyList(),
+) {
+    fun toStandard(): TmdbCreditsResponse = TmdbCreditsResponse(
+        cast = cast.map { member ->
+            TmdbCastMember(
+                id = member.id,
+                name = member.name,
+                character = member.roles.firstOrNull()?.character,
+                profilePath = member.profilePath,
+            )
+        },
+        crew = crew.flatMap { member ->
+            member.jobs.map { job ->
+                TmdbCrewMember(
+                    id = member.id,
+                    name = member.name,
+                    job = job.job,
+                    profilePath = member.profilePath,
+                )
+            }
+        },
+    )
+}
+
+@Serializable
+private data class TmdbAggregateCastMember(
+    val id: Int? = null,
+    val name: String? = null,
+    val roles: List<TmdbAggregateRole> = emptyList(),
+    @SerialName("profile_path") val profilePath: String? = null,
+)
+
+@Serializable
+private data class TmdbAggregateRole(
+    val character: String? = null,
+    @SerialName("episode_count") val episodeCount: Int? = null,
+)
+
+@Serializable
+private data class TmdbAggregateCrewMember(
+    val id: Int? = null,
+    val name: String? = null,
+    val department: String? = null,
+    val jobs: List<TmdbAggregateJob> = emptyList(),
+    @SerialName("profile_path") val profilePath: String? = null,
+)
+
+@Serializable
+private data class TmdbAggregateJob(
+    val job: String? = null,
+    @SerialName("episode_count") val episodeCount: Int? = null,
 )
 
 @Serializable

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watching/domain/WatchingPolicies.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/watching/domain/WatchingPolicies.kt
@@ -10,6 +10,13 @@ private const val CompletionThresholdFraction = 0.90
 private const val ProgressStoreThresholdMs = 1_000L
 private const val UpcomingNextSeasonWindowDays = 7
 
+/**
+ * Streams shorter than this are treated as error/placeholder clips (e.g. debrid
+ * cache-sync placeholders, "service unavailable" error videos, RAR-only torrents),
+ * not real episodes. Mirrors the internal-player guard in NuvioTV.
+ */
+private const val MinRealContentDurationMs = 121_000L
+
 fun watchedKey(
     content: WatchingContentRef,
     seasonNumber: Int? = null,
@@ -26,12 +33,21 @@ fun isProgressComplete(
     durationMs: Long,
     isEnded: Boolean,
 ): Boolean {
+    if (isEnded && isShortPlaceholderDuration(durationMs)) return false
     if (isEnded) return true
     if (durationMs <= 0L) return false
 
     val watchedFraction = positionMs.toDouble() / durationMs.toDouble()
     return watchedFraction >= CompletionThresholdFraction
 }
+
+/**
+ * Returns `true` when the duration looks like an error clip or debrid cache-sync
+ * placeholder rather than real content. A zero/negative duration is left to the
+ * normal path so that players which only report "ended" still work.
+ */
+fun isShortPlaceholderDuration(durationMs: Long): Boolean =
+    durationMs in 1 until MinRealContentDurationMs
 
 fun isReleasedBy(
     todayIsoDate: String,

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/trailer/InAppYouTubeExtractor.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/trailer/InAppYouTubeExtractor.kt
@@ -14,7 +14,7 @@ internal const val TRAILER_EXTRACTOR_TAG = "InAppYouTubeExtractor"
 internal const val TRAILER_REQUEST_TIMEOUT_MS = 20_000L
 
 private const val EXTRACTOR_TIMEOUT_MS = 30_000L
-private const val PREFERRED_SEPARATE_CLIENT = "android_vr"
+private const val PREFERRED_SEPARATE_CLIENT = "visionos"
 
 private val VIDEO_ID_REGEX = Regex("^[a-zA-Z0-9_-]{11}$")
 private val API_KEY_REGEX = Regex("\"INNERTUBE_API_KEY\":\"([^\"]+)\"")
@@ -44,6 +44,10 @@ internal data class StreamCandidate(
     val height: Int,
     val fps: Int,
     val ext: String,
+    // Only meaningful for audio candidates: false means this format is an
+    // alternate-language dub track, not the video's original/default audio.
+    // Always true for video/progressive candidates, so it never affects them.
+    val isDefaultAudioTrack: Boolean = true,
 )
 
 private data class ManifestBestVariant(
@@ -74,20 +78,18 @@ private val JSON = Json { ignoreUnknownKeys = true }
 
 private val CLIENTS = listOf(
     YouTubeClient(
-        key = "android_vr",
-        id = "28",
-        version = "1.56.21",
-        userAgent = "com.google.android.apps.youtube.vr.oculus/1.56.21 " +
-            "(Linux; U; Android 12; en_US; Quest 3; Build/SQ3A.220605.009.A1) gzip",
+        key = "visionos",
+        id = "101",
+        version = "1.02",
+        userAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_3) AppleWebKit/605.1.15 " +
+            "(KHTML, like Gecko) Version/26.0 Safari/605.1.15",
         context = jsonObjectOf(
-            "clientName" to "ANDROID_VR",
-            "clientVersion" to "1.56.21",
-            "deviceMake" to "Oculus",
-            "deviceModel" to "Quest 3",
-            "osName" to "Android",
-            "osVersion" to "12",
-            "platform" to "MOBILE",
-            "androidSdkVersion" to 32,
+            "clientName" to "VISIONOS",
+            "clientVersion" to "1.02",
+            "deviceMake" to "Apple",
+            "deviceModel" to "RealityDevice17,1",
+            "osName" to "visionOS",
+            "osVersion" to "26.5.23O471",
             "hl" to "en",
             "gl" to "US",
         ),
@@ -242,6 +244,12 @@ class InAppYouTubeExtractor {
                             ?: format.numberValue("averageBitrate")
                             ?: 0.0
                         val audioSampleRate = format.numberValue("audioSampleRate") ?: 0.0
+                        // Multi-language uploads (common for major-studio trailers)
+                        // expose each dub as a separate adaptiveFormats entry with an
+                        // audioTrack.audioIsDefault flag. Formats with no audioTrack
+                        // are the only audio for that video, so treat them as default.
+                        val isDefaultAudioTrack = format.objectValue("audioTrack")
+                            ?.booleanValue("audioIsDefault") ?: true
 
                         adaptiveAudio += StreamCandidate(
                             client = client.key,
@@ -252,6 +260,7 @@ class InAppYouTubeExtractor {
                             height = 0,
                             fps = 0,
                             ext = if (mimeType.contains("webm")) "webm" else "m4a",
+                            isDefaultAudioTrack = isDefaultAudioTrack,
                         )
                     }
                 }
@@ -504,9 +513,10 @@ class InAppYouTubeExtractor {
         return bitrate * 1_000_000.0 + audioSampleRate
     }
 
-    private fun sortCandidates(items: List<StreamCandidate>): List<StreamCandidate> {
+    internal fun sortCandidates(items: List<StreamCandidate>): List<StreamCandidate> {
         return items.sortedWith(
-            compareByDescending<StreamCandidate> { it.score }
+            compareBy<StreamCandidate> { if (it.isDefaultAudioTrack) 0 else 1 }
+                .thenByDescending { it.score }
                 .thenBy { if (it.hasN) 1 else 0 }
                 .thenBy { containerPreference(it.ext) }
                 .thenBy { it.priority },
@@ -615,6 +625,11 @@ private fun JsonObject.stringValue(key: String): String? {
 private fun JsonObject.numberValue(key: String): Double? {
     val primitive = this[key] as? JsonPrimitive ?: return null
     return primitive.toString().trim('"').toDoubleOrNull()
+}
+
+private fun JsonObject.booleanValue(key: String): Boolean? {
+    val primitive = this[key] as? JsonPrimitive ?: return null
+    return primitive.content.toBooleanStrictOrNull()
 }
 
 private fun jsonObjectOf(vararg pairs: Pair<String, Any?>): JsonObject {


### PR DESCRIPTION
## Summary

Port several NuvioTV fixes and improvements to NuvioMobile:

1. Switch YouTube extractor default client from `android_vr` to `visionos` (ported from https://github.com/NuvioMedia/NuvioTV/pull/3080)
2. Add `isDefaultAudioTrack` to stream candidate sorting so multi-language trailers play original audio instead of a random dub (ported from https://github.com/NuvioMedia/NuvioTV/pull/3132)
3. Add language-aware TMDB trailer ranking so hero trailer auto-play prefers the user's configured TMDB language (ported from https://github.com/NuvioMedia/NuvioTV/pull/3132)
4. Add short content scrobble protection -> error clips and debrid cache-sync placeholders (< ~2 min) are no longer marked as watched)
5. Use TMDB aggregate credits (`/aggregate_credits`) for TV shows instead of `/credits` -> shows cast from all seasons, not just season 1

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

These fixes already exist in NuvioTV and address real user-reported issues:

- The `android_vr` YouTube client was deprecated in favor of `visionos` for better extraction reliability
- Multi-language trailers (common for major-studio content) could play a random dub instead of the original audio track
- Hero trailer auto-play ignored the user's TMDB language preference, playing e.g. English trailers for users who set Hindi
- A user reported that a short error video was counted as a watched episode, cascading auto-next through the season
- TV show cast only showed actors from season 1, missing actors who joined in later seasons

## Issue or approval

No linked issue - porting existing NuvioTV fixes:
- YouTube client: https://github.com/NuvioMedia/NuvioTV/pull/3080
- Audio track + language ranking: https://github.com/NuvioMedia/NuvioTV/pull/3132
- Short content guard: parity fix, no separate PR
- Aggregate credits: parity fix, no separate PR

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Only ported fixes that already exist in NuvioTV. No new features.
- `selectHeroTrailer` signature unchanged - language ranking applied at the data layer in `fetchTrailers()`.
- Short content threshold matches NuvioTV (< ~2:01). Zero/negative durations pass through normally so players that only report "ended" still work.
- Aggregate credits mapping takes first role per actor, consistent with NuvioTV behavior.

## Testing

- Built APK successfully on Linux (assembleFullDebug)
- Tested on physical Android device
- YouTube extractor: verified trailer playback resolves with visionos client
- Audio track: multi-language trailers play original audio
- Language ranking: hero auto-play trailer respects TMDB language setting
- Short content guard: verified short error videos are not marked as watched and do not trigger auto-next
- Aggregate credits: TV show detail screens now show cast from all seasons

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

- YouTube client: https://github.com/NuvioMedia/NuvioTV/pull/3080
- Audio track + language ranking: https://github.com/NuvioMedia/NuvioTV/pull/3132

