### PR TITLE
fix(details): retain collapsed sticky header after scroll restoration

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -52,6 +52,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.blur
@@ -873,7 +874,7 @@ fun MetaDetailsScreen(
                         .calculateTopPadding()
                         .toPx()
                 }
-                val heroHeightPx = remember(meta.id) { mutableIntStateOf(0) }
+                val heroHeightPx = rememberSaveable(meta.id) { mutableIntStateOf(0) }
                 // Keep pixel-by-pixel list state reads out of this composition. Reading the
                 // offset here would recompose every metadata section on every scroll frame.
                 val detailScrollOffsetPx = remember(listState, heroHeightPx) {
@@ -890,10 +891,13 @@ fun MetaDetailsScreen(
                 }
                 val isHeroCollapsed = remember(listState, heroHeightPx, safeAreaTopPx) {
                     derivedStateOf {
-                        val measuredHeroHeightPx = heroHeightPx.intValue
-                        val thresholdPx = (measuredHeroHeightPx - safeAreaTopPx).coerceAtLeast(0f)
-                        measuredHeroHeightPx > 0 &&
-                            (listState.firstVisibleItemIndex > 0 || detailScrollOffsetPx() > thresholdPx)
+                        if (listState.firstVisibleItemIndex > 0) {
+                            true
+                        } else {
+                            val measuredHeroHeightPx = heroHeightPx.intValue
+                            val thresholdPx = (measuredHeroHeightPx - safeAreaTopPx).coerceAtLeast(0f)
+                            measuredHeroHeightPx > 0 && detailScrollOffsetPx() > thresholdPx
+                        }
                     }
                 }
                 val heroTrailerSourceUrl = heroTrailerPlaybackSource


### PR DESCRIPTION
## Summary

Preserve the collapsed sticky-header state when a details screen restores a scroll position beyond the hero section.

The measured hero height is now saved across state restoration, and `firstVisibleItemIndex > 0` independently establishes the collapsed state when the hero item is no longer composed.

This is the focused Mobile equivalent of the fix merged in NuvioDesktop PR #468:
https://github.com/NuvioMedia/NuvioDesktop/pull/468

Note: Sticky header on scroll was fully removed from the desktop dev branch. I'm not sure if the same will happen on mobile, so I'll keep this PR open for now.

Desktop removal PR:
https://github.com/NuvioMedia/NuvioDesktop/pull/544

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

When a previously scrolled details screen was restored, its list position could resume beyond the hero item while the sticky header incorrectly lost its collapsed state.

Because the hero item was no longer composed, its measured height was unavailable to the previous collapse calculation.

The new behavior keeps the sticky header collapsed whenever the restored list position is beyond the hero item.

## Issue or approval

Fixes #1796

Desktop reference:
https://github.com/NuvioMedia/NuvioDesktop/pull/468

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the sticky-header collapse calculation and preservation of the measured hero height were changed.

No styling, navigation, dependencies, architecture, or unrelated details-screen behavior was changed.

## Testing

- Ran `.\gradlew.bat :composeApp:compileAndroidMain`
- Built and installed the full debug Android app from Android Studio
- Tested on a Pixel 7 emulator running Android 16 / API 36
- Reproduced the incorrect restored header state on `cmp-rewrite`
- Repeated the same flow on this branch and confirmed the sticky header remained correctly collapsed

## Screenshots / Video

| Before — `cmp-rewrite` | After — fixed branch |
| --- | --- |
| <img width="318" height="712" alt="Sticky header before fix" src="https://github.com/user-attachments/assets/881b02f1-763b-49c3-873c-11be5fbcc47e" /> | <img width="287" height="647" alt="Sticky header after fix" src="https://github.com/user-attachments/assets/de869fde-f011-4973-9079-0ec525c52f22" /> |

## Breaking changes

None.

## Linked issues

Fixes #1796