### PR TITLE
fix(player): keep subtitle picker stable for duplicate tracks

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ClickableIncludingFlingStop.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ClickableIncludingFlingStop.kt
@@ -1,0 +1,58 @@
+package com.nuvio.app.features.player
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.PointerEventPass
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
+
+/**
+ * Like [Modifier.clickable], but still delivers [onClick] when LazyColumn consumed the
+ * down event to cancel an in-progress fling or overscroll settle.
+ */
+@Composable
+internal fun Modifier.clickableIncludingFlingStop(onClick: () -> Unit): Modifier {
+    val latestOnClick by rememberUpdatedState(onClick)
+    return clickable(onClick = latestOnClick)
+        .pointerInput(Unit) {
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                if (!down.isConsumed) return@awaitEachGesture
+
+                val slop = viewConfiguration.touchSlop
+                val origin = down.position
+                val pointerId = down.id
+                while (true) {
+                    val event = awaitPointerEvent(PointerEventPass.Main)
+                    val change = event.changes.firstOrNull { it.id == pointerId }
+                        ?: return@awaitEachGesture
+                    val movement = (change.position - origin).getDistance()
+                    if (change.changedToUpIgnoreConsumed()) {
+                        if (shouldDeliverFlingStopClick(
+                                downConsumed = true,
+                                movement = movement,
+                                touchSlop = slop,
+                                pointerUp = true,
+                            )
+                        ) {
+                            latestOnClick()
+                        }
+                        return@awaitEachGesture
+                    }
+                    if (movement > slop) return@awaitEachGesture
+                }
+            }
+        }
+}
+
+internal fun shouldDeliverFlingStopClick(
+    downConsumed: Boolean,
+    movement: Float,
+    touchSlop: Float,
+    pointerUp: Boolean,
+): Boolean = downConsumed && pointerUp && movement <= touchSlop

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeTrackActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeTrackActions.kt
@@ -20,19 +20,16 @@ internal val PlayerScreenRuntime.visibleAddonSubtitles: List<AddonSubtitle>
             settings = playerSettingsUiState,
         )
         val selectedId = selectedAddonSubtitleId ?: return filtered
-        val selectedSub = addonSubtitles.firstOrNull { it.id == selectedId || it.url == selectedId } ?: return filtered
-        return if (filtered.any { it.id == selectedSub.id || it.url == selectedSub.url }) {
-            filtered
-        } else {
-            listOf(selectedSub) + filtered
-        }
+        if (filtered.any { it.matchesSelection(selectedId) }) return filtered
+        val selectedSub = addonSubtitles.findSelectedAddon(selectedId) ?: return filtered
+        return listOf(selectedSub) + filtered
     }
 
 internal val PlayerScreenRuntime.selectedAddonSubtitle: AddonSubtitle?
     get() {
         val selectedId = selectedAddonSubtitleId ?: return null
-        return addonSubtitles.firstOrNull { it.id == selectedId || it.url == selectedId }
-            ?: visibleAddonSubtitles.firstOrNull { it.id == selectedId || it.url == selectedId }
+        return addonSubtitles.findSelectedAddon(selectedId)
+            ?: visibleAddonSubtitles.findSelectedAddon(selectedId)
     }
 
 internal fun PlayerScreenRuntime.updateTrackPreference(
@@ -136,7 +133,7 @@ internal fun PlayerScreenRuntime.restorePersistedTrackPreferenceIfNeeded() {
         PersistedSubtitleSelectionType.ADDON -> {
             val url = preference.addonSubtitleUrl?.takeIf { it.isNotBlank() }
             if (url != null) {
-                selectedAddonSubtitleId = preference.addonSubtitleId ?: url
+                selectedAddonSubtitleId = url ?: preference.addonSubtitleId
                 selectedSubtitleIndex = -1
                 useCustomSubtitles = true
                 playerController?.setSubtitleUri(url)
@@ -272,7 +269,7 @@ private fun PlayerScreenRuntime.tryAutoSelectPreferredSubtitleFromAvailableTrack
             }
             if (primaryAddonMatch != null) {
                 preferredSubtitleSelectionApplied = true
-                selectedAddonSubtitleId = primaryAddonMatch.id
+                selectedAddonSubtitleId = primaryAddonMatch.selectionKey
                 selectedSubtitleIndex = -1
                 useCustomSubtitles = true
                 playerController?.setSubtitleUri(primaryAddonMatch.url)
@@ -314,7 +311,7 @@ private fun PlayerScreenRuntime.tryAutoSelectPreferredSubtitleFromAvailableTrack
         }
         preferredSubtitleSelectionApplied = true
         if (forcedAddonMatch != null) {
-            selectedAddonSubtitleId = forcedAddonMatch.id
+            selectedAddonSubtitleId = forcedAddonMatch.selectionKey
             selectedSubtitleIndex = -1
             useCustomSubtitles = true
             playerController?.setSubtitleUri(forcedAddonMatch.url)
@@ -352,7 +349,7 @@ private fun PlayerScreenRuntime.tryAutoSelectPreferredSubtitleFromAvailableTrack
     }
     if (addonMatch != null) {
         preferredSubtitleSelectionApplied = true
-        selectedAddonSubtitleId = addonMatch.id
+        selectedAddonSubtitleId = addonMatch.selectionKey
         selectedSubtitleIndex = -1
         useCustomSubtitles = true
         playerController?.setSubtitleUri(addonMatch.url)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -472,7 +472,7 @@ private fun PlayerScreenRuntime.RenderPlayerModals(displayedPositionMs: Long) {
         },
         onAddonSubtitleSelected = { addon ->
             isUserExplicitSubtitleSelection = true
-            selectedAddonSubtitleId = addon.id
+            selectedAddonSubtitleId = addon.selectionKey
             selectedSubtitleIndex = -1
             useCustomSubtitles = true
             preferredSubtitleSelectionApplied = true

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleModal.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleModal.kt
@@ -362,7 +362,7 @@ private fun SubtitleLanguageRow(
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(if (selected) tokens.colors.accent else Color.Transparent)
-            .clickable(onClick = onClick)
+            .clickableIncludingFlingStop(onClick = onClick)
             .padding(horizontal = 10.dp, vertical = 8.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
@@ -431,7 +431,7 @@ private fun SubtitleOptionRow(
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(if (selected) tokens.colors.accent else Color.Transparent)
-            .clickable(onClick = onClick)
+            .clickableIncludingFlingStop(onClick = onClick)
             .padding(horizontal = 12.dp, vertical = 9.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleModal.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleModal.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.nuvio.app.core.ui.nuvio
+import com.nuvio.app.core.ui.withDuplicateSafeLazyKeys
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.addon_title
 import nuvio.composeapp.generated.resources.compose_player_built_in
@@ -85,9 +86,8 @@ fun SubtitleModal(
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val effectiveSelectedAddonSubtitle = selectedAddonSubtitle ?: addonSubtitles.firstOrNull { subtitle ->
-        subtitle.id == selectedAddonSubtitleId || subtitle.url == selectedAddonSubtitleId
-    }
+    val effectiveSelectedAddonSubtitle = selectedAddonSubtitle
+        ?: addonSubtitles.findSelectedAddon(selectedAddonSubtitleId)
     val playbackLanguageKey = selectedSubtitleLanguageKey(
         subtitleTracks = subtitleTracks,
         selectedSubtitleIndex = selectedSubtitleIndex,
@@ -98,9 +98,11 @@ fun SubtitleModal(
         selectedSubtitleIndex = selectedSubtitleIndex,
         selectedAddonSubtitle = effectiveSelectedAddonSubtitle,
     )
+    val subtitleStructureKey = subtitleTracksStructureKey(subtitleTracks)
+    val addonStructureKey = addonSubtitlesStructureKey(addonSubtitles)
     val languageItems = remember(
-        subtitleTracks,
-        addonSubtitles,
+        subtitleStructureKey,
+        addonStructureKey,
         preferredSubtitleLanguage,
         secondaryPreferredSubtitleLanguage,
         subtitleStyle.showOnlyPreferredLanguages,
@@ -123,9 +125,10 @@ fun SubtitleModal(
         )
     }
     var pendingOptionId by remember(visible) { mutableStateOf<String?>(playbackOptionId) }
-    val options = remember(activeLanguageKey, subtitleTracks, addonSubtitles) {
+    val options = remember(activeLanguageKey, subtitleStructureKey, addonStructureKey) {
         buildSubtitleSelectionOptions(activeLanguageKey, subtitleTracks, addonSubtitles)
     }
+    val keyedOptions = remember(options) { options.withDuplicateSafeLazyKeys { it.id } }
     val selectedOptionId = pendingOptionId ?: playbackOptionId
     val languageListState = rememberLazyListState()
     val optionsListState = rememberLazyListState()
@@ -257,7 +260,8 @@ fun SubtitleModal(
                                     verticalArrangement = Arrangement.spacedBy(4.dp),
                                     contentPadding = PaddingValues(vertical = 8.dp),
                                 ) {
-                                    items(options, key = { it.id }) { option ->
+                                    items(keyedOptions, key = { it.lazyKey }) { keyedOption ->
+                                        val option = keyedOption.value
                                         SubtitleOptionRow(
                                             option = option,
                                             selected = option.id == selectedOptionId,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleSelectionModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleSelectionModel.kt
@@ -26,9 +26,34 @@ internal sealed interface SubtitleSelectionOption {
     data class Addon(
         val subtitle: AddonSubtitle,
     ) : SubtitleSelectionOption {
-        override val id: String = "addon:${subtitle.addonName}:${subtitle.id}:${subtitle.url}"
+        override val id: String = "addon:${subtitle.addonName}:${subtitle.id}:${subtitle.selectionKey}"
     }
 }
+
+internal val AddonSubtitle.selectionKey: String
+    get() = url.takeIf { it.isNotBlank() } ?: listOfNotNull(addonName, id).joinToString(":")
+
+internal fun AddonSubtitle.matchesSelection(selectedId: String?): Boolean {
+    if (selectedId.isNullOrBlank()) return false
+    return url == selectedId || id == selectedId || selectionKey == selectedId
+}
+
+internal fun List<AddonSubtitle>.findSelectedAddon(selectedId: String?): AddonSubtitle? {
+    if (selectedId.isNullOrBlank()) return null
+    firstOrNull { it.url == selectedId }?.let { return it }
+    firstOrNull { it.selectionKey == selectedId }?.let { return it }
+    return firstOrNull { it.id == selectedId }
+}
+
+internal fun subtitleTracksStructureKey(tracks: List<SubtitleTrack>): String =
+    tracks.joinToString("\u0001") { track ->
+        "${track.index}\u0000${track.id}\u0000${track.language}\u0000${track.label}\u0000${track.isForced}"
+    }
+
+internal fun addonSubtitlesStructureKey(subtitles: List<AddonSubtitle>): String =
+    subtitles.joinToString("\u0001") { subtitle ->
+        "${subtitle.id}\u0000${subtitle.selectionKey}\u0000${subtitle.language}\u0000${subtitle.addonName}\u0000${subtitle.display}"
+    }
 
 internal fun buildSubtitleLanguageItems(
     subtitleTracks: List<SubtitleTrack>,
@@ -119,7 +144,7 @@ internal fun selectedSubtitleOptionId(
     selectedSubtitleIndex: Int,
     selectedAddonSubtitle: AddonSubtitle?,
 ): String? {
-    selectedAddonSubtitle?.let { return SubtitleSelectionOption.Addon(it).id }
+    selectedAddonSubtitle?.let { subtitle -> return SubtitleSelectionOption.Addon(subtitle).id }
     return subtitleTracks
         .firstOrNull { it.index == selectedSubtitleIndex }
         ?.let { SubtitleSelectionOption.BuiltIn(it) }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/ClickableIncludingFlingStopTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/ClickableIncludingFlingStopTest.kt
@@ -1,0 +1,55 @@
+package com.nuvio.app.features.player
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ClickableIncludingFlingStopTest {
+    @Test
+    fun unconsumedDownLeavesTheClickToClickable() {
+        assertFalse(
+            shouldDeliverFlingStopClick(
+                downConsumed = false,
+                movement = 0f,
+                touchSlop = 18f,
+                pointerUp = true,
+            ),
+        )
+    }
+
+    @Test
+    fun consumedDownAndUpWithinSlopSelectsTheRow() {
+        assertTrue(
+            shouldDeliverFlingStopClick(
+                downConsumed = true,
+                movement = 4f,
+                touchSlop = 18f,
+                pointerUp = true,
+            ),
+        )
+    }
+
+    @Test
+    fun consumedDownPastSlopIsADragNotAClick() {
+        assertFalse(
+            shouldDeliverFlingStopClick(
+                downConsumed = true,
+                movement = 24f,
+                touchSlop = 18f,
+                pointerUp = true,
+            ),
+        )
+    }
+
+    @Test
+    fun consumedDownWithoutUpDoesNotClick() {
+        assertFalse(
+            shouldDeliverFlingStopClick(
+                downConsumed = true,
+                movement = 0f,
+                touchSlop = 18f,
+                pointerUp = false,
+            ),
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/SubtitleSelectionModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/SubtitleSelectionModelTest.kt
@@ -87,6 +87,41 @@ class SubtitleSelectionModelTest {
     }
 
     @Test
+    fun keepsAddonOptionsWithTheSameNameAndTitleWhenUrlsDiffer() {
+        val first = addonSubtitle(
+            id = "en",
+            language = "en",
+            url = "https://example.com/en-a.srt",
+            display = "English",
+        )
+        val second = addonSubtitle(
+            id = "en",
+            language = "en",
+            url = "https://example.com/en-b.srt",
+            display = "English",
+        )
+
+        val options = buildSubtitleSelectionOptions(
+            languageKey = "en",
+            subtitleTracks = emptyList(),
+            addonSubtitles = listOf(first, second),
+        )
+
+        assertEquals(listOf(first.url, second.url), options.map { (it as SubtitleSelectionOption.Addon).subtitle.url })
+        assertEquals(2, options.map { it.id }.distinct().size)
+        assertEquals(second, listOf(first, second).findSelectedAddon(second.selectionKey))
+        assertEquals(second, listOf(first, second).findSelectedAddon(second.url))
+    }
+
+    @Test
+    fun structureKeyIgnoresSelectionSoTheListDoesNotRebuildOnToggle() {
+        val unselected = subtitleTrack(index = 0, language = "en", label = "English")
+        val selected = unselected.copy(isSelected = true)
+
+        assertEquals(subtitleTracksStructureKey(listOf(unselected)), subtitleTracksStructureKey(listOf(selected)))
+    }
+
+    @Test
     fun emptySubtitleRailShowsFetchActionWhenNoLanguagesAreAvailable() {
         assertEquals(
             SubtitleOptionsRailEmptyContent.FETCH,
@@ -136,11 +171,13 @@ class SubtitleSelectionModelTest {
     private fun addonSubtitle(
         id: String,
         language: String,
+        url: String = "https://example.com/$id.srt",
+        display: String = id,
     ) = AddonSubtitle(
         id = id,
-        url = "https://example.com/$id.srt",
+        url = url,
         language = language,
-        display = id,
+        display = display,
         addonName = "Addon",
     )
 }


### PR DESCRIPTION

## Summary

- Follow-up to the sidecar subtitle picker work in #1705: selecting an addon subtitle that shares the same name and title no longer rebuilds or jumps the options list.
- Identify the selected addon subtitle by URL (`selectionKey`) instead of the reused addon `id`, so two English tracks from the same addon stay distinct.
- Keep the language/options lists cached on a structure key that ignores `isSelected`, so toggling a row does not recreate the LazyColumn items.
- Use `withDuplicateSafeLazyKeys` on subtitle options so duplicate Compose keys cannot reshuffle the list.
- Recover the tap that Compose consumes to stop a subtitle-list fling, so language and option rows select on the first tap instead of requiring a second one.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

After #1705, addon subtitle entries often share the same addon id (for example `en`) and the same display name/title. Selecting the second identical-looking row resolved back to the first track, and `isSelected` updates rebuilt the picker list. Playback still applied the chosen URL, but the overlay highlight and list identity were wrong.

Separately, when the language or options list is still flinging, Compose consumes the next down to cancel that animation. `Modifier.clickable` never sees a complete tap, so nothing is selected until a second tap.

## Issue or approval

Follow-up to #1705

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Does not change sidecar rendering, addon fetch, audio selection, preference storage schema, or subtitle styling. Only picker identity/selection matching, list stability, and delivering the fling-cancel tap on language/option rows.

## Testing

- Unit: `./gradlew :composeApp:testAndroidHostTest --tests com.nuvio.app.features.player.SubtitleSelectionModelTest --tests com.nuvio.app.features.player.ClickableIncludingFlingStopTest`
- Device: `:androidApp:installFullDebug` on physical Android `24129PN74G` (`c49108`)
- Manual: open the subtitle overlay, pick a second addon subtitle that has the same name and title as another row, confirm the highlight stays on the chosen row and the list does not rebuild or jump
- Manual: fling a scrollable language or options list, tap a row while it is still moving, confirm the first tap both stops the fling and selects that row

## Screenshots / Video

Verified on physical Android device (`24129PN74G`): selecting a second same-name addon subtitle keeps the check on that row; the options rail no longer recomposes or snaps back to the first duplicate. Tapping a row during an in-progress fling selects it on the first tap.

## Breaking changes

None.

## Linked issues

Continuation of #1705
Follow-up to the sidecar addon subtitle selection work in that PR.

## Special thanks

Thank you @i7xre for reporting this duplicate-name subtitle picker bug and for the solution suggestion that led to this fix.
