### PR TITLE
Strip speaker-change markers when stripping SDH

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleSdhFilter.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleSdhFilter.kt
@@ -2,6 +2,9 @@ package com.nuvio.app.features.player
 
 internal object SubtitleSdhFilter {
     private val squareBrackets = Regex("\\[[^]]*][ \\t]*")
+    // ">>" marks a speaker change and ">>>" a topic change in CEA-608 style
+    // captions, which survive into text subtitles.
+    private val speakerChevrons = Regex("[<>]{2,}[ \t]*")
     private val parentheses = Regex(
         "(?:\\((?=[A-Za-z0-9 '#.,\\\"\\\\\\-\\r\\n]*\\))(?![0-9]*\\))[^)]*\\)|" +
             "（(?=[A-Za-z0-9 '#.,\\\"\\\\\\-\\r\\n]*）)(?![0-9]*）)[^）]*）)[ \\t]*",
@@ -11,7 +14,10 @@ internal object SubtitleSdhFilter {
     )
 
     fun filter(text: String): String? {
-        var filtered = speakerLabel.replace(text) { match -> match.groups[1]?.value.orEmpty() }
+        // Runs before speakerLabel so that ">> NAME:" loses the chevrons first and
+        // is then recognised as a speaker label.
+        var filtered = speakerChevrons.replace(text, "")
+        filtered = speakerLabel.replace(filtered) { match -> match.groups[1]?.value.orEmpty() }
         filtered = squareBrackets.replace(filtered, "")
         filtered = parentheses.replace(filtered, "")
         return filtered.lines()


### PR DESCRIPTION
## Summary

Strip `>>` and `<<` speaker-change markers in `SubtitleSdhFilter`, alongside the sound descriptions and speaker
labels it already removes. Applies wherever SDH stripping is already enabled.

## PR type

- [ ] Translation/localization only
- [ ] Critical bug fix

## Why

`>>` and `>>>` are CEA-608 captioning control markers, not dialogue: `>>` signals a speaker change and `>>>` a
topic change. They are an artifact of broadcast captioning that survives conversion to text subtitles, and they
appear frequently in tracks sourced from broadcast or auto-generated captions. Anyone who turns on "Strip SDH
subtitles" is asking for exactly this class of non-dialogue marker to be removed, so leaving the chevrons in is an
inconsistency in the filter rather than a separate preference.

Stripping them first also lets the existing speaker-label rule work: `>> JOHN:` was previously unmatched, because
the chevrons sit where the rule expects a name, so both the marker and the label survived. With the chevrons gone
the line reduces to plain dialogue.

## Issue or approval

No linked issue.

## Reproduction steps

Enable **Strip SDH subtitles** in subtitle settings, then play any content whose subtitle track uses `>>`
markers.

- Before: `>> JOHN: we should go` renders unchanged.
- After: `we should go`.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [x] Behavior changed only to fix a documented bug/regression

Behaviour changes only for users who already have SDH stripping enabled.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [ ] This PR fits the current PR policy.
- [x] This PR does not add features, UI changes, or refactors.
- [x] Small, focused, one concern.
- [x] No unrelated changes.
- [x] Testing listed below.

## Scope boundaries

One regex and its application order. No change to the bracket, parenthesis, or speaker-label rules, and no change
to when the filter runs. Cues left empty after filtering are dropped by the existing blank-line handling.

## Testing

Manual on onn. 4K Plus Streaming (Android 14) with SDH stripping enabled: `>>`-prefixed lines render as plain
dialogue, `>> NAME:` loses both marker and label, and lines that were only a marker disappear rather than leaving
a blank caption.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

None.