### PR TITLE
fix(player): reset subtitle selection on source change

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -1565,7 +1565,7 @@ private class NuvioLibmpvView(
                 hasActiveSubtitle: Boolean,
                 useCustomSubtitles: Boolean,
             ) {
-                if (hasActiveSubtitle || useCustomSubtitles) {
+                if ((hasActiveSubtitle || useCustomSubtitles) && autoSelectionApplied) {
                     return
                 }
                 val languages = listOfNotNull(
@@ -1997,7 +1997,7 @@ private fun ExoPlayer.applySubtitleTrackPreferences(
     hasActiveSubtitle: Boolean,
     useCustomSubtitles: Boolean,
 ) {
-    if (hasActiveSubtitle || useCustomSubtitles) {
+    if ((hasActiveSubtitle || useCustomSubtitles) && autoSelectionApplied) {
         return
     }
 

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -86,6 +86,9 @@ internal fun PlayerScreenRuntime.BindPlayerRuntimeEffects() {
         preferredSubtitleSelectionApplied = false
         isUserExplicitSubtitleSelection = false
         hasScannedTextTracksOnce = false
+        selectedSubtitleIndex = -1
+        selectedAddonSubtitleId = null
+        useCustomSubtitles = false
         showSourcesPanel = false
         showEpisodesPanel = false
         episodeStreamsPanelState = EpisodeStreamsPanelState()


### PR DESCRIPTION
## Summary

Fixes a regression where embedded subtitle tracks (e.g. `.ass`) fail to load on the next episode after an episode transition without leaving the player.

Two changes:

1. **`PlayerScreenRuntimeEffects.kt`** — the `LaunchedEffect(activeSourceUrl, ...)` reset block now also clears the active subtitle *selection* state (`selectedSubtitleIndex`, `selectedAddonSubtitleId`, `useCustomSubtitles`). These values were reset for the flags but not for the selection itself, so a stale raw track index from the previous episode survived the transition.

2. **`PlayerEngine.android.kt`** — the early-return guard in `applySubtitleTrackPreferences` (ExoPlayer) and the equivalent libmpv guard now only short-circuit when `autoSelectionApplied` is true. This ensures the new media item's preferred text language is always configured even if some other path leaves selection state stale.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Regression introduced by commit 0451b02e, which added an unconditional early return `if (hasActiveSubtitle || useCustomSubtitles) return` in `applySubtitleTrackPreferences`.

Repro:

1. Play an anime episode with an embedded `.ass` subtitle track selected.
2. Transition to the next episode (auto-advance or manual next) without leaving the player.
3. The next episode's subtitle track does not load. Switching to another subtitle language in the modal also does not load.
4. Leaving the player screen and re-entering fixes it.

Cause: `selectedSubtitleIndex` (a media-specific raw track index) is not reset on source change. On the next episode it is still `>= 0`, so `hasActiveSubtitle = true` is passed to `applySubtitleTrackPreferences`, which returns early and never sets the preferred text language for the new media item. The stale index also does not map to a real track in the new episode's track list, so auto-selection finds nothing.

## Issue or approval

No linked issue

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

The change restores the pre-regression behavior: subtitles continue to load (and follow the persisted language preference) across episode transitions.

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change subtitle auto-selection logic itself.
- Does not change how persisted subtitle preferences are stored or restored (they are re-applied per item by language/URL via `restorePersistedTrackPreferenceIfNeeded`).
- The libmpv guard change mirrors the ExoPlayer one for consistency; mpv `slang` is per-file scoped so the impact there is minimal.

## Testing

- Static verification of the failure chain: with the fix, the `activeSourceUrl` effect clears the stale selection, so `applySubtitlePreferences` runs with `hasActiveSubtitle = false` and the guard passes for the new item.
- **Not yet runtime-tested.** This PR is intentionally in draft so it can be validated on a device: play an episode with `.ass`, transition to the next episode, confirm subtitles load; also switch subtitle language in the modal during the next episode.
- No unit tests cover this Compose runtime state flow; none were added (manual device test required).

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue — see "Issue or approval" above.