### PR TITLE
i18n(el): translate sign-in with link strings

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-el/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-el/strings.xml
@@ -133,6 +133,16 @@
     <string name="compose_auth_create_account">Δημιουργία λογαριασμού</string>
     <string name="compose_auth_dont_have_account">Δεν έχετε λογαριασμό; </string>
     <string name="compose_auth_email">Ηλεκτρονικό ταχυδρομείο</string>
+    <string name="compose_auth_link_cancel">Άκυρο</string>
+    <string name="compose_auth_link_code_expired">Αυτός ο κωδικός έληξε.</string>
+    <string name="compose_auth_link_creating_code">Δημιουργία κωδικού…</string>
+    <string name="compose_auth_link_failed">Η σύνδεση μέσω συνδέσμου απέτυχε.</string>
+    <string name="compose_auth_link_open">Άνοιγμα nuvio.tv/link</string>
+    <string name="compose_auth_link_open_failed">Δεν ήταν δυνατό το άνοιγμα του συνδέσμου.</string>
+    <string name="compose_auth_link_sign_in">Σύνδεση με σύνδεσμο</string>
+    <string name="compose_auth_link_signing_in">Γίνεται σύνδεση…</string>
+    <string name="compose_auth_link_try_again">Δοκιμάστε ξανά</string>
+    <string name="compose_auth_link_waiting">Αναμονή έγκρισης…</string>
     <string name="compose_auth_or_separator">  ή  </string>
     <string name="compose_auth_password">Κωδικός</string>
     <string name="compose_auth_sign_in_subtitle">Συνδεθείτε για να αποκτήσετε πρόσβαση στη βιβλιοθήκη και την πρόοδό σας</string>


### PR DESCRIPTION
## Summary

Completes the Greek (el) localization for the new **Sign In with Link** feature (six-character login codes) by adding the **10 missing strings** that were introduced in `feat(auth): add six-character login codes`:

- `compose_auth_link_cancel` — Cancel
- `compose_auth_link_code_expired` — This code expired.
- `compose_auth_link_creating_code` — Creating code…
- `compose_auth_link_failed` — Link sign-in failed.
- `compose_auth_link_open` — Open nuvio.tv/link
- `compose_auth_link_open_failed` — Couldn't open the link.
- `compose_auth_link_sign_in` — Sign In with Link
- `compose_auth_link_signing_in` — Signing in…
- `compose_auth_link_try_again` — Try Again
- `compose_auth_link_waiting` — Waiting for approval…

Translations follow the existing Greek terminology (e.g., "Άκυρο" for Cancel, "Δοκιμάστε ξανά" for Try Again, "Αναμονή έγκρισης…" for Waiting for approval…, matching the existing `settings_debrid_device_auth_*` strings). The `nuvio.tv/link` URL is intentionally left untranslated.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [x] Translation/localization only
- [ ] Approved larger or directional change

## Why

The Greek translation was missing the keys for the new link sign-in flow, so Greek users would see English fallback text in the sign-in screen (code entry, waiting/expired states, error messages).

## Issue or approval

No linked issue: translation/localization update, which is explicitly allowed by `CONTRIBUTING.md` without an issue.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only `composeApp/src/commonMain/composeResources/values-el/strings.xml` was changed. No other files, no code changes.

## Testing

- Verified the file parses as valid XML.
- Programmatically compared all string keys against `values/strings.xml`: **2200/2200 keys present, 0 missing, 0 duplicates** (including plurals).
- Reviewed every new translation for consistency with existing Greek terminology (e.g., "Άκυρο" for Cancel, "Δοκιμάστε ξανά" for Try Again, "Αναμονή έγκρισης…" matching the existing `settings_debrid_device_auth_waiting`).
- Confirmed no format placeholders are required in the new strings (none of the source strings contain any).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - translation/localization update (allowed by `CONTRIBUTING.md`).