### PR TITLE
fix(player): replace invalid RegexOption.DOT_MATCHES_ALL with inline flag

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSubtitleCueParser.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerSubtitleCueParser.kt
@@ -213,7 +213,7 @@ object PlayerSubtitleCueParser {
     }
 
     private fun parseTtml(text: String): List<SubtitleSyncCue> =
-        Regex("""<p\b([^>]*)>(.*?)</p>""", setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL))
+        Regex("""(?si)<p\b([^>]*)>(.*?)</p>""")
             .findAll(text)
             .mapNotNull { match ->
                 val attrs = match.groupValues[1]


### PR DESCRIPTION
## Summary

Replaces `RegexOption.DOT_MATCHES_ALL` with the inline `(?si)` regex flag in `PlayerSubtitleCueParser.kt` to resolve a build failure in Kotlin Multiplatform's `commonMain` target.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

In `PlayerSubtitleCueParser.kt`, `RegexOption.DOT_MATCHES_ALL` was used to parse multiline TTML subtitle paragraph tags. However, `RegexOption.DOT_MATCHES_ALL` is JVM/Android-specific and is not available in Kotlin Multiplatform's `commonMain` standard library, causing `./gradlew compileCommonMainKotlinMetadata` to fail with `Unresolved reference 'DOT_MATCHES_ALL'`.

Replacing it with the inline `(?si)` regex flag preserves identical single-line (dot matches all) and case-insensitive matching while compiling cleanly across all KMP targets.

## Issue or approval

PR #0 No linked issue - fixes compile-blocking failure in KMP `commonMain` metadata task.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Strictly touches 1 line in `PlayerSubtitleCueParser.kt`.
- Does not modify TTML parsing structure, timestamp extraction, or any other subtitle format handlers (VTT, ASS, SRT).

## Testing

- Ran `./gradlew compileCommonMainKotlinMetadata` to verify the task passes and the build succeeds without compiler errors.
- Ran `./gradlew compileAndroidMain` and `./gradlew installFullDebug` to confirm Android builds pass cleanly.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

PR #0.No linked issue - 1-line compile fix for KMP `commonMain`.