### PR TITLE
fix(player): treat the next-episode auto play timeout as a cap

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerNextEpisodeAutoPlay.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerNextEpisodeAutoPlay.kt
@@ -215,7 +215,12 @@ internal fun CoroutineScope.launchPlayerNextEpisodeAutoPlay(
         val isBoundedTimeout = timeoutSeconds in 1..30
 
         if (isBoundedTimeout) {
-            delay(timeoutMs)
+            // The timeout caps how long to wait for a stream to become
+            // selectable, so it has to be raced against the selection rather
+            // than served in full. Sleeping it unconditionally made every
+            // transition cost the whole setting even when the collector above
+            // had already picked a source in the first few hundred milliseconds.
+            withTimeoutOrNull(timeoutMs) { autoSelectSettled.await() }
             timeoutElapsed = true
             if (!autoSelectTriggered) {
                 val allStreams = PlayerStreamsRepository.episodeStreamsState.value.groups.flatMap { it.streams }


### PR DESCRIPTION
## Summary

The next-episode stream selection timeout is treated as a fixed delay instead of a cap. In the bounded branch the coroutine sleeps the whole configured value before it looks at anything, so every episode transition costs the full setting even when a stream was selectable almost immediately. Race the timeout against the selection instead.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Settings → Playback → Stream auto-play → "Stream Selection Timeout" reads as a maximum wait. It behaves as a minimum: `if (isBoundedTimeout) { delay(timeoutMs) }` runs unconditionally, while the collector above it can settle a selection in a few hundred milliseconds. With the timeout set to 20s, the next episode starts 20s after the previous one ends, on a black screen, even when the source was ready at once. At the default of 3s it is a smaller but constant tax on every transition.

This was reported on the desktop side as https://github.com/NuvioMedia/NuvioDesktop/issues/454, with the reporter pointing at these exact lines. The file is shared, so the behaviour is the same here. I am opening it against this repository because a maintainer asked for non-desktop-specific changes to land in NuvioMobile first, for platform parity.

## Issue or approval

https://github.com/NuvioMedia/NuvioDesktop/issues/454 — open bug report, root-caused by its reporter with line references. No equivalent issue exists in this repository; I searched before filing. Happy to open one here as well if you would rather the link stayed in-repo.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

> UI polish, cosmetic-only changes, minor behavior tweaks, and unapproved product changes will be closed without review.

## Scope boundaries

Deliberately not changed:

- The unbounded branch, and the hard timeout that follows it.
- `timeoutElapsed`, which is still set immediately after the wait, so everything downstream sees the same sequence.
- The 3s countdown before the next episode starts. That is a separate, deliberate delay and this PR leaves it alone.
- The selection rules themselves — which stream wins, and when a binge-group match is allowed to win early, are untouched.
- No refactor of the surrounding block, even though it has grown long.

## Testing

Built and tested against this repository on Linux, with the Android SDK provisioned through nixpkgs and `compileSdk 37` fetched by AGP:

- `./gradlew :composeApp:compileCommonMainKotlinMetadata` — green.
- `./gradlew :androidApp:compileFullDebugKotlin` — green, the full Android debug variant.
- `./gradlew :composeApp:testAndroid` — green: 117 suites, 744 tests, 0 failures.

Behaviour was exercised on the desktop build, where this same shared file runs, with the timeout set to 20s:

- Before: the next episode starts 20s after the previous one ends, on a black screen, regardless of how quickly a source resolves.
- After: it starts in about 3s, which is the separate hardcoded countdown, and the wait now scales with how long the source actually takes rather than with the setting.
- With no source available, the timeout still elapses in full and the manual stream list appears as before.

Not exercised on a physical Android device or emulator — the change is one call in `commonMain` with no platform-specific behaviour, and the shared tests cover it, but I would rather state that than imply a device run I did not do.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None. The setting keeps its meaning, and its documented meaning is what this restores.

## Linked issues

https://github.com/NuvioMedia/NuvioDesktop/issues/454
