### PR TITLE
fix(trailer): reject PO-token-gated stream URLs and resolve without the rate-limited watch page

### DIFF
--- a/composeApp/src/androidFull/kotlin/com/nuvio/app/features/trailer/TrailerExtractionPlatform.android.kt
+++ b/composeApp/src/androidFull/kotlin/com/nuvio/app/features/trailer/TrailerExtractionPlatform.android.kt
@@ -15,6 +15,9 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.util.concurrent.TimeUnit
 
+private const val PROBE_TIMEOUT_SECONDS = 5L
+private const val PROBE_RACE_TIMEOUT_MS = 8_000L
+
 internal object TrailerExtractionPlatform {
     val defaultHeaders: Map<String, String> = mapOf(
         "accept-language" to "en-US,en;q=0.9",
@@ -34,8 +37,8 @@ internal object TrailerExtractionPlatform {
 
     private val probeClient = OkHttpClient.Builder()
         .dns(IPv4FirstDns())
-        .connectTimeout(2, TimeUnit.SECONDS)
-        .readTimeout(2, TimeUnit.SECONDS)
+        .connectTimeout(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        .readTimeout(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
         .followRedirects(true)
         .followSslRedirects(true)
         .build()
@@ -76,57 +79,102 @@ internal object TrailerExtractionPlatform {
     }
 
     suspend fun buildPlaybackSource(
-        bestManifest: ManifestCandidate?,
-        bestProgressive: StreamCandidate?,
-        bestVideo: StreamCandidate?,
-        bestAudio: StreamCandidate?,
+        manifestCandidates: List<ManifestCandidate>,
+        progressiveCandidates: List<StreamCandidate>,
+        videoCandidates: List<StreamCandidate>,
+        audioCandidates: List<StreamCandidate>,
     ): TrailerPlaybackSource? = withContext(Dispatchers.IO) {
-        val bestCombinedIsManifest = bestManifest != null &&
-            (bestProgressive == null || bestManifest.height > bestProgressive.height)
+        // A candidate can look fine and still be unplayable: PO token gated URLs
+        // answer the first range and 403 everything after it. Every candidate is
+        // probed and the first one that survives wins.
+        var videoOnlyFallback: String? = null
+        // One rejection condemns a whole client: the gate applies to all of its
+        // adaptive formats, so there is no point probing its siblings.
+        val gatedClients = mutableSetOf<String>()
 
-        val combinedUrl = if (bestCombinedIsManifest) {
-            bestManifest.selectedVariantUrl
-        } else {
-            bestProgressive?.url
+        suspend fun fromManifests(): TrailerPlaybackSource? {
+            for (candidate in manifestCandidates.take(MAX_CANDIDATE_ATTEMPTS)) {
+                val url = resolveReachableUrlOrNull(candidate.selectedVariantUrl) ?: continue
+                return TrailerPlaybackSource(videoUrl = url, audioUrl = null)
+            }
+            return null
         }
 
-        val separatedVideoUrl = bestVideo?.url?.let { resolveReachableUrlOrNull(it) }
-        val combinedCandidateUrl = combinedUrl?.let { resolveReachableUrlOrNull(it) }
-        val videoUrl = separatedVideoUrl ?: combinedCandidateUrl ?: return@withContext null
-        val audioUrl = if (!separatedVideoUrl.isNullOrBlank()) {
-            bestAudio?.url?.let { resolveReachableUrlOrNull(it) }
-        } else {
-            null
+        suspend fun fromSeparateStreams(): TrailerPlaybackSource? {
+            for (video in videoCandidates.take(MAX_CANDIDATE_ATTEMPTS)) {
+                if (video.client in gatedClients) continue
+                val videoUrl = resolveReachableUrlOrNull(video.url)
+                if (videoUrl == null) {
+                    gatedClients += video.client
+                    continue
+                }
+                for (audio in audioCandidates.take(MAX_CANDIDATE_ATTEMPTS)) {
+                    val audioUrl = resolveReachableUrlOrNull(audio.url) ?: continue
+                    return TrailerPlaybackSource(videoUrl = videoUrl, audioUrl = audioUrl)
+                }
+                // Video is reachable but no audio track survived: remember it and
+                // let the other strategies try to produce a source with sound.
+                if (videoOnlyFallback == null) {
+                    videoOnlyFallback = videoUrl
+                }
+                break
+            }
+            return null
         }
 
-        TrailerPlaybackSource(
-            videoUrl = videoUrl,
-            audioUrl = audioUrl,
-        )
+        suspend fun fromProgressive(): TrailerPlaybackSource? {
+            for (candidate in progressiveCandidates.take(MAX_CANDIDATE_ATTEMPTS)) {
+                val url = resolveReachableUrlOrNull(candidate.url) ?: continue
+                return TrailerPlaybackSource(videoUrl = url, audioUrl = null)
+            }
+            return null
+        }
+
+        val manifestHeight = manifestCandidates.firstOrNull()?.height ?: -1
+        val separateHeight = videoCandidates.firstOrNull()?.height ?: -1
+        val strategies: List<suspend () -> TrailerPlaybackSource?> = if (manifestHeight >= separateHeight) {
+            listOf({ fromManifests() }, { fromSeparateStreams() }, { fromProgressive() })
+        } else {
+            listOf({ fromSeparateStreams() }, { fromManifests() }, { fromProgressive() })
+        }
+
+        for (strategy in strategies) {
+            strategy()?.let { return@withContext it }
+        }
+
+        videoOnlyFallback?.let { videoUrl ->
+            return@withContext TrailerPlaybackSource(videoUrl = videoUrl, audioUrl = null)
+        }
+
+        null
     }
 
     private suspend fun resolveReachableUrlOrNull(url: String): String? {
         if (!url.contains("googlevideo.com")) return url
         val uri = Uri.parse(url)
-        val mnParam = uri.getQueryParameter("mn") ?: return url
-        val servers = mnParam.split(',').map { it.trim() }.filter { it.isNotBlank() }
-        if (servers.size < 2) {
-            return if (isUrlReachable(url)) url else null
-        }
+        val servers = uri.getQueryParameter("mn")
+            ?.split(',')
+            ?.map { it.trim() }
+            ?.filter { it.isNotBlank() }
+            .orEmpty()
+        val host = uri.host
 
-        val host = uri.host ?: return if (isUrlReachable(url)) url else null
-        val candidates = mutableListOf(url)
-        servers.forEachIndexed { index, server ->
-            val altHost = host
-                .replaceFirst(Regex("^rr\\d+---"), "rr${index + 1}---")
-                .replaceFirst(Regex("sn-[a-z0-9]+-[a-z0-9]+"), server)
-            if (altHost != host) {
-                candidates += url.replace(host, altHost)
+        val candidates = buildList {
+            add(url)
+            if (host != null) {
+                servers.forEachIndexed { index, server ->
+                    val altHost = host
+                        .replaceFirst(Regex("^rr\\d+---"), "rr${index + 1}---")
+                        .replaceFirst(Regex("sn-[a-z0-9]+-[a-z0-9]+"), server)
+                    if (altHost != host) {
+                        add(url.replace(host, altHost))
+                    }
+                }
             }
-        }
+        }.distinct()
 
         if (candidates.size == 1) {
-            return if (isUrlReachable(candidates[0])) candidates[0] else null
+            return candidates.first().takeIf { isUrlReachable(it) }
         }
 
         val result = CompletableDeferred<String>()
@@ -140,26 +188,37 @@ internal object TrailerExtractionPlatform {
         }
 
         return try {
-            withTimeoutOrNull(2_000L) { result.await() }
+            withTimeoutOrNull(PROBE_RACE_TIMEOUT_MS) { result.await() }
         } finally {
             probeScope.cancel()
         }
     }
 
-    private fun isUrlReachable(url: String): Boolean {
-        return runCatching {
+    // A single head range probe is not enough: gated URLs answer the first chunk
+    // and 403 the rest, so the tail is probed too whenever the length is known.
+    private fun isUrlReachable(url: String): Boolean = runCatching {
+        val sourceSize = Uri.parse(url).getQueryParameter("clen")?.toLongOrNull()?.takeIf { it > 0L }
+        val ranges = sourceSize?.let { size ->
+            listOf(
+                0L to 65_535L.coerceAtMost(size - 1L),
+                (size - 65_536L).coerceAtLeast(0L) to size - 1L,
+            ).distinct()
+        } ?: listOf(0L to 0L)
+
+        ranges.all { (rangeStart, rangeEnd) ->
             val request = Request.Builder()
                 .url(url)
-                .get()
-                .header("Range", "bytes=0-0")
                 .headers(buildHeaders(defaultHeaders))
+                .header("Range", "bytes=$rangeStart-$rangeEnd")
+                .get()
                 .build()
 
             probeClient.newCall(request).execute().use { response ->
-                response.code in 200..299
+                response.code == 206 ||
+                    (sourceSize == null && rangeStart == 0L && response.code in 200..299)
             }
-        }.getOrDefault(false)
-    }
+        }
+    }.getOrDefault(false)
 
     private fun buildHeaders(source: Map<String, String>): Headers {
         val headers = Headers.Builder()

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/trailer/InAppYouTubeExtractor.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/trailer/InAppYouTubeExtractor.kt
@@ -2,6 +2,8 @@ package com.nuvio.app.features.trailer
 
 import co.touchlab.kermit.Logger
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
@@ -9,12 +11,43 @@ import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 
 internal const val TRAILER_EXTRACTOR_TAG = "InAppYouTubeExtractor"
 internal const val TRAILER_REQUEST_TIMEOUT_MS = 20_000L
 
 private const val EXTRACTOR_TIMEOUT_MS = 30_000L
-private const val PREFERRED_SEPARATE_CLIENT = "visionos"
+
+// YouTube gates the ANDROID and IOS InnerTube clients behind a PO token: their
+// googlevideo URLs serve the first chunk and then reject every further range
+// with 403, which surfaces as mid-open playback failures. VISIONOS URLs (and
+// its HLS manifest) are still ungated, so only those are used for playback.
+// The other clients stay in CLIENTS as a last-resort fallback in case VISIONOS
+// gets gated too - unreachable candidates are then dropped by the probes.
+private val PLAYBACK_CLIENT_ALLOWLIST = setOf("visionos", "android_vr")
+
+// The InnerTube key is a public constant shipped in every YouTube page and the
+// player endpoint even accepts requests without it. Scraping it from the watch
+// page (over a megabyte per video) is what breaks first when the device gets
+// rate limited, so it is only used as a fallback.
+private const val DEFAULT_INNERTUBE_API_KEY = "AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
+
+// Probing is not free, so only the top few candidates of each kind are tried.
+internal const val MAX_CANDIDATE_ATTEMPTS = 3
+
+// The watch page is over a megabyte and only exists to scrape the InnerTube key
+// and visitor id, which are not per-video. Re-fetching it for every trailer is
+// what gets the device rate limited, so it is cached process-wide.
+private val WatchConfigTtl = 3.hours
+
+// A 429 is device wide: every further request makes it worse, so extraction
+// stops entirely until the cooldown expires. Per client bot checks are handled
+// separately and only skip the client that was challenged.
+private val RateLimitCooldown = 15.minutes
 
 private val VIDEO_ID_REGEX = Regex("^[a-zA-Z0-9_-]{11}$")
 private val API_KEY_REGEX = Regex("\"INNERTUBE_API_KEY\":\"([^\"]+)\"")
@@ -29,6 +62,14 @@ private data class YouTubeClient(
     val context: JsonObject,
     val priority: Int,
 )
+
+// A verdict YouTube will keep repeating no matter how often we ask: geo blocks,
+// removed videos, private videos. Retrying only burns request budget.
+private class UnplayableException(val playabilityStatus: String, val playabilityReason: String) :
+    IllegalStateException("unplayable ($playabilityStatus): $playabilityReason")
+
+private class BotCheckException(clientKey: String, playabilityStatus: String) :
+    IllegalStateException("bot check for $clientKey ($playabilityStatus)")
 
 private data class WatchConfig(
     val apiKey: String?,
@@ -95,41 +136,114 @@ private val CLIENTS = listOf(
         ),
         priority = 0,
     ),
+    // Oculus client: no PO token required, so its URLs stay playable. It gets
+    // bot challenged sooner than ANDROID/IOS, hence second rather than first.
     YouTubeClient(
-        key = "android",
-        id = "3",
-        version = "20.10.35",
-        userAgent = "com.google.android.youtube/20.10.35 (Linux; U; Android 14; en_US) gzip",
+        key = "android_vr",
+        id = "28",
+        version = "1.65.10",
+        userAgent = "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; " +
+            "eureka-user Build/SQ3A.220605.009.A1) gzip",
         context = jsonObjectOf(
-            "clientName" to "ANDROID",
-            "clientVersion" to "20.10.35",
+            "clientName" to "ANDROID_VR",
+            "clientVersion" to "1.65.10",
+            "deviceMake" to "Oculus",
+            "deviceModel" to "Quest 3",
             "osName" to "Android",
-            "osVersion" to "14",
-            "platform" to "MOBILE",
-            "androidSdkVersion" to 34,
+            "osVersion" to "12L",
+            "androidSdkVersion" to 32,
             "hl" to "en",
             "gl" to "US",
         ),
         priority = 1,
     ),
+    // ANDROID and IOS survive bot checks the longest but their adaptive formats
+    // are PO token gated; only their progressive format stays playable.
     YouTubeClient(
-        key = "ios",
-        id = "5",
-        version = "20.10.1",
-        userAgent = "com.google.ios.youtube/20.10.1 (iPhone16,2; U; CPU iOS 17_4 like Mac OS X)",
+        key = "android",
+        id = "3",
+        version = "21.26.364",
+        userAgent = "com.google.android.youtube/21.26.364 (Linux; U; Android 11) gzip",
         context = jsonObjectOf(
-            "clientName" to "IOS",
-            "clientVersion" to "20.10.1",
-            "deviceModel" to "iPhone16,2",
-            "osName" to "iPhone",
-            "osVersion" to "17.4.0.21E219",
+            "clientName" to "ANDROID",
+            "clientVersion" to "21.26.364",
+            "osName" to "Android",
+            "osVersion" to "11",
             "platform" to "MOBILE",
+            "androidSdkVersion" to 30,
             "hl" to "en",
             "gl" to "US",
         ),
         priority = 2,
     ),
+    YouTubeClient(
+        key = "ios",
+        id = "5",
+        version = "21.26.4",
+        userAgent = "com.google.ios.youtube/21.26.4 (iPhone16,2; U; CPU iOS 18_3_2 like Mac OS X;)",
+        context = jsonObjectOf(
+            "clientName" to "IOS",
+            "clientVersion" to "21.26.4",
+            "deviceMake" to "Apple",
+            "deviceModel" to "iPhone16,2",
+            "osName" to "iPhone",
+            "osVersion" to "18.3.2.22D82",
+            "platform" to "MOBILE",
+            "hl" to "en",
+            "gl" to "US",
+        ),
+        priority = 3,
+    ),
 )
+
+// Shared across every extractor instance: the InnerTube key and visitor id are
+// account-agnostic and stay valid for hours.
+private object WatchConfigCache {
+    private val mutex = Mutex()
+    private var cached: WatchConfig? = null
+    private var cachedAt: TimeMark? = null
+
+    suspend fun get(fetch: suspend () -> WatchConfig): WatchConfig = mutex.withLock {
+        val current = cached
+        val age = cachedAt
+        if (current != null && age != null && age.elapsedNow() < WatchConfigTtl) {
+            return@withLock current
+        }
+        val fresh = fetch()
+        if (fresh.apiKey != null) {
+            cached = fresh
+            cachedAt = TimeSource.Monotonic.markNow()
+        }
+        fresh
+    }
+
+    suspend fun invalidate() = mutex.withLock {
+        cached = null
+        cachedAt = null
+    }
+}
+
+// Global backoff so a rate limited device stops issuing requests instead of
+// retrying per trailer, per hover and per hero.
+private object RateLimitGate {
+    private val mutex = Mutex()
+    private var trippedAt: TimeMark? = null
+
+    suspend fun remaining(): Duration? = mutex.withLock {
+        val tripped = trippedAt ?: return@withLock null
+        val elapsed = tripped.elapsedNow()
+        if (elapsed >= RateLimitCooldown) {
+            trippedAt = null
+            null
+        } else {
+            RateLimitCooldown - elapsed
+        }
+    }
+
+    suspend fun trip() = mutex.withLock {
+        trippedAt = TimeSource.Monotonic.markNow()
+    }
+}
 
 class InAppYouTubeExtractor {
     private val log = Logger.withTag(TRAILER_EXTRACTOR_TAG)
@@ -149,76 +263,51 @@ class InAppYouTubeExtractor {
     private suspend fun extractPlaybackSourceInternal(youtubeUrl: String): TrailerPlaybackSource? {
         val videoId = extractVideoId(youtubeUrl) ?: return null
 
-        val watchUrl = "https://www.youtube.com/watch?v=$videoId&hl=en"
-        val watchResponse = TrailerExtractionPlatform.performRequest(
-            url = watchUrl,
-            method = "GET",
-            headers = TrailerExtractionPlatform.defaultHeaders,
-            body = null,
-            timeoutMillis = TRAILER_REQUEST_TIMEOUT_MS,
-        )
-        if (!watchResponse.ok) {
-            throw IllegalStateException("Failed to fetch watch page (${watchResponse.status})")
+        RateLimitGate.remaining()?.let { remaining ->
+            return null
         }
 
-        val watchConfig = getWatchConfig(watchResponse.body)
-        val apiKey = watchConfig.apiKey
-            ?: throw IllegalStateException("Unable to extract INNERTUBE_API_KEY")
+        // The watch page is deliberately NOT fetched up front: it is the first
+        // thing YouTube rate limits, and the player endpoint works fine with the
+        // public key. It is only consulted if every client came back empty.
+        var watchConfig: WatchConfig? = null
 
         val progressive = mutableListOf<StreamCandidate>()
         val adaptiveVideo = mutableListOf<StreamCandidate>()
         val adaptiveAudio = mutableListOf<StreamCandidate>()
         val manifestUrls = mutableListOf<Triple<String, Int, String>>()
+        var definitiveVerdict: UnplayableException? = null
 
-        for (client in CLIENTS) {
-            runCatching {
-                val playerResponse = fetchPlayerResponse(
-                    apiKey = apiKey,
-                    videoId = videoId,
-                    client = client,
-                    visitorData = watchConfig.visitorData,
-                )
-
-                val streamingData = playerResponse.objectValue("streamingData") ?: return@runCatching
-                val hlsManifestUrl = streamingData.stringValue("hlsManifestUrl")
-                if (!hlsManifestUrl.isNullOrBlank()) {
-                    manifestUrls += Triple(client.key, client.priority, hlsManifestUrl)
+        suspend fun queryClients() {
+            for (client in CLIENTS) {
+                // The allowlisted client is tried first and, when it yields anything
+                // playable, the remaining clients are skipped: their URLs are gated
+                // anyway and every extra call brings the device closer to a 429.
+                if (client.key !in PLAYBACK_CLIENT_ALLOWLIST &&
+                    (manifestUrls.isNotEmpty() || progressive.isNotEmpty() || adaptiveVideo.isNotEmpty())
+                ) {
+                    continue
                 }
-
-                for (format in streamingData.listObjectValue("formats")) {
-                    val url = format.stringValue("url") ?: continue
-                    val mimeType = format.stringValue("mimeType").orEmpty()
-                    if (!mimeType.contains("video/") && mimeType.isNotBlank()) continue
-
-                    val height = (
-                        format.numberValue("height")
-                            ?: parseQualityLabel(format.stringValue("qualityLabel"))?.toDouble()
-                            ?: 0.0
-                        ).toInt()
-                    val fps = (format.numberValue("fps") ?: 0.0).toInt()
-                    val bitrate = format.numberValue("bitrate")
-                        ?: format.numberValue("averageBitrate")
-                        ?: 0.0
-
-                    progressive += StreamCandidate(
-                        client = client.key,
-                        priority = client.priority,
-                        url = url,
-                        score = videoScore(height, fps, bitrate),
-                        hasN = hasNParam(url),
-                        height = height,
-                        fps = fps,
-                        ext = if (mimeType.contains("webm")) "webm" else "mp4",
+                runCatching {
+                    val playerResponse = fetchPlayerResponse(
+                        apiKey = watchConfig?.apiKey ?: DEFAULT_INNERTUBE_API_KEY,
+                        videoId = videoId,
+                        client = client,
+                        visitorData = watchConfig?.visitorData,
                     )
-                }
 
-                for (format in streamingData.listObjectValue("adaptiveFormats")) {
-                    val url = format.stringValue("url") ?: continue
-                    val mimeType = format.stringValue("mimeType").orEmpty()
-                    val hasVideo = mimeType.contains("video/")
-                    val hasAudio = mimeType.contains("audio/") || mimeType.startsWith("audio/")
+                    val streamingData = playerResponse.objectValue("streamingData")
+                        ?: throw IllegalStateException("missing streamingData")
+                    val hlsManifestUrl = streamingData.stringValue("hlsManifestUrl")
+                    if (!hlsManifestUrl.isNullOrBlank()) {
+                        manifestUrls += Triple(client.key, client.priority, hlsManifestUrl)
+                    }
 
-                    if (hasVideo) {
+                    for (format in streamingData.listObjectValue("formats")) {
+                        val url = format.stringValue("url") ?: continue
+                        val mimeType = format.stringValue("mimeType").orEmpty()
+                        if (!mimeType.contains("video/") && mimeType.isNotBlank()) continue
+
                         val height = (
                             format.numberValue("height")
                                 ?: parseQualityLabel(format.stringValue("qualityLabel"))?.toDouble()
@@ -229,7 +318,7 @@ class InAppYouTubeExtractor {
                             ?: format.numberValue("averageBitrate")
                             ?: 0.0
 
-                        adaptiveVideo += StreamCandidate(
+                        progressive += StreamCandidate(
                             client = client.key,
                             priority = client.priority,
                             url = url,
@@ -239,31 +328,81 @@ class InAppYouTubeExtractor {
                             fps = fps,
                             ext = if (mimeType.contains("webm")) "webm" else "mp4",
                         )
-                    } else if (hasAudio) {
-                        val bitrate = format.numberValue("bitrate")
-                            ?: format.numberValue("averageBitrate")
-                            ?: 0.0
-                        val audioSampleRate = format.numberValue("audioSampleRate") ?: 0.0
-                        // Multi-language uploads (common for major-studio trailers)
-                        // expose each dub as a separate adaptiveFormats entry with an
-                        // audioTrack.audioIsDefault flag. Formats with no audioTrack
-                        // are the only audio for that video, so treat them as default.
-                        val isDefaultAudioTrack = format.objectValue("audioTrack")
-                            ?.booleanValue("audioIsDefault") ?: true
+                    }
 
-                        adaptiveAudio += StreamCandidate(
-                            client = client.key,
-                            priority = client.priority,
-                            url = url,
-                            score = audioScore(bitrate, audioSampleRate),
-                            hasN = hasNParam(url),
-                            height = 0,
-                            fps = 0,
-                            ext = if (mimeType.contains("webm")) "webm" else "m4a",
-                            isDefaultAudioTrack = isDefaultAudioTrack,
-                        )
+                    for (format in streamingData.listObjectValue("adaptiveFormats")) {
+                        val url = format.stringValue("url") ?: continue
+                        val mimeType = format.stringValue("mimeType").orEmpty()
+                        val hasVideo = mimeType.contains("video/")
+                        val hasAudio = mimeType.contains("audio/") || mimeType.startsWith("audio/")
+
+                        if (hasVideo) {
+                            val height = (
+                                format.numberValue("height")
+                                    ?: parseQualityLabel(format.stringValue("qualityLabel"))?.toDouble()
+                                    ?: 0.0
+                                ).toInt()
+                            val fps = (format.numberValue("fps") ?: 0.0).toInt()
+                            val bitrate = format.numberValue("bitrate")
+                                ?: format.numberValue("averageBitrate")
+                                ?: 0.0
+
+                            adaptiveVideo += StreamCandidate(
+                                client = client.key,
+                                priority = client.priority,
+                                url = url,
+                                score = videoScore(height, fps, bitrate),
+                                hasN = hasNParam(url),
+                                height = height,
+                                fps = fps,
+                                ext = if (mimeType.contains("webm")) "webm" else "mp4",
+                            )
+                        } else if (hasAudio) {
+                            val bitrate = format.numberValue("bitrate")
+                                ?: format.numberValue("averageBitrate")
+                                ?: 0.0
+                            val audioSampleRate = format.numberValue("audioSampleRate") ?: 0.0
+                            // Multi-language uploads (common for major-studio trailers)
+                            // expose each dub as a separate adaptiveFormats entry with an
+                            // audioTrack.audioIsDefault flag. Formats with no audioTrack
+                            // are the only audio for that video, so treat them as default.
+                            val isDefaultAudioTrack = format.objectValue("audioTrack")
+                                ?.booleanValue("audioIsDefault") ?: true
+
+                            adaptiveAudio += StreamCandidate(
+                                client = client.key,
+                                priority = client.priority,
+                                url = url,
+                                score = audioScore(bitrate, audioSampleRate),
+                                hasN = hasNParam(url),
+                                height = 0,
+                                fps = 0,
+                                ext = if (mimeType.contains("webm")) "webm" else "m4a",
+                                isDefaultAudioTrack = isDefaultAudioTrack,
+                            )
+                        }
+                    }
+                }.onFailure {
+                    if (it is UnplayableException) {
+                        definitiveVerdict = it
                     }
                 }
+                }
+        }
+
+        queryClients()
+
+        // Everything came back empty: the constant key or a stale visitor id may
+        // be the reason, so the watch page is tried once as a last resort.
+        definitiveVerdict?.let { verdict ->
+            return null
+        }
+
+        if (manifestUrls.isEmpty() && progressive.isEmpty() && adaptiveVideo.isEmpty() && adaptiveAudio.isEmpty()) {
+            val fetched = runCatching { fetchWatchConfig(videoId) }.getOrNull()
+            if (fetched?.apiKey != null) {
+                watchConfig = fetched
+                queryClients()
             }
         }
 
@@ -271,11 +410,16 @@ class InAppYouTubeExtractor {
             return null
         }
 
-        var bestManifest: ManifestCandidate? = null
-        for ((clientKey, priority, manifestUrl) in manifestUrls) {
+        val playbackManifestUrls = manifestUrls.preferPlaybackClients { it.first }
+        val playbackProgressive = progressive.preferPlaybackClients { it.client }
+        val playbackVideo = adaptiveVideo.preferPlaybackClients { it.client }
+        val playbackAudio = adaptiveAudio.preferPlaybackClients { it.client }
+
+        val manifestCandidates = mutableListOf<ManifestCandidate>()
+        for ((clientKey, priority, manifestUrl) in playbackManifestUrls) {
             runCatching {
                 val variant = parseHlsManifest(manifestUrl) ?: return@runCatching
-                val candidate = ManifestCandidate(
+                manifestCandidates += ManifestCandidate(
                     client = clientKey,
                     priority = priority,
                     manifestUrl = manifestUrl,
@@ -283,26 +427,53 @@ class InAppYouTubeExtractor {
                     height = variant.height,
                     bandwidth = variant.bandwidth,
                 )
-                if (
-                    bestManifest == null ||
-                    candidate.height > bestManifest.height ||
-                    (candidate.height == bestManifest.height && candidate.bandwidth > bestManifest.bandwidth)
-                ) {
-                    bestManifest = candidate
-                }
             }
         }
+        manifestCandidates.sortWith(
+            compareByDescending<ManifestCandidate> { it.height }
+                .thenByDescending { it.bandwidth }
+                .thenBy { it.priority },
+        )
 
-        val bestProgressive = sortCandidates(progressive).firstOrNull()
-        val bestVideo = pickBestForClient(adaptiveVideo, PREFERRED_SEPARATE_CLIENT)
-        val bestAudio = pickBestForClient(adaptiveAudio, PREFERRED_SEPARATE_CLIENT)
+        val progressiveCandidates = sortCandidates(playbackProgressive)
+        val videoCandidates = sortCandidates(playbackVideo)
+        val audioCandidates = sortCandidates(playbackAudio)
 
         return TrailerExtractionPlatform.buildPlaybackSource(
-            bestManifest = bestManifest,
-            bestProgressive = bestProgressive,
-            bestVideo = bestVideo,
-            bestAudio = bestAudio,
+            manifestCandidates = manifestCandidates,
+            progressiveCandidates = progressiveCandidates,
+            videoCandidates = videoCandidates,
+            audioCandidates = audioCandidates,
         )
+    }
+
+    // Keeps only candidates minted by a playback-safe client, falling back to
+    // the untrusted ones when that leaves nothing to play.
+    private fun <T> List<T>.preferPlaybackClients(clientOf: (T) -> String): List<T> {
+        val allowed = filter { clientOf(it) in PLAYBACK_CLIENT_ALLOWLIST }
+        if (allowed.isNotEmpty()) return allowed
+        if (isNotEmpty()) {
+        }
+        return this
+    }
+
+    private suspend fun fetchWatchConfig(videoId: String): WatchConfig = WatchConfigCache.get {
+        val watchUrl = "https://www.youtube.com/watch?v=$videoId&hl=en"
+        val watchResponse = TrailerExtractionPlatform.performRequest(
+            url = watchUrl,
+            method = "GET",
+            headers = TrailerExtractionPlatform.defaultHeaders,
+            body = null,
+            timeoutMillis = TRAILER_REQUEST_TIMEOUT_MS,
+        )
+        if (watchResponse.status == 429) {
+            RateLimitGate.trip()
+            throw IllegalStateException("Rate limited by YouTube (429)")
+        }
+        if (!watchResponse.ok) {
+            throw IllegalStateException("Failed to fetch watch page (${watchResponse.status})")
+        }
+        getWatchConfig(watchResponse.body)
     }
 
     private suspend fun fetchPlayerResponse(
@@ -341,13 +512,37 @@ class InAppYouTubeExtractor {
             timeoutMillis = TRAILER_REQUEST_TIMEOUT_MS,
         )
 
+        if (response.status == 429) {
+            RateLimitGate.trip()
+            throw IllegalStateException("Rate limited by YouTube (429)")
+        }
         if (!response.ok) {
             val preview = response.body.take(200)
             throw IllegalStateException("player API ${client.key} failed (${response.status}): $preview")
         }
 
         val parsed = JSON.parseToJsonElement(response.body)
-        return parsed as? JsonObject ?: JsonObject(emptyMap())
+        val playerResponse = parsed as? JsonObject ?: JsonObject(emptyMap())
+
+        val playability = playerResponse.objectValue("playabilityStatus")
+        val playabilityStatus = playability?.stringValue("status")
+        val playabilityReason = playability?.stringValue("reason").orEmpty()
+        if (playabilityStatus != null && playabilityStatus != "OK") {
+            // "Sign in to confirm you're not a bot" is per client: the rare clients
+            // (visionos, android_vr, tvhtml5) get challenged long before ANDROID
+            // and IOS do. Only this client is abandoned - the loop still falls
+            // through to the others, whose progressive stream stays playable.
+            if (playabilityStatus == "LOGIN_REQUIRED" || playabilityReason.contains("bot", ignoreCase = true)) {
+                throw BotCheckException(client.key, playabilityStatus)
+            }
+            // UNPLAYABLE / ERROR are final: no client and no fresh visitor id will
+            // produce streams for a video that is geo blocked or gone.
+            if (playabilityStatus == "UNPLAYABLE" || playabilityStatus == "ERROR") {
+                throw UnplayableException(playabilityStatus, playabilityReason)
+            }
+        }
+
+        return playerResponse
     }
 
     private suspend fun parseHlsManifest(manifestUrl: String): ManifestBestVariant? {
@@ -523,14 +718,6 @@ class InAppYouTubeExtractor {
         )
     }
 
-    private fun pickBestForClient(items: List<StreamCandidate>, clientKey: String): StreamCandidate? {
-        val sameClient = items.filter { it.client == clientKey }
-        if (sameClient.isNotEmpty()) {
-            return sortCandidates(sameClient).firstOrNull()
-        }
-        return sortCandidates(items).firstOrNull()
-    }
-
     private fun containerPreference(ext: String): Int {
         return when (ext.lowercase()) {
             "mp4", "m4a" -> 0
@@ -665,3 +852,5 @@ private fun toJsonElement(value: Any): JsonElement {
         else -> JsonPrimitive(value.toString())
     }
 }
+
+

--- a/composeApp/src/iosFull/kotlin/com/nuvio/app/features/trailer/TrailerExtractionPlatform.ios.kt
+++ b/composeApp/src/iosFull/kotlin/com/nuvio/app/features/trailer/TrailerExtractionPlatform.ios.kt
@@ -20,6 +20,9 @@ import kotlinx.coroutines.withTimeoutOrNull
 import platform.Foundation.NSURLComponents
 import platform.Foundation.NSURLQueryItem
 
+private const val PROBE_TIMEOUT_MS = 5_000L
+private const val PROBE_RACE_TIMEOUT_MS = 8_000L
+
 internal object TrailerExtractionPlatform {
     val defaultHeaders: Map<String, String> = mapOf(
         "accept-language" to "en-US,en;q=0.9",
@@ -72,78 +75,142 @@ internal object TrailerExtractionPlatform {
     }
 
     suspend fun buildPlaybackSource(
-        bestManifest: ManifestCandidate?,
-        bestProgressive: StreamCandidate?,
-        bestVideo: StreamCandidate?,
-        bestAudio: StreamCandidate?,
+        manifestCandidates: List<ManifestCandidate>,
+        progressiveCandidates: List<StreamCandidate>,
+        videoCandidates: List<StreamCandidate>,
+        audioCandidates: List<StreamCandidate>,
     ): TrailerPlaybackSource? = withContext(Dispatchers.Default) {
-        val bestManifestHeight = bestManifest?.height ?: -1
-        val bestCombinedIsManifest = bestManifest != null &&
-            (bestProgressive == null || bestManifestHeight > bestProgressive.height)
+        // A candidate can look fine and still be unplayable: PO token gated URLs
+        // answer the first range and 403 everything after it. Every candidate is
+        // probed and the first one that survives wins.
+        var videoOnlyFallback: String? = null
+        // One rejection condemns a whole client: the gate applies to all of its
+        // adaptive formats, so there is no point probing its siblings.
+        val gatedClients = mutableSetOf<String>()
 
-        val combinedUrl = if (bestCombinedIsManifest) {
-            bestManifest.manifestUrl
-        } else {
-            bestProgressive?.url
+        suspend fun fromManifests(): TrailerPlaybackSource? {
+            for (candidate in manifestCandidates.take(MAX_CANDIDATE_ATTEMPTS)) {
+                val url = resolveReachableUrlOrNull(candidate.manifestUrl) ?: continue
+                return TrailerPlaybackSource(videoUrl = url, audioUrl = null)
+            }
+            return null
         }
 
-        val videoUrl = resolveReachableUrl(bestVideo?.url ?: combinedUrl ?: return@withContext null)
-        val audioUrl = bestAudio?.url?.let { resolveReachableUrl(it) }
+        suspend fun fromSeparateStreams(): TrailerPlaybackSource? {
+            for (video in videoCandidates.take(MAX_CANDIDATE_ATTEMPTS)) {
+                if (video.client in gatedClients) continue
+                val videoUrl = resolveReachableUrlOrNull(video.url)
+                if (videoUrl == null) {
+                    gatedClients += video.client
+                    continue
+                }
+                for (audio in audioCandidates.take(MAX_CANDIDATE_ATTEMPTS)) {
+                    val audioUrl = resolveReachableUrlOrNull(audio.url) ?: continue
+                    return TrailerPlaybackSource(videoUrl = videoUrl, audioUrl = audioUrl)
+                }
+                // Video is reachable but no audio track survived: remember it and
+                // let the other strategies try to produce a source with sound.
+                if (videoOnlyFallback == null) {
+                    videoOnlyFallback = videoUrl
+                }
+                break
+            }
+            return null
+        }
 
-        TrailerPlaybackSource(
-            videoUrl = videoUrl,
-            audioUrl = audioUrl,
-        )
+        suspend fun fromProgressive(): TrailerPlaybackSource? {
+            for (candidate in progressiveCandidates.take(MAX_CANDIDATE_ATTEMPTS)) {
+                val url = resolveReachableUrlOrNull(candidate.url) ?: continue
+                return TrailerPlaybackSource(videoUrl = url, audioUrl = null)
+            }
+            return null
+        }
+
+        val manifestHeight = manifestCandidates.firstOrNull()?.height ?: -1
+        val separateHeight = videoCandidates.firstOrNull()?.height ?: -1
+        val strategies: List<suspend () -> TrailerPlaybackSource?> = if (manifestHeight >= separateHeight) {
+            listOf({ fromManifests() }, { fromSeparateStreams() }, { fromProgressive() })
+        } else {
+            listOf({ fromSeparateStreams() }, { fromManifests() }, { fromProgressive() })
+        }
+
+        for (strategy in strategies) {
+            strategy()?.let { return@withContext it }
+        }
+
+        videoOnlyFallback?.let { videoUrl ->
+            return@withContext TrailerPlaybackSource(videoUrl = videoUrl, audioUrl = null)
+        }
+
+        null
     }
 
-    private suspend fun resolveReachableUrl(url: String): String {
+    private suspend fun resolveReachableUrlOrNull(url: String): String? {
         if (!url.contains("googlevideo.com")) return url
 
-        val mnParam = getQueryParameter(url, "mn") ?: return url
-        val servers = mnParam.split(',').map { it.trim() }.filter { it.isNotBlank() }
-        if (servers.size < 2) return url
+        val servers = getQueryParameter(url, "mn")
+            ?.split(',')
+            ?.map { it.trim() }
+            ?.filter { it.isNotBlank() }
+            .orEmpty()
+        val host = getHost(url)
 
-        val host = getHost(url) ?: return url
-        val candidates = mutableListOf(url)
-
-        servers.forEachIndexed { index, server ->
-            val altHost = host
-                .replaceFirst(Regex("^rr\\d+---"), "rr${index + 1}---")
-                .replaceFirst(Regex("sn-[a-z0-9]+-[a-z0-9]+"), server)
-            if (altHost != host) {
-                candidates += url.replace(host, altHost)
+        val candidates = buildList {
+            add(url)
+            if (host != null) {
+                servers.forEachIndexed { index, server ->
+                    val altHost = host
+                        .replaceFirst(Regex("^rr\\d+---"), "rr${index + 1}---")
+                        .replaceFirst(Regex("sn-[a-z0-9]+-[a-z0-9]+"), server)
+                    if (altHost != host) {
+                        add(url.replace(host, altHost))
+                    }
+                }
             }
-        }
+        }.distinct()
 
-        if (candidates.size == 1) return candidates.first()
+        if (candidates.size == 1) {
+            return candidates.first().takeIf { isUrlReachable(it) }
+        }
 
         return coroutineScope {
             val probes = candidates.map { candidate ->
-                async {
-                    if (isUrlReachable(candidate)) candidate else null
-                }
+                async { if (isUrlReachable(candidate)) candidate else null }
             }
-            withTimeoutOrNull(2_000L) {
+            withTimeoutOrNull(PROBE_RACE_TIMEOUT_MS) {
                 probes.awaitAll().firstOrNull { !it.isNullOrBlank() }
-            } ?: url
+            }
         }
     }
 
+    // A single head range probe is not enough: gated URLs answer the first chunk
+    // and 403 the rest, so the tail is probed too whenever the length is known.
     private suspend fun isUrlReachable(url: String): Boolean {
-        val response = runCatching {
-            performRequest(
-                url = url,
-                method = "GET",
-                headers = mapOf(
-                    "range" to "bytes=0-0",
-                    "user-agent" to defaultHeaders.getValue("user-agent"),
-                ),
-                body = null,
-                timeoutMillis = 2_000L,
-            )
-        }.getOrNull() ?: return false
+        val sourceSize = getQueryParameter(url, "clen")?.toLongOrNull()?.takeIf { it > 0L }
+        val ranges = sourceSize?.let { size ->
+            listOf(
+                0L to 65_535L.coerceAtMost(size - 1L),
+                (size - 65_536L).coerceAtLeast(0L) to size - 1L,
+            ).distinct()
+        } ?: listOf(0L to 0L)
 
-        return response.status in 200..299
+        return ranges.all { (rangeStart, rangeEnd) ->
+            val response = runCatching {
+                performRequest(
+                    url = url,
+                    method = "GET",
+                    headers = mapOf(
+                        "range" to "bytes=$rangeStart-$rangeEnd",
+                        "user-agent" to defaultHeaders.getValue("user-agent"),
+                    ),
+                    body = null,
+                    timeoutMillis = PROBE_TIMEOUT_MS,
+                )
+            }.getOrNull() ?: return false
+
+            response.status == 206 ||
+                (sourceSize == null && rangeStart == 0L && response.status in 200..299)
+        }
     }
 
     private fun getHost(url: String): String? {


### PR DESCRIPTION
## Summary

Trailers stop failing with `[ffmpeg] https: HTTP error 403 Forbidden`, and resolution no longer depends on the watch page that YouTube rate limits first. Reachability probing now detects PO token gated URLs, and resolution falls back through HLS, separate audio/video and finally `ANDROID` progressive itag 18, so a trailer keeps playing at lower quality instead of failing.

## PR type

- [x] Behavior bug/regression fix

## Why

Two independent causes, both measured directly and documented in #1857.

**1. `isUrlReachable` probes with `range: bytes=0-0`, which cannot see PO token gating.**
`ANDROID` and `IOS` adaptive URLs answer the first range and then reject every later range. This is independent of User-Agent (tested Chrome, Safari, `Lavf` and each client's own UA) and independent of itag:

| Client that minted the URL | `bytes=0-65535` | tail range | full GET |
|---|---|---|---|
| IOS (itag 137) | 206 | 403 | 403 |
| ANDROID (itag 137, 136, 134, 140, 251) | 206 | 403 | 403 |
| ANDROID (itag 18, progressive) | 206 | n/a | 200, downloads fully |
| VISIONOS (itag 137) | 206 | 206 | 200 |

The head range always succeeds, so a dead URL passed validation and mpv/ffmpeg then 403'd on the next range, which is the exact error users see.

**2. Extraction required the watch page, which is the first thing YouTube rate limits.**
`extractPlaybackSourceInternal` fetched the watch page (1.1-1.4 MB) before every player call, only to scrape `INNERTUBE_API_KEY` and `VISITOR_DATA`, and threw when that failed. Once the device is flagged the page returns 429 and then a 302 to a 407 byte error page, so extraction died before any player call. Measured at that same moment:

| Video | Player API (ANDROID) | Progressive itag 18 |
|---|---|---|
| `MAbjq7ydKDI` | `OK` with and without a key | full GET 200, 10,139,298 bytes |
| `8ZYhuvIv1pA` | `OK` with and without a key | full GET 200, 4,282,937 bytes |

`INNERTUBE_API_KEY` is a public constant present in every YouTube page (the same value this code already scraped), so it is used directly and the watch page is only consulted if every client returned nothing.

## Issue or approval

Fixes #1857. Same fix for desktop: NuvioMedia/NuvioDesktop#552 (issue NuvioMedia/NuvioDesktop#584).

(The first filing, #1829, was closed by the unlabeled-issue bot before triage because an outside contributor cannot set labels from the API. #1857 is the same report submitted through the bug template so it carries the `bug` label.)

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## What changed

Three files: the shared extractor plus the iOS and Android `TrailerExtractionPlatform` actuals.

- Reachability requires head **and** tail ranges (tail only when `clen` is present), so gated URLs are rejected instead of reaching the player. One rejection condemns the rest of that client's adaptive formats, so its siblings are not probed.
- `buildPlaybackSource` now receives candidate lists rather than one pre-picked candidate per kind, and tries HLS, then separate streams, then progressive, taking the first that probes clean. A video only source is kept as a last resort so a silent trailer never wins over one with audio.
- Watch page is off the hot path: the public constant key is used, and the page is scraped only when every client came back empty.
- Clients whose URLs are not gated (`visionos`, `android_vr`) are preferred, and the remaining clients are skipped once one of them produced candidates. Typical extraction is one player call instead of three, plus no 1.4 MB page fetch.
- Client versions refreshed: android `20.10.35` to `21.26.364`, ios `20.10.1` to `21.26.4`, and `android_vr` added. Stale versions attract bot challenges on their own.
- `UNPLAYABLE` and `ERROR` are final for that video (geo blocks, removed videos) instead of being retried.
- After an HTTP 429 the extractor backs off for 15 minutes instead of retrying per trailer, per hover and per hero. Request volume from a single residential IP is what gets a whole network flagged (NuvioMedia/NuvioTV#2451 reports YouTube blocking every device behind the IP).

## Scope boundaries

Intentionally not included:

- No caching of resolved URLs. Desktop caches them; this repository does not, and I kept it that way to stay inside the scope of this bug. It is worth adding separately, since re-resolving on every hero, hover and popup is a large part of the request volume that triggers flagging.
- No UI or copy changes, and no changes to hero trailer or hover preview call sites.
- No PO token / BotGuard support and no cookie support. Both address the underlying bot check more completely and both deserve their own feature request.
- No new diagnostics or logging, to keep the diff limited to behavior.

## Testing

Manual, iOS, plus compile checks:

1. Built an unsigned release ipa from this branch with `scripts/build-ios-ipa.sh` and installed it on an iPhone. Trailers play, including titles that previously failed with the ffmpeg 403.
2. Reproduced the original failures first on the previous code: the ffmpeg 403 on adaptive URLs, and total failure once the IP was flagged.
3. Verified a geo blocked trailer ("The uploader has not made this video available in your country") now fails on its own and does not affect the next trailer.
4. Verified the gate behaviour outside the app by replaying the same requests and comparing head range, tail range and full GET per client and per itag (tables above).
5. `./gradlew :composeApp:compileKotlinIosArm64` and `./gradlew :composeApp:compileAndroidMain` both pass.

Android was validated by compilation only; I do not have an Android device to hand, and the Android platform change is the same probe and fallback logic as iOS.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1857. Related: NuvioMedia/NuvioDesktop#584, NuvioMedia/NuvioDesktop#552, NuvioMedia/NuvioTV#2451.
