### PR TITLE
fix(details): optimize large vertical episode lists

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -51,6 +52,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -100,6 +102,8 @@ import com.nuvio.app.features.details.components.DetailMetaInfo
 import com.nuvio.app.features.details.components.DetailPosterRailSection
 import com.nuvio.app.features.details.components.DetailProductionSection
 import com.nuvio.app.features.details.components.DetailSeriesContent
+import com.nuvio.app.features.details.components.DetailSeriesListEpisode
+import com.nuvio.app.features.details.components.DetailSeriesListHeader
 import com.nuvio.app.features.details.components.DetailTrailersSection
 import com.nuvio.app.features.details.components.EpisodeWatchedActionSheet
 import com.nuvio.app.features.details.components.SeasonWatchedActionSheet
@@ -601,6 +605,29 @@ fun MetaDetailsScreen(
                     seriesActionVideo?.id?.takeIf { it.isNotBlank() } ?: action.videoId
                 }
                 val hasEpisodes = meta.videos.any { it.season != null || it.episode != null }
+                val episodeListGroupedEpisodes = remember(
+                    meta.videos,
+                    meta.type,
+                    metaScreenSettingsUiState.episodeCardStyle,
+                ) {
+                    if (metaScreenSettingsUiState.episodeCardStyle == MetaEpisodeCardStyle.List) {
+                        meta.groupedEpisodesForDisplay()
+                    } else {
+                        emptyMap()
+                    }
+                }
+                val episodeListSeasons = remember(episodeListGroupedEpisodes) {
+                    episodeListGroupedEpisodes.keys.sortedBy(::seasonSortKey)
+                }
+                var selectedEpisodeListSeason by rememberSaveable(meta.id) {
+                    mutableStateOf<Int?>(null)
+                }
+                val defaultEpisodeListSeason = seriesAction?.seasonNumber
+                    ?.takeIf { it in episodeListGroupedEpisodes }
+                    ?: episodeListSeasons.firstOrNull()
+                val currentEpisodeListSeason = selectedEpisodeListSeason
+                    ?.takeIf { it in episodeListGroupedEpisodes }
+                    ?: defaultEpisodeListSeason
                 val hasProductionSection = remember(meta) {
                     meta.productionCompanies.isNotEmpty() || meta.networks.isNotEmpty()
                 }
@@ -1065,6 +1092,10 @@ fun MetaDetailsScreen(
                                 commentsPageCount = commentsPageCount,
                                 commentsError = commentsError,
                                 episodeImdbRatings = episodeImdbRatings,
+                                episodeListGroupedEpisodes = episodeListGroupedEpisodes,
+                                episodeListSeasons = episodeListSeasons,
+                                episodeListCurrentSeason = currentEpisodeListSeason,
+                                onEpisodeListSeasonSelect = { selectedEpisodeListSeason = it },
                                 onRetryComments = {
                                     detailsScope.launch {
                                         isCommentsLoading = true
@@ -1738,6 +1769,10 @@ private fun LazyListScope.configuredMetaSectionItems(
     commentsPageCount: Int,
     commentsError: String?,
     episodeImdbRatings: Map<Pair<Int, Int>, Double>,
+    episodeListGroupedEpisodes: Map<Int, List<MetaVideo>>,
+    episodeListSeasons: List<Int>,
+    episodeListCurrentSeason: Int?,
+    onEpisodeListSeasonSelect: (Int) -> Unit,
     onRetryComments: () -> Unit,
     onLoadMoreComments: () -> Unit,
     onCommentClick: (TraktCommentReview) -> Unit,
@@ -1834,14 +1869,80 @@ private fun LazyListScope.configuredMetaSectionItems(
         }
     }
 
+    fun addLazyEpisodeListItems(key: String) {
+        val currentSeason = episodeListCurrentSeason ?: return
+        val episodes = episodeListGroupedEpisodes[currentSeason].orEmpty()
+        if (episodes.isEmpty()) return
+
+        item(
+            key = "$key-header",
+            contentType = "detail-episode-header",
+        ) {
+            DetailSectionContainer(
+                horizontalPadding = contentHorizontalPadding,
+                contentMaxWidth = contentMaxWidth,
+                bottomPadding = 12.dp,
+            ) {
+                DetailSeriesListHeader(
+                    meta = meta,
+                    groupedEpisodes = episodeListGroupedEpisodes,
+                    seasons = episodeListSeasons,
+                    currentSeason = currentSeason,
+                    horizontalScrollPadding = contentHorizontalPadding,
+                    onSeasonSelect = onEpisodeListSeasonSelect,
+                    onSeasonLongPress = onSeasonLongPress,
+                )
+            }
+        }
+        itemsIndexed(
+            items = episodes,
+            key = { index, episode ->
+                "$key-episode-$currentSeason-${episode.episode}-${episode.id}-$index"
+            },
+            contentType = { _, _ -> "detail-episode" },
+        ) { index, episode ->
+            DetailSectionContainer(
+                horizontalPadding = contentHorizontalPadding,
+                contentMaxWidth = contentMaxWidth,
+                bottomPadding = if (index == episodes.lastIndex) 20.dp else 12.dp,
+            ) {
+                DetailSeriesListEpisode(
+                    meta = meta,
+                    episode = episode,
+                    progressByVideoId = progressByVideoId,
+                    watchedKeys = watchedKeys,
+                    episodeRatings = episodeImdbRatings,
+                    blurUnwatchedEpisodes = blurUnwatchedEpisodes,
+                    onEpisodeClick = onEpisodeClick,
+                    onEpisodeLongPress = onEpisodeLongPress,
+                )
+            }
+        }
+    }
+
+    fun addStandaloneSection(
+        section: MetaScreenSectionItem,
+        key: String,
+        forceTabLayout: Boolean = false,
+    ) {
+        if (section.key == MetaScreenSectionKey.EPISODES && settings.episodeCardStyle == MetaEpisodeCardStyle.List) {
+            addLazyEpisodeListItems(key)
+        } else {
+            addSectionItem(
+                key = key,
+                sectionItems = listOf(section),
+                forceTabLayout = forceTabLayout,
+            )
+        }
+    }
+
     if (!settings.tabLayout) {
         enabledItems
             .filter { sectionHasContent(it.key) }
             .forEach { section ->
-                addSectionItem(
+                addStandaloneSection(
+                    section = section,
                     key = "detail-section-${section.key.name}",
-                    sectionItems = listOf(section),
-                    forceTabLayout = false,
                 )
             }
         return
@@ -1849,26 +1950,33 @@ private fun LazyListScope.configuredMetaSectionItems(
 
     val processedGroups = mutableSetOf<Int>()
     enabledItems.forEach { section ->
-        val groupId = section.tabGroup
+        val groupId = section.tabGroupForRendering(settings.episodeCardStyle)
         if (groupId == null) {
             if (sectionHasContent(section.key)) {
-                addSectionItem(
+                addStandaloneSection(
+                    section = section,
                     key = "detail-section-${section.key.name}",
-                    sectionItems = listOf(section),
                     forceTabLayout = true,
                 )
             }
         } else if (groupId !in processedGroups) {
             processedGroups.add(groupId)
             val groupMembers = enabledItems.filter { item ->
-                item.tabGroup == groupId && sectionHasContent(item.key)
+                item.tabGroupForRendering(settings.episodeCardStyle) == groupId && sectionHasContent(item.key)
             }
             if (groupMembers.isNotEmpty()) {
-                addSectionItem(
-                    key = "detail-section-group-$groupId",
-                    sectionItems = groupMembers,
-                    forceTabLayout = groupMembers.size > 1,
-                )
+                if (groupMembers.size == 1) {
+                    addStandaloneSection(
+                        section = groupMembers.single(),
+                        key = "detail-section-group-$groupId",
+                    )
+                } else {
+                    addSectionItem(
+                        key = "detail-section-group-$groupId",
+                        sectionItems = groupMembers,
+                        forceTabLayout = true,
+                    )
+                }
             }
         }
     }
@@ -1878,13 +1986,14 @@ private fun LazyListScope.configuredMetaSectionItems(
 private fun DetailSectionContainer(
     horizontalPadding: Dp,
     contentMaxWidth: Dp,
+    bottomPadding: Dp = 20.dp,
     content: @Composable () -> Unit,
 ) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = horizontalPadding)
-            .padding(bottom = 20.dp),
+            .padding(bottom = bottomPadding),
         contentAlignment = Alignment.Center,
     ) {
         Box(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaScreenSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaScreenSettingsRepository.kt
@@ -97,6 +97,16 @@ enum class MetaEpisodeCardStyle {
     }
 }
 
+internal fun MetaScreenSectionItem.tabGroupForRendering(
+    episodeCardStyle: MetaEpisodeCardStyle,
+): Int? = if (
+    key == MetaScreenSectionKey.EPISODES && episodeCardStyle == MetaEpisodeCardStyle.List
+) {
+    null
+} else {
+    tabGroup
+}
+
 @Serializable
 private data class StoredMetaScreenSectionPreference(
     val key: String,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/SeriesSeasonSupport.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/SeriesSeasonSupport.kt
@@ -29,3 +29,14 @@ internal fun preferredEpisodeNumberForSeason(
     preferredSeasonNumber: Int?,
     preferredEpisodeNumber: Int?,
 ): Int? = preferredEpisodeNumber.takeIf { displayedSeasonNumber == preferredSeasonNumber }
+
+internal fun MetaDetails.groupedEpisodesForDisplay(): Map<Int, List<MetaVideo>> {
+    val numberedEpisodes = videos.filter { it.season != null || it.episode != null }
+    return when {
+        numberedEpisodes.isNotEmpty() -> numberedEpisodes
+            .sortedWith(metaVideoSeasonEpisodeComparator)
+            .groupBy { normalizeSeasonNumber(it.season) }
+        type != "series" && videos.isNotEmpty() -> mapOf(normalizeSeasonNumber(null) to videos)
+        else -> emptyMap()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/components/DetailSeriesContent.kt
@@ -76,8 +76,7 @@ import com.nuvio.app.features.details.MetaVideo
 import com.nuvio.app.features.details.SeasonViewMode
 import com.nuvio.app.features.details.SeasonViewModeStorage
 import com.nuvio.app.features.details.formatRuntimeFromMinutes
-import com.nuvio.app.features.details.metaVideoSeasonEpisodeComparator
-import com.nuvio.app.features.details.normalizeSeasonNumber
+import com.nuvio.app.features.details.groupedEpisodesForDisplay
 import com.nuvio.app.features.details.preferredEpisodeNumberForSeason
 import com.nuvio.app.features.details.seasonSortKey
 import com.nuvio.app.features.watchprogress.WatchProgressEntry
@@ -140,16 +139,7 @@ fun DetailSeriesContent(
         if (meta.videos.isNotEmpty() && withSeasonOrEp.isEmpty()) {
             log.w { "All videos lack season/episode fields! First: ${meta.videos.first()}" }
         }
-        if (withSeasonOrEp.isNotEmpty()) {
-            withSeasonOrEp
-                .sortedWith(metaVideoSeasonEpisodeComparator)
-                .groupBy { normalizeSeasonNumber(it.season) }
-        } else if (meta.type != "series" && meta.videos.isNotEmpty()) {
-            // For non-series types (e.g. "other"), show videos without season/episode as a flat list
-            mapOf(normalizeSeasonNumber(null) to meta.videos)
-        } else {
-            emptyMap()
-        }
+        meta.groupedEpisodesForDisplay()
     }
 
     if (groupedEpisodes.isEmpty()) {
@@ -178,10 +168,6 @@ fun DetailSeriesContent(
         ?.takeIf { it in groupedEpisodes }
         ?: defaultSeason
 
-    var seasonViewMode by remember {
-        mutableStateOf(SeasonViewModeStorage.load() ?: SeasonViewMode.Posters)
-    }
-
     BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
         val sizing = seriesContentSizing(maxWidth.value)
         val containerWidthDp = maxWidth.value
@@ -189,83 +175,16 @@ fun DetailSeriesContent(
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            if (seasons.size > 1) {
-                val hasSeasonPosters = seasons.any { season ->
-                    resolveSeasonPoster(
-                        season = season,
-                        groupedEpisodes = groupedEpisodes,
-                        meta = meta,
-                    ) != null
-                }
-                Column(
-                    modifier = Modifier.animateContentSize(animationSpec = tween(280)),
-                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                ) {
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(Res.string.details_seasons),
-                            style = MaterialTheme.typography.titleLarge.copy(
-                                fontSize = sizing.seasonHeaderSize,
-                                fontWeight = FontWeight.SemiBold,
-                            ),
-                            color = MaterialTheme.colorScheme.onBackground,
-                        )
-                        if (hasSeasonPosters) {
-                            SeasonViewModeToggle(
-                                mode = seasonViewMode,
-                                sizing = sizing,
-                                onClick = {
-                                    val next = seasonViewMode.toggled()
-                                    seasonViewMode = next
-                                    SeasonViewModeStorage.save(next)
-                                },
-                            )
-                        }
-                    }
-
-                    if (hasSeasonPosters) {
-                        Crossfade(
-                            targetState = seasonViewMode,
-                            animationSpec = tween(280),
-                            label = "season_selector_layout",
-                        ) { mode ->
-                            when (mode) {
-                                SeasonViewMode.Posters -> SeasonPosterScrollRow(
-                                    seasons = seasons,
-                                    groupedEpisodes = groupedEpisodes,
-                                    meta = meta,
-                                    currentSeason = currentSeason,
-                                    sizing = sizing,
-                                    horizontalScrollPadding = horizontalScrollPadding,
-                                    onSelect = { selectedSeasonOverride = it },
-                                    onLongPress = onSeasonLongPress,
-                                )
-                                SeasonViewMode.Text -> SeasonTextChipScrollRow(
-                                    seasons = seasons,
-                                    currentSeason = currentSeason,
-                                    sizing = sizing,
-                                    horizontalScrollPadding = horizontalScrollPadding,
-                                    onSelect = { selectedSeasonOverride = it },
-                                    onLongPress = onSeasonLongPress,
-                                )
-                            }
-                        }
-                    } else {
-                        SeasonTextChipScrollRow(
-                            seasons = seasons,
-                            currentSeason = currentSeason,
-                            sizing = sizing,
-                            horizontalScrollPadding = horizontalScrollPadding,
-                            onSelect = { selectedSeasonOverride = it },
-                            onLongPress = onSeasonLongPress,
-                        )
-                    }
-                }
-            }
+            SeriesSeasonSelector(
+                meta = meta,
+                seasons = seasons,
+                groupedEpisodes = groupedEpisodes,
+                currentSeason = currentSeason,
+                sizing = sizing,
+                horizontalScrollPadding = horizontalScrollPadding,
+                onSelect = { selectedSeasonOverride = it },
+                onLongPress = onSeasonLongPress,
+            )
 
             AnimatedContent(
                 targetState = currentSeason,
@@ -345,6 +264,174 @@ fun DetailSeriesContent(
                     }
                 }
             }
+        }
+    }
+}
+
+@Composable
+internal fun DetailSeriesListHeader(
+    meta: MetaDetails,
+    groupedEpisodes: Map<Int, List<MetaVideo>>,
+    seasons: List<Int>,
+    currentSeason: Int,
+    horizontalScrollPadding: Dp,
+    onSeasonSelect: (Int) -> Unit,
+    onSeasonLongPress: ((Int) -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val sizing = seriesContentSizing(maxWidth.value)
+        Column(verticalArrangement = Arrangement.spacedBy(16.dp)) {
+            SeriesSeasonSelector(
+                meta = meta,
+                seasons = seasons,
+                groupedEpisodes = groupedEpisodes,
+                currentSeason = currentSeason,
+                sizing = sizing,
+                horizontalScrollPadding = horizontalScrollPadding,
+                onSelect = onSeasonSelect,
+                onLongPress = onSeasonLongPress,
+            )
+            DetailSectionTitle(
+                title = if (meta.type != "series" && seasons.size == 1 && currentSeason <= 0) {
+                    stringResource(Res.string.details_videos)
+                } else {
+                    currentSeason.label()
+                },
+            )
+        }
+    }
+}
+
+@Composable
+internal fun DetailSeriesListEpisode(
+    meta: MetaDetails,
+    episode: MetaVideo,
+    progressByVideoId: Map<String, WatchProgressEntry>,
+    watchedKeys: Set<String>,
+    episodeRatings: Map<Pair<Int, Int>, Double>,
+    blurUnwatchedEpisodes: Boolean,
+    onEpisodeClick: ((MetaVideo) -> Unit)?,
+    onEpisodeLongPress: ((MetaVideo) -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    BoxWithConstraints(modifier = modifier.fillMaxWidth()) {
+        val sizing = seriesContentSizing(maxWidth.value)
+        val episodeVideoId = buildPlaybackVideoId(
+            parentMetaId = meta.id,
+            seasonNumber = episode.season,
+            episodeNumber = episode.episode,
+            fallbackVideoId = episode.id,
+        )
+        EpisodeListCard(
+            video = episode,
+            fallbackImage = meta.background ?: meta.poster,
+            progressEntry = progressByVideoId[episodeVideoId],
+            imdbRating = episode.seasonEpisodeKey()?.let { episodeRatings[it] } ?: episode.rating,
+            isWatched = progressByVideoId[episodeVideoId]?.isEffectivelyCompleted == true ||
+                WatchingState.isEpisodeWatched(
+                    watchedKeys = watchedKeys,
+                    metaType = meta.type,
+                    metaId = meta.id,
+                    episode = episode,
+                ),
+            blurUnwatchedEpisodes = blurUnwatchedEpisodes,
+            sizing = sizing,
+            onClick = { onEpisodeClick?.invoke(episode) },
+            onLongPress = { onEpisodeLongPress?.invoke(episode) },
+        )
+    }
+}
+
+@Composable
+private fun SeriesSeasonSelector(
+    meta: MetaDetails,
+    seasons: List<Int>,
+    groupedEpisodes: Map<Int, List<MetaVideo>>,
+    currentSeason: Int,
+    sizing: SeriesContentSizing,
+    horizontalScrollPadding: Dp,
+    onSelect: (Int) -> Unit,
+    onLongPress: ((Int) -> Unit)?,
+) {
+    if (seasons.size <= 1) return
+
+    var seasonViewMode by remember {
+        mutableStateOf(SeasonViewModeStorage.load() ?: SeasonViewMode.Posters)
+    }
+    val hasSeasonPosters = seasons.any { season ->
+        resolveSeasonPoster(
+            season = season,
+            groupedEpisodes = groupedEpisodes,
+            meta = meta,
+        ) != null
+    }
+    Column(
+        modifier = Modifier.animateContentSize(animationSpec = tween(280)),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(Res.string.details_seasons),
+                style = MaterialTheme.typography.titleLarge.copy(
+                    fontSize = sizing.seasonHeaderSize,
+                    fontWeight = FontWeight.SemiBold,
+                ),
+                color = MaterialTheme.colorScheme.onBackground,
+            )
+            if (hasSeasonPosters) {
+                SeasonViewModeToggle(
+                    mode = seasonViewMode,
+                    sizing = sizing,
+                    onClick = {
+                        val next = seasonViewMode.toggled()
+                        seasonViewMode = next
+                        SeasonViewModeStorage.save(next)
+                    },
+                )
+            }
+        }
+
+        if (hasSeasonPosters) {
+            Crossfade(
+                targetState = seasonViewMode,
+                animationSpec = tween(280),
+                label = "season_selector_layout",
+            ) { mode ->
+                when (mode) {
+                    SeasonViewMode.Posters -> SeasonPosterScrollRow(
+                        seasons = seasons,
+                        groupedEpisodes = groupedEpisodes,
+                        meta = meta,
+                        currentSeason = currentSeason,
+                        sizing = sizing,
+                        horizontalScrollPadding = horizontalScrollPadding,
+                        onSelect = onSelect,
+                        onLongPress = onLongPress,
+                    )
+                    SeasonViewMode.Text -> SeasonTextChipScrollRow(
+                        seasons = seasons,
+                        currentSeason = currentSeason,
+                        sizing = sizing,
+                        horizontalScrollPadding = horizontalScrollPadding,
+                        onSelect = onSelect,
+                        onLongPress = onLongPress,
+                    )
+                }
+            }
+        } else {
+            SeasonTextChipScrollRow(
+                seasons = seasons,
+                currentSeason = currentSeason,
+                sizing = sizing,
+                horizontalScrollPadding = horizontalScrollPadding,
+                onSelect = onSelect,
+                onLongPress = onLongPress,
+            )
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/MetaScreenSectionLayoutTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/MetaScreenSectionLayoutTest.kt
@@ -1,0 +1,34 @@
+package com.nuvio.app.features.details
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class MetaScreenSectionLayoutTest {
+
+    private val groupedEpisodes = MetaScreenSectionItem(
+        key = MetaScreenSectionKey.EPISODES,
+        title = "Episodes",
+        description = "Episode list",
+        enabled = true,
+        order = 0,
+        tabGroup = 3,
+    )
+
+    @Test
+    fun `list episodes render outside a multi-section tab group`() {
+        assertNull(groupedEpisodes.tabGroupForRendering(MetaEpisodeCardStyle.List))
+    }
+
+    @Test
+    fun `horizontal episodes retain their configured tab group`() {
+        assertEquals(3, groupedEpisodes.tabGroupForRendering(MetaEpisodeCardStyle.Horizontal))
+    }
+
+    @Test
+    fun `other list sections retain their configured tab group`() {
+        val groupedCast = groupedEpisodes.copy(key = MetaScreenSectionKey.CAST)
+
+        assertEquals(3, groupedCast.tabGroupForRendering(MetaEpisodeCardStyle.List))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/SeriesSeasonSupportTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/SeriesSeasonSupportTest.kt
@@ -51,4 +51,27 @@ class SeriesSeasonSupportTest {
             ),
         )
     }
+
+    @Test
+    fun `grouped episodes preserve a large absolute-numbered catalog`() {
+        val episodeCount = 1_500
+        val meta = MetaDetails(
+            id = "long-running-show",
+            type = "series",
+            name = "Long Running Show",
+            videos = (episodeCount downTo 1).map { episodeNumber ->
+                MetaVideo(
+                    id = "episode-$episodeNumber",
+                    title = "Episode $episodeNumber",
+                    season = 1,
+                    episode = episodeNumber,
+                )
+            },
+        )
+
+        val groupedEpisodes = meta.groupedEpisodesForDisplay()
+
+        assertEquals(listOf(1), groupedEpisodes.keys.toList())
+        assertEquals((1..episodeCount).toList(), groupedEpisodes.getValue(1).map(MetaVideo::episode))
+    }
 }


### PR DESCRIPTION
## Summary

- Render vertical episode cards as individual items in the details screen's lazy list instead of eagerly composing the entire season.
- Keep List-mode Episodes on the lazy path when they share a configured tab group with other sections.
- Preserve the configured tab group for Horizontal mode, along with season selection, watched state, progress, ratings, and episode actions.
- Add regression coverage for large episode catalogs and List-mode tab-group routing.

This ports the shared `commonMain` work from NuvioDesktop PR #527 following the maintainer's request that the fix be moved to NuvioMobile:

https://github.com/NuvioMedia/NuvioDesktop/pull/527

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

The vertical episode-card layout composed every episode in the selected season inside one large nested section. Long-running series with very large episode catalogs could therefore perform unnecessary rendering work while opening, scrolling, selecting an episode, or returning to the details screen.

The lazy path could also be bypassed when Tab Layout was enabled and Episodes shared a group with another populated section.

List-mode Episodes now render as individual lazy-list items. When necessary, Episodes render outside the configured group while the remaining sections stay grouped. The saved configuration is not changed, so Episodes rejoin their configured group when Horizontal mode is selected.

## Issue or approval

Fixes #1834

Desktop implementation and video reference:

https://github.com/NuvioMedia/NuvioDesktop/pull/527

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Does not change metadata or addon fetching.
- Does not introduce caching or repository architecture changes.
- Does not modify scrollbar styling or unrelated screens.
- Does not change episode ordering, season selection, watched state, or playback behavior.
- In List mode only, Episodes render outside a configured multi-section tab group so the lazy path remains active.
- The saved group configuration remains intact and continues to apply in Horizontal mode.

## Testing

Tested locally on a Pixel 7 emulator running Android 16 / API 36:

- Ran the focused details-section and season-support regression tests and compiled the Android target.
- Built and installed the Full Debug Android app.
- Verified responsive scrolling and back navigation with a large episode catalog in List mode.
- Verified List-mode Episodes remain standalone and responsive when configured with Cast and Details in the same group.
- Verified the other configured sections remain grouped.
- Verified Horizontal episode cards rejoin their configured group.

The affected implementation is in `commonMain` and is also used by iOS. iOS was not runtime-tested because Apple targets require macOS and Xcode.

## Screenshots / Video (UI changes only)

No separate Mobile capture was recorded. The original Desktop implementation contains before-and-after videos demonstrating the shared behavior:

### Before

https://github.com/user-attachments/assets/1dc342b8-f698-42a5-adef-960fb4f904c8

### After

https://github.com/user-attachments/assets/2360881f-468b-4c7b-a783-09b1c5531ebc

Desktop reference:

https://github.com/NuvioMedia/NuvioDesktop/pull/527

## Breaking changes

None.

## Linked issues

Fixes #1834

Reference: NuvioDesktop PR #527