### PR TITLE
Use Simkl for anime ID resolution in skip-intro (replaces ARM)

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
@@ -780,6 +780,7 @@ internal fun MainAppContent(
                 request = baseRequest,
                 type = launch.contentType ?: launch.parentMetaType,
                 videoId = launch.videoId ?: launch.parentMetaId,
+                contentId = launch.parentMetaId,
                 forwardSubtitles = playerSettingsUiState.externalPlayerForwardSubtitles,
                 sendSkipSegments = shouldSendSkipSegments,
                 preferredLanguage = playerSettingsUiState.preferredSubtitleLanguage,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerLaunchCoordinator.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/ExternalPlayerLaunchCoordinator.kt
@@ -33,6 +33,7 @@ suspend fun prepareExternalPlayerLaunch(
     request: ExternalPlayerPlaybackRequest,
     type: String,
     videoId: String,
+    contentId: String? = null,
     forwardSubtitles: Boolean,
     sendSkipSegments: Boolean,
     preferredLanguage: String,
@@ -66,7 +67,7 @@ suspend fun prepareExternalPlayerLaunch(
     }
 
     val skipSegmentsDeferred = if (sendSkipSegments) {
-        async { resolveSkipSegmentsJson(videoId, request.season, request.episode) }
+        async { resolveSkipSegmentsJson(videoId, request.season, request.episode, contentId) }
     } else {
         null
     }
@@ -90,18 +91,19 @@ suspend fun prepareExternalPlayerLaunch(
  * intentionally independent of the in-app skip-intro toggle (requireSkipIntroEnabled = false):
  * this is its own opt-in setting.
  */
-private suspend fun resolveSkipSegmentsJson(videoId: String, season: Int?, episode: Int?): String? {
+private suspend fun resolveSkipSegmentsJson(videoId: String, season: Int?, episode: Int?, contentId: String?): String? {
     val ep = episode ?: return null
+    val imdbFromContent = contentId?.takeIf { it.startsWith("tt") }
     val intervals = skipResolveScope.async {
         withTimeoutOrNull(SkipSegmentResolveTimeoutMs) {
             when {
                 videoId.startsWith("mal:") -> {
                     val malId = videoId.removePrefix("mal:").substringBefore(':')
-                    SkipIntroRepository.getSkipIntervalsForMal(malId, ep, requireSkipIntroEnabled = false)
+                    SkipIntroRepository.getSkipIntervalsForMal(malId, ep, requireSkipIntroEnabled = false, imdbId = imdbFromContent, imdbSeason = season, imdbEpisode = episode)
                 }
                 videoId.startsWith("kitsu:") -> {
                     val kitsuId = videoId.removePrefix("kitsu:").substringBefore(':')
-                    SkipIntroRepository.getSkipIntervalsForKitsu(kitsuId, ep, requireSkipIntroEnabled = false)
+                    SkipIntroRepository.getSkipIntervalsForKitsu(kitsuId, ep, requireSkipIntroEnabled = false, imdbId = imdbFromContent, imdbSeason = season, imdbEpisode = episode)
                 }
                 else -> {
                     val imdbId = videoId.substringBefore(':').takeIf { it.startsWith("tt") } ?: return@withTimeoutOrNull null

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -449,14 +449,15 @@ private fun PlayerScreenRuntime.BindPlayerMetadataAndSkipEffects() {
         if (season == null || episode == null || vid == null) return@LaunchedEffect
 
         launch {
+            val imdbFromContent = parentMetaId.takeIf { it.startsWith("tt") }
             val intervals = when {
                 vid.startsWith("mal:") -> {
                     val malId = vid.removePrefix("mal:").substringBefore(':')
-                    SkipIntroRepository.getSkipIntervalsForMal(malId = malId, episode = episode)
+                    SkipIntroRepository.getSkipIntervalsForMal(malId = malId, episode = episode, imdbId = imdbFromContent, imdbSeason = season, imdbEpisode = episode)
                 }
                 vid.startsWith("kitsu:") -> {
                     val kitsuId = vid.removePrefix("kitsu:").substringBefore(':')
-                    SkipIntroRepository.getSkipIntervalsForKitsu(kitsuId = kitsuId, episode = episode)
+                    SkipIntroRepository.getSkipIntervalsForKitsu(kitsuId = kitsuId, episode = episode, imdbId = imdbFromContent, imdbSeason = season, imdbEpisode = episode)
                 }
                 else -> SkipIntroRepository.getSkipIntervals(
                     imdbId = vid.substringBefore(':').takeIf { it.startsWith("tt") },

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SimklIdResolver.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SimklIdResolver.kt
@@ -1,0 +1,115 @@
+package com.nuvio.app.features.player.skip
+
+import com.nuvio.app.features.addons.httpGetText
+import com.nuvio.app.features.simkl.SimklConfig
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+
+private const val BASE = "https://api.simkl.com"
+
+internal object SimklIdResolver {
+
+    private val json = Json { ignoreUnknownKeys = true; isLenient = true }
+
+    data class ResolvedIds(
+        val simklId: Long,
+        val type: String,
+        val mal: String? = null,
+        val anilist: String? = null,
+        val kitsu: String? = null,
+        val imdb: String? = null,
+        val tvdbSeason: Int? = null
+    )
+
+    data class EpisodeMapping(
+        val animeEpisode: Int,
+        val tvdbSeason: Int,
+        val tvdbEpisode: Int
+    )
+
+    private val idsCache = HashMap<String, ResolvedIds?>()
+    private val episodeCache = HashMap<Long, List<EpisodeMapping>>()
+
+    private fun commonParams(): String {
+        val clientId = SimklConfig.CLIENT_ID
+        val appName = SimklConfig.APP_NAME
+        return "client_id=$clientId&app-name=$appName&app-version=1.0"
+    }
+
+    suspend fun resolveIds(source: String, id: String): ResolvedIds? {
+        val cacheKey = "$source:$id"
+        idsCache[cacheKey]?.let { return it }
+        if (SimklConfig.CLIENT_ID.isBlank()) return null
+
+        return try {
+            val searchText = httpGetText("$BASE/search/id?$source=$id&${commonParams()}")
+            val results = json.parseToJsonElement(searchText).jsonArray
+            if (results.isEmpty()) return null
+            val simklId = results[0].jsonObject["ids"]?.jsonObject?.get("simkl")?.jsonPrimitive?.long ?: return null
+
+            val type = results[0].jsonObject["type"]?.jsonPrimitive?.content ?: "anime"
+            val mediaType = when (type) {
+                "movie" -> "movies"
+                "show" -> "tv"
+                else -> "anime"
+            }
+
+            val detailsText = httpGetText("$BASE/$mediaType/$simklId?extended=full&${commonParams()}")
+            val details = json.parseToJsonElement(detailsText).jsonObject
+            val ids = details["ids"]?.jsonObject
+
+            ResolvedIds(
+                simklId = simklId,
+                type = mediaType,
+                mal = ids?.get("mal")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() },
+                anilist = ids?.get("anilist")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() },
+                kitsu = ids?.get("kitsu")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() },
+                imdb = ids?.get("imdb")?.jsonPrimitive?.content?.takeIf { it.isNotBlank() },
+                tvdbSeason = details["season"]?.jsonPrimitive?.int?.takeIf { it > 0 }
+            ).also { idsCache[cacheKey] = it }
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    suspend fun getEpisodeMapping(simklId: Long, type: String = "anime"): List<EpisodeMapping> {
+        episodeCache[simklId]?.let { return it }
+        if (SimklConfig.CLIENT_ID.isBlank()) return emptyList()
+
+        return try {
+            val text = httpGetText("$BASE/$type/episodes/$simklId?${commonParams()}")
+            val episodes = json.parseToJsonElement(text).jsonArray
+            val mapping = mutableListOf<EpisodeMapping>()
+            for (ep in episodes) {
+                val obj = ep.jsonObject
+                val epNum = obj["episode"]?.jsonPrimitive?.int ?: continue
+                val tvdb = obj["tvdb"]?.jsonObject ?: continue
+                val tvdbSeason = tvdb["season"]?.jsonPrimitive?.int ?: continue
+                val tvdbEpisode = tvdb["episode"]?.jsonPrimitive?.int ?: continue
+                if (epNum > 0 && tvdbSeason > 0 && tvdbEpisode > 0) {
+                    mapping.add(EpisodeMapping(epNum, tvdbSeason, tvdbEpisode))
+                }
+            }
+            mapping.also { episodeCache[simklId] = it }
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    suspend fun resolveEpisodeTvdb(source: String, id: String, episode: Int): Pair<Int, Int>? {
+        val ids = resolveIds(source, id) ?: return null
+        val entry = getEpisodeMapping(ids.simklId, ids.type).firstOrNull { it.animeEpisode == episode }
+        return entry?.let { it.tvdbSeason to it.tvdbEpisode }
+    }
+
+    fun clearCache() {
+        idsCache.clear()
+        episodeCache.clear()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SimklIdResolver.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SimklIdResolver.kt
@@ -1,6 +1,7 @@
 package com.nuvio.app.features.player.skip
 
 import com.nuvio.app.features.addons.httpGetText
+import com.nuvio.app.features.simkl.SIMKL_API_BASE_URL
 import com.nuvio.app.features.simkl.SimklConfig
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
@@ -10,8 +11,6 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.long
-
-private const val BASE = "https://api.simkl.com"
 
 internal object SimklIdResolver {
 
@@ -48,7 +47,7 @@ internal object SimklIdResolver {
         if (SimklConfig.CLIENT_ID.isBlank()) return null
 
         return try {
-            val searchText = httpGetText("$BASE/search/id?$source=$id&${commonParams()}")
+            val searchText = httpGetText("$SIMKL_API_BASE_URL/search/id?$source=$id&${commonParams()}")
             val results = json.parseToJsonElement(searchText).jsonArray
             if (results.isEmpty()) return null
             val simklId = results[0].jsonObject["ids"]?.jsonObject?.get("simkl")?.jsonPrimitive?.long ?: return null
@@ -60,7 +59,7 @@ internal object SimklIdResolver {
                 else -> "anime"
             }
 
-            val detailsText = httpGetText("$BASE/$mediaType/$simklId?extended=full&${commonParams()}")
+            val detailsText = httpGetText("$SIMKL_API_BASE_URL/$mediaType/$simklId?extended=full&${commonParams()}")
             val details = json.parseToJsonElement(detailsText).jsonObject
             val ids = details["ids"]?.jsonObject
 
@@ -83,7 +82,7 @@ internal object SimklIdResolver {
         if (SimklConfig.CLIENT_ID.isBlank()) return emptyList()
 
         return try {
-            val text = httpGetText("$BASE/$type/episodes/$simklId?${commonParams()}")
+            val text = httpGetText("$SIMKL_API_BASE_URL/$type/episodes/$simklId?${commonParams()}")
             val episodes = json.parseToJsonElement(text).jsonArray
             val mapping = mutableListOf<EpisodeMapping>()
             for (ep in episodes) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipIntroApi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipIntroApi.kt
@@ -9,7 +9,6 @@ internal object SkipIntroApi {
     private val json = Json { ignoreUnknownKeys = true; isLenient = true }
 
     private const val ANISKIP_BASE = "https://api.aniskip.com/v2/"
-    private const val ARM_BASE = "https://arm.haglund.dev/api/v2/"
     private const val ANIMESKIP_BASE = "https://api.anime-skip.com/"
 
     // --- IntroDb ---
@@ -97,68 +96,6 @@ internal object SkipIntroApi {
         return try {
             val text = httpGetText(url)
             json.decodeFromString<AniSkipResponse>(text)
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    // --- ARM API (ID resolution) ---
-
-    suspend fun resolveImdbToAll(imdbId: String): List<ArmEntry> {
-        val url = "${ARM_BASE}imdb?id=$imdbId&include=myanimelist,anilist,kitsu"
-        return try {
-            val text = httpGetText(url)
-            json.decodeFromString<List<ArmEntry>>(text)
-        } catch (_: Exception) {
-            emptyList()
-        }
-    }
-
-    suspend fun resolveMalToImdb(malId: String): ArmEntry? {
-        val url = "${ARM_BASE}ids?source=myanimelist&id=$malId&include=imdb"
-        return try {
-            val text = httpGetText(url)
-            json.decodeFromString<ArmEntry>(text)
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    suspend fun resolveMalToAnilist(malId: String): ArmEntry? {
-        val url = "${ARM_BASE}ids?source=myanimelist&id=$malId&include=anilist"
-        return try {
-            val text = httpGetText(url)
-            json.decodeFromString<ArmEntry>(text)
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    suspend fun resolveKitsuToMal(kitsuId: String): ArmEntry? {
-        val url = "${ARM_BASE}ids?source=kitsu&id=$kitsuId&include=myanimelist"
-        return try {
-            val text = httpGetText(url)
-            json.decodeFromString<ArmEntry>(text)
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    suspend fun resolveKitsuToAnilist(kitsuId: String): ArmEntry? {
-        val url = "${ARM_BASE}ids?source=kitsu&id=$kitsuId&include=anilist"
-        return try {
-            val text = httpGetText(url)
-            json.decodeFromString<ArmEntry>(text)
-        } catch (_: Exception) {
-            null
-        }
-    }
-
-    suspend fun resolveKitsuToImdb(kitsuId: String): ArmEntry? {
-        val url = "${ARM_BASE}ids?source=kitsu&id=$kitsuId&include=imdb"
-        return try {
-            val text = httpGetText(url)
-            json.decodeFromString<ArmEntry>(text)
         } catch (_: Exception) {
             null
         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipIntroRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipIntroRepository.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.coroutineScope
 object SkipIntroRepository {
 
     private val cache = HashMap<String, List<SkipInterval>>()
-    private val imdbEntriesCache = HashMap<String, List<ArmEntry>>()
     private val animeSkipShowIdCache = HashMap<String, String>()
     private const val NO_ID = "__none__"
 
@@ -30,13 +29,15 @@ object SkipIntroRepository {
         val introDbDeferred = async {
             if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
         }
-        val entriesDeferred = async { resolveImdbEntries(imdbId) }
-        val entries = entriesDeferred.await()
-        val animeSkipDeferred = async { fetchAnimeSkipForEntries(entries, season, episode) }
-        val malId = entries.getOrNull(season - 1)?.myanimelist?.toString()
-            ?: entries.firstOrNull()?.myanimelist?.toString()
+        val simklIdsDeferred = async { SimklIdResolver.resolveIds("imdb", imdbId) }
+        val simklIds = simklIdsDeferred.await()
+        val malId = simklIds?.mal
+        val anilistId = simklIds?.anilist
         val aniSkipDeferred = async {
             if (malId != null) fetchFromAniSkip(malId, episode) else emptyList()
+        }
+        val animeSkipDeferred = async {
+            if (anilistId != null) fetchFromAnimeSkip(anilistId, episode, season = null) else emptyList()
         }
 
         return@coroutineScope mergeByPriority(
@@ -50,6 +51,9 @@ object SkipIntroRepository {
         malId: String,
         episode: Int,
         requireSkipIntroEnabled: Boolean = true,
+        imdbId: String? = null,
+        imdbSeason: Int? = null,
+        imdbEpisode: Int? = null,
     ): List<SkipInterval> = coroutineScope {
         val settings = PlayerSettingsRepository.uiState.value
         if (requireSkipIntroEnabled && !settings.skipIntroEnabled) return@coroutineScope emptyList()
@@ -59,28 +63,35 @@ object SkipIntroRepository {
 
         val aniSkipDeferred = async { fetchFromAniSkip(malId, episode) }
 
-        val imdbIdDeferred = async {
-            try {
-                SkipIntroApi.resolveMalToImdb(malId)?.imdb
-            } catch (_: Exception) { null }
+        val simklIdsDeferred = async { SimklIdResolver.resolveIds("mal", malId) }
+        val simklIds = simklIdsDeferred.await()
+        val resolvedImdbId = imdbId ?: simklIds?.imdb
+
+        val tvdbDeferred = async {
+            if (resolvedImdbId != null && imdbSeason == null && simklIds != null) {
+                SimklIdResolver.resolveEpisodeTvdb("mal", malId, episode)
+            } else null
         }
 
         var introDb = emptyList<SkipInterval>()
         var animeSkip = emptyList<SkipInterval>()
-        val imdbId = imdbIdDeferred.await()
-        if (imdbId != null) {
-            val entries = resolveImdbEntries(imdbId)
-            val season = entries.indexOfFirst { it.myanimelist == malId.toIntOrNull() } + 1
-            val introDbDeferred = async {
-                if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
+        if (resolvedImdbId != null) {
+            val tvdb = tvdbDeferred.await()
+            val introDbSeason = imdbSeason ?: tvdb?.first ?: return@coroutineScope run {
+                mergeByPriority(introDb, animeSkip, aniSkipDeferred.await()).also { cache[cacheKey] = it }
             }
-            val animeSkipDeferred = async { fetchAnimeSkipForEntries(entries, season, episode) }
+            val introDbEpisode = imdbEpisode ?: tvdb?.second ?: episode
+            val introDbDeferred = async {
+                if (introDbConfigured) fetchFromIntroDb(resolvedImdbId, introDbSeason, introDbEpisode) else emptyList()
+            }
+            val anilistId = simklIds?.anilist
+            val animeSkipDeferred = async {
+                if (anilistId != null) fetchFromAnimeSkip(anilistId, episode, season = null) else emptyList()
+            }
             introDb = introDbDeferred.await()
             animeSkip = animeSkipDeferred.await()
         } else {
-            val anilistId = try {
-                SkipIntroApi.resolveMalToAnilist(malId)?.anilist?.toString()
-            } catch (_: Exception) { null }
+            val anilistId = simklIds?.anilist
             if (anilistId != null) animeSkip = fetchFromAnimeSkip(anilistId, episode, season = null)
         }
 
@@ -91,6 +102,9 @@ object SkipIntroRepository {
         kitsuId: String,
         episode: Int,
         requireSkipIntroEnabled: Boolean = true,
+        imdbId: String? = null,
+        imdbSeason: Int? = null,
+        imdbEpisode: Int? = null,
     ): List<SkipInterval> = coroutineScope {
         val settings = PlayerSettingsRepository.uiState.value
         if (requireSkipIntroEnabled && !settings.skipIntroEnabled) return@coroutineScope emptyList()
@@ -98,48 +112,46 @@ object SkipIntroRepository {
         val cacheKey = "kitsu:$kitsuId:$episode"
         cache[cacheKey]?.let { return@coroutineScope it }
 
-        val malIdDeferred = async {
-            try {
-                SkipIntroApi.resolveKitsuToMal(kitsuId)?.myanimelist?.toString()
-            } catch (_: Exception) { null }
-        }
-        val imdbIdDeferred = async {
-            try {
-                SkipIntroApi.resolveKitsuToImdb(kitsuId)?.imdb
-            } catch (_: Exception) { null }
-        }
+        val simklIdsDeferred = async { SimklIdResolver.resolveIds("kitsu", kitsuId) }
+        val simklIds = simklIdsDeferred.await()
+        val malIdStr = simklIds?.mal
+        val resolvedImdbId = imdbId ?: simklIds?.imdb
+
         val aniSkipDeferred = async {
-            malIdDeferred.await()?.let { fetchFromAniSkip(it, episode) } ?: emptyList()
+            if (malIdStr != null) fetchFromAniSkip(malIdStr, episode) else emptyList()
+        }
+
+        val tvdbDeferred = async {
+            if (resolvedImdbId != null && imdbSeason == null && simklIds != null) {
+                SimklIdResolver.resolveEpisodeTvdb("kitsu", kitsuId, episode)
+            } else null
         }
 
         var introDb = emptyList<SkipInterval>()
         var animeSkip = emptyList<SkipInterval>()
-        val imdbId = imdbIdDeferred.await()
-        if (imdbId != null) {
-            val entries = resolveImdbEntries(imdbId)
-            val season = entries.indexOfFirst { it.kitsu == kitsuId.toIntOrNull() } + 1
-            val introDbDeferred = async {
-                if (introDbConfigured) fetchFromIntroDb(imdbId, season, episode) else emptyList()
+        if (resolvedImdbId != null) {
+            val tvdb = tvdbDeferred.await()
+            val introDbSeason = imdbSeason ?: tvdb?.first ?: return@coroutineScope run {
+                mergeByPriority(introDb, animeSkip, aniSkipDeferred.await()).also { cache[cacheKey] = it }
             }
-            val animeSkipDeferred = async { fetchAnimeSkipForEntries(entries, season, episode) }
+            val introDbEpisode = imdbEpisode ?: tvdb?.second ?: episode
+            val introDbDeferred = async {
+                if (introDbConfigured) fetchFromIntroDb(resolvedImdbId, introDbSeason, introDbEpisode) else emptyList()
+            }
+            val anilistId = simklIds?.anilist
+            val animeSkipDeferred = async {
+                if (anilistId != null) fetchFromAnimeSkip(anilistId, episode, season = null) else emptyList()
+            }
             introDb = introDbDeferred.await()
             animeSkip = animeSkipDeferred.await()
         } else {
-            val anilistId = try {
-                SkipIntroApi.resolveKitsuToAnilist(kitsuId)?.anilist?.toString()
-            } catch (_: Exception) { null }
+            val anilistId = simklIds?.anilist
             if (anilistId != null) animeSkip = fetchFromAnimeSkip(anilistId, episode, season = null)
         }
 
         return@coroutineScope mergeByPriority(introDb, animeSkip, aniSkipDeferred.await()).also { cache[cacheKey] = it }
     }
 
-    /**
-     * Merge provider results into one best-of: fill each segment category (opening / ending /
-     * recap) from the highest-priority provider that has it. Arguments MUST be passed in priority
-     * order (IntroDB has the broadest coverage, then Anime-Skip, then AniSkip), so a partial
-     * result from one provider never shadows a complete segment from another.
-     */
     private fun mergeByPriority(vararg providerResults: List<SkipInterval>): List<SkipInterval> {
         val chosen = LinkedHashMap<String, SkipInterval>()
         for (result in providerResults) {
@@ -156,24 +168,6 @@ object SkipIntroRepository {
         "outro", "ed", "mixed-ed", "credits", "ending" -> "ending"
         "recap" -> "recap"
         else -> null
-    }
-
-    // AnimeSkip: season-specific AniList ID first, then season-1 as a season-filtered fallback.
-    private suspend fun fetchAnimeSkipForEntries(
-        entries: List<ArmEntry>,
-        season: Int,
-        episode: Int
-    ): List<SkipInterval> {
-        val seasonAnilistId = entries.getOrNull(season - 1)?.anilist?.toString()
-        val fallbackAnilistId = entries.firstOrNull()?.anilist?.toString()
-        for ((anilistId, seasonFilter) in listOfNotNull(
-            seasonAnilistId?.let { it to null },
-            if (fallbackAnilistId != null && fallbackAnilistId != seasonAnilistId) fallbackAnilistId to season else null
-        )) {
-            val result = fetchFromAnimeSkip(anilistId, episode, season = seasonFilter)
-            if (result.isNotEmpty()) return result
-        }
-        return emptyList()
     }
 
     private suspend fun fetchFromIntroDb(imdbId: String, season: Int, episode: Int): List<SkipInterval> {
@@ -270,13 +264,6 @@ object SkipIntroRepository {
         return showIds
     }
 
-    private suspend fun resolveImdbEntries(imdbId: String): List<ArmEntry> {
-        imdbEntriesCache[imdbId]?.let { return it }
-        return try {
-            SkipIntroApi.resolveImdbToAll(imdbId)
-        } catch (_: Exception) { emptyList() }.also { imdbEntriesCache[imdbId] = it }
-    }
-
     suspend fun submitIntro(
         imdbId: String,
         season: Int,
@@ -309,7 +296,7 @@ object SkipIntroRepository {
 
     fun clearCache() {
         cache.clear()
-        imdbEntriesCache.clear()
         animeSkipShowIdCache.clear()
+        SimklIdResolver.clearCache()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/SkipModels.kt
@@ -84,16 +84,6 @@ data class AniSkipInterval(
     @SerialName("endTime") val endTime: Double,
 )
 
-// --- ARM API response models ---
-
-@Serializable
-data class ArmEntry(
-    @SerialName("myanimelist") val myanimelist: Int? = null,
-    @SerialName("anilist") val anilist: Int? = null,
-    @SerialName("kitsu") val kitsu: Int? = null,
-    @SerialName("imdb") val imdb: String? = null,
-)
-
 // --- Anime-Skip GraphQL API response models ---
 
 @Serializable


### PR DESCRIPTION
## Summary

Port of https://github.com/NuvioMedia/NuvioTV/pull/3284 for Mobile. Replace ARM API with Simkl for anime ID resolution in skip-intro.

ARM mapped anime seasons to a flat index that doesn't match IMDB/TVDB numbering, so IntroDB returned skip segments for wrong episodes. Simkl provides the actual TVDB season/episode mapping per anime episode and resolves MAL/AniList/IMDB IDs via search/id + detail call. When the player's content ID is already an IMDB ID, it's passed directly to IntroDB along with the current season/episode.

## PR type

- [x] Critical bug fix

## Why

Same issue as https://github.com/NuvioMedia/NuvioTV/pull/3284 - skip intro showed wrong timestamps for anime with MAL or Kitsu video IDs due to ARM's flat season index not matching IMDB/TVDB numbering.

## Issue or approval

NuvioTV#3284

## Reproduction steps

1. Play an anime episode using Kitsu or MAL video IDs (e.g. Bleach TYBW, videoId = kitsu:49444:6)
2. Wait for skip intro to appear
3. Observe incorrect intro timing

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR fits the current PR policy: localization/translation only or a critical bug fix.
- [x] This PR does not add features, UI changes, refactors, or other non-critical changes.
- [x] This PR is small, focused, and limited to one issue.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR includes a linked issue, reproduction steps, and testing notes if it is a critical bug fix.
- [x] I listed the testing performed below.

## Scope boundaries

- ARM API methods removed from SkipIntroApi.kt. ArmEntry model removed from SkipModels.kt.
- SimklIdResolver uses search/id (JSON) instead of /redirect (header-only) because KMP common code can't easily do no-follow redirects across platforms.
- Media type (anime/tv/movies) detected from Simkl search result type field.
- Player callers extract IMDB ID from parentMetaId/contentId when available and pass it with IMDB season/episode to skip Simkl resolution.

## Testing

- Verified build compiles (existing unrelated error in PlayerSubtitleCueParser.kt predates this change)
- Logic identical to verified NuvioTV#3284 implementation

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Port of https://github.com/NuvioMedia/NuvioTV/pull/3284
