### PR TITLE
fix(player): preserve addon subtitle provider identity

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleSelectionModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/SubtitleSelectionModel.kt
@@ -26,22 +26,27 @@ internal sealed interface SubtitleSelectionOption {
     data class Addon(
         val subtitle: AddonSubtitle,
     ) : SubtitleSelectionOption {
-        override val id: String = "addon:${subtitle.addonName}:${subtitle.id}:${subtitle.selectionKey}"
+        override val id: String = subtitle.selectionKey
     }
 }
 
 internal val AddonSubtitle.selectionKey: String
+    // Selection identifies the provider row; url remains the playback resource.
+    get() = "addon:$addonName:$id:$legacySelectionKey"
+
+private val AddonSubtitle.legacySelectionKey: String
     get() = url.takeIf { it.isNotBlank() } ?: listOfNotNull(addonName, id).joinToString(":")
 
 internal fun AddonSubtitle.matchesSelection(selectedId: String?): Boolean {
     if (selectedId.isNullOrBlank()) return false
-    return url == selectedId || id == selectedId || selectionKey == selectedId
+    return url == selectedId || id == selectedId || selectionKey == selectedId || legacySelectionKey == selectedId
 }
 
 internal fun List<AddonSubtitle>.findSelectedAddon(selectedId: String?): AddonSubtitle? {
     if (selectedId.isNullOrBlank()) return null
-    firstOrNull { it.url == selectedId }?.let { return it }
     firstOrNull { it.selectionKey == selectedId }?.let { return it }
+    firstOrNull { it.url == selectedId }?.let { return it }
+    firstOrNull { it.legacySelectionKey == selectedId }?.let { return it }
     return firstOrNull { it.id == selectedId }
 }
 

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeStateTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeStateTest.kt
@@ -12,6 +12,63 @@ import kotlin.test.assertTrue
 class PlayerScreenRuntimeStateTest {
 
     @Test
+    fun providerRowSurvivesRuntimeResolutionAndPlaybackOptionSynchronization() {
+        val runtime = PlayerScreenRuntime(testPlayerScreenArgs())
+        val providers = listOf("OpenSubtitles v3", "AIOStreams | ElfHosted", "Third provider")
+        runtime.addonSubtitles = providers.map { provider ->
+            AddonSubtitle(
+                id = "11742948",
+                url = "https://example.com/shared.srt",
+                language = "ind",
+                display = "Indonesian",
+                addonName = provider,
+            )
+        }
+        val options = buildSubtitleSelectionOptions("id", emptyList(), runtime.visibleAddonSubtitles)
+            .filterIsInstance<SubtitleSelectionOption.Addon>()
+        assertEquals(3, options.size)
+        assertEquals(3, options.map { it.id }.distinct().size)
+
+        // The row callback writes selectionKey; the modal later replaces its pending
+        // option with selectedSubtitleOptionId derived from the runtime's resolved addon.
+        // Starting with B reproduces the first-tap jump, not just the warm A/B case.
+        for (index in listOf(1, 0, 1, 0, 1, 2)) {
+            val tapped = options[index]
+            runtime.selectedAddonSubtitleId = tapped.subtitle.selectionKey
+            runtime.selectedSubtitleIndex = -1
+
+            val effective = runtime.selectedAddonSubtitle
+            assertEquals(providers[index], effective?.addonName)
+            assertEquals("https://example.com/shared.srt", effective?.url)
+            assertEquals(tapped.id, selectedSubtitleOptionId(emptyList(), -1, effective))
+        }
+
+        // Off -> B must not synchronize the highlight back to provider A.
+        runtime.selectedAddonSubtitleId = null
+        assertNull(runtime.selectedAddonSubtitle)
+        assertNull(selectedSubtitleOptionId(emptyList(), -1, runtime.selectedAddonSubtitle))
+        runtime.selectedAddonSubtitleId = options[1].subtitle.selectionKey
+        assertEquals("AIOStreams | ElfHosted", runtime.selectedAddonSubtitle?.addonName)
+        assertEquals(options[1].id, selectedSubtitleOptionId(emptyList(), -1, runtime.selectedAddonSubtitle))
+    }
+
+    @Test
+    fun legacyUrlSelectionRemainsReadableUntilAProviderRowIsSelected() {
+        val runtime = PlayerScreenRuntime(testPlayerScreenArgs())
+        val first = AddonSubtitle("shared", "https://example.com/shared.srt", "en", "English", "First")
+        val second = first.copy(addonName = "Second")
+        runtime.addonSubtitles = listOf(first, second)
+        runtime.selectedAddonSubtitleId = first.url
+        assertEquals(first, runtime.selectedAddonSubtitle)
+        assertEquals(first.url, runtime.selectedAddonSubtitleId)
+
+        runtime.selectedAddonSubtitleId = second.selectionKey
+        assertEquals(second, runtime.selectedAddonSubtitle)
+        runtime.addonSubtitles = listOf(second.copy(), first.copy())
+        assertEquals(second, runtime.selectedAddonSubtitle)
+    }
+
+    @Test
     fun controlsStartHidden() {
         assertFalse(PlayerScreenRuntime(testPlayerScreenArgs()).controlsVisible)
     }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/SubtitleSelectionModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/SubtitleSelectionModelTest.kt
@@ -3,8 +3,30 @@ package com.nuvio.app.features.player
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class SubtitleSelectionModelTest {
+
+    @Test
+    fun providerSelectionRetainsExistingOptionIdsAndPlaybackUrls() {
+        val subtitle = addonSubtitle("en", "en", "https://example.com/en.srt")
+        val option = SubtitleSelectionOption.Addon(subtitle)
+        assertEquals("addon:Addon:en:https://example.com/en.srt", option.id)
+        assertEquals(option.id, subtitle.selectionKey)
+        assertEquals("https://example.com/en.srt", subtitle.url)
+        assertTrue(subtitle.matchesSelection(option.id))
+        assertTrue(subtitle.matchesSelection(subtitle.url))
+    }
+
+    @Test
+    fun legacyNonUrlSelectionKeysAndRawIdsStillResolve() {
+        val noUrl = addonSubtitle("en", "en", "")
+        assertEquals("addon:Addon:en:Addon:en", SubtitleSelectionOption.Addon(noUrl).id)
+        assertEquals(noUrl, listOf(noUrl).findSelectedAddon("Addon:en"))
+        assertTrue(noUrl.matchesSelection("Addon:en"))
+        assertEquals(noUrl, listOf(noUrl).findSelectedAddon("en"))
+        assertEquals(noUrl, listOf(noUrl).findSelectedAddon(noUrl.selectionKey))
+    }
 
     @Test
     fun groupsTracksAndAddonsByLanguageWithPreferredLanguagesFirst() {


### PR DESCRIPTION
## Summary

Focused follow-up to #1800: preserve exact addon/provider subtitle-row selection when multiple providers legitimately reference the same subtitle URL.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] New feature
- [ ] Refactor/cleanup (no behavior change)
- [ ] Documentation-only
- [ ] Build/CI/tooling
- [ ] Other (explain below)

## Why

Selecting a later provider row previously reduced the selected identity to its URL. Runtime URL resolution then selected the first provider with that URL, making the highlighted provider jump even though playback resource was unchanged.
### How it works

`SubtitleSelectionOption.Addon.id` is now the provider-qualified `optionId` / `selectionKey` (`addon:<provider>:<subtitle-id>:<legacy-url-key>`). A tap therefore stores and resolves that exact row key first:

`tap ElfHosted row → selected optionId → resolver returns ElfHosted row`.

`addon.url` remains unchanged and is used only as playback resource plus legacy URL fallback, so providers sharing one URL can still play that resource without losing which provider row user chose.

## Issue or approval

Fixes #1888.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only as described below
- [x] Behavior changed only to fix a documented bug/regression

Exact provider-row selection now remains stable. Playback still receives `addon.url`.

## Policy check

- [x] I used the repository's documented architecture/patterns for this area.
- [x] I reviewed the change for regressions and kept scope focused.
- [x] I added or updated tests where behavior changed, or explained why tests are not applicable.
- [x] I did not add secrets, tokens, credentials, or private URLs.
- [x] I did not change unrelated files or perform drive-by refactors.
- [x] Any UI change follows the project's design conventions, or this PR has no UI change.
- [x] Any behavior change is covered by a reproducible issue, approved request, or test.

## Scope boundaries

- Only `SubtitleSelectionModel.kt` production behavior changes.
- No `SubtitleModal`, runtime callback, preference-storage, ownership, fling, backend, player-engine, or diagnostic changes.
- Existing raw-ID fallback remains `return firstOrNull { it.id == selectedId }`.
- Existing addon option IDs and Lazy keys are unchanged.

## Testing

- Pre-fix regression failed: expected `AIOStreams | ElfHosted`; actual `OpenSubtitles v3`.
- Full verification: `gradlew.bat :composeApp:testAndroidHostTest :androidApp:assembleFullDebug --console=plain`
  - `BUILD SUCCESSFUL`
  - 823 tests; 0 failures, 0 errors, 0 skips.
- `git diff --check` passed.
- BlueStacks real-playback validation:
  - Indonesian: 60/60 correct selections/cycles.
  - Japanese: 40/40 correct selections.
  - One correct player request per tap; no extra first-provider request; playback remained active.

## Screenshots / Video

No UI layout or design change. Reproduction evidence:

- *Before: provider row jumps to first provider*

https://github.com/user-attachments/assets/2e1de42b-36ad-4e5e-94f3-c2cf1f8665c4

- *After: clicked provider remains selected*

https://github.com/user-attachments/assets/e090bc4b-c844-468b-8b9e-6d8e88640310


## Breaking changes

None. Legacy URL-only selections remain readable and use existing URL fallback when no exact provider-qualified selection is available.

## Linked issues

Fixes #1888.
