### PR TITLE
Fix HLS rendition fallback after media-segment 404

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/HlsRenditionFallbackPolicy.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/HlsRenditionFallbackPolicy.android.kt
@@ -1,0 +1,42 @@
+package com.nuvio.app.features.player
+
+import androidx.media3.common.C
+import androidx.media3.datasource.HttpDataSource
+import androidx.media3.exoplayer.upstream.DefaultLoadErrorHandlingPolicy
+import androidx.media3.exoplayer.upstream.LoadErrorHandlingPolicy
+
+/** Prefer a healthy HLS rendition when the selected rendition loses a segment. */
+internal class HlsRenditionFallbackPolicy : DefaultLoadErrorHandlingPolicy() {
+    override fun getFallbackSelectionFor(
+        fallbackOptions: LoadErrorHandlingPolicy.FallbackOptions,
+        loadErrorInfo: LoadErrorHandlingPolicy.LoadErrorInfo,
+    ): LoadErrorHandlingPolicy.FallbackSelection? {
+        val responseCode = loadErrorInfo.exception
+            .findCause<HttpDataSource.InvalidResponseCodeException>()
+            ?.responseCode
+        if (
+            shouldPreferAlternativeHlsTrack(
+                responseCode = responseCode,
+                isMediaSegment = loadErrorInfo.mediaLoadData.dataType == C.DATA_TYPE_MEDIA,
+                alternativeTrackAvailable = fallbackOptions.isFallbackAvailable(
+                    LoadErrorHandlingPolicy.FALLBACK_TYPE_TRACK
+                ),
+            )
+        ) {
+            return LoadErrorHandlingPolicy.FallbackSelection(
+                LoadErrorHandlingPolicy.FALLBACK_TYPE_TRACK,
+                DefaultLoadErrorHandlingPolicy.DEFAULT_TRACK_EXCLUSION_MS,
+            )
+        }
+        return super.getFallbackSelectionFor(fallbackOptions, loadErrorInfo)
+    }
+}
+
+private inline fun <reified T : Throwable> Throwable.findCause(): T? {
+    var current: Throwable? = this
+    while (current != null) {
+        if (current is T) return current
+        current = current.cause
+    }
+    return null
+}

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -324,6 +324,7 @@ private fun ExoPlayerSurface(
     fun ExoPlayer.setPlaybackMediaItem(videoMediaItem: MediaItem, startPositionMs: Long? = null) {
         if (!sourceAudioUrl.isNullOrBlank()) {
             val mediaSourceFactory = DefaultMediaSourceFactory(dataSourceFactory, extractorsFactory)
+                .setLoadErrorHandlingPolicy(HlsRenditionFallbackPolicy())
             val videoSource = mediaSourceFactory.createMediaSource(videoMediaItem)
             val audioSource = mediaSourceFactory.createMediaSource(playbackMediaItemFromUrl(sourceAudioUrl))
             val mergedSource = MergingMediaSource(videoSource, audioSource)
@@ -399,7 +400,7 @@ private fun ExoPlayerSurface(
             val mediaSourceFactory = DefaultMediaSourceFactory(
                 dataSourceFactory,
                 extractorsFactory,
-            )
+            ).setLoadErrorHandlingPolicy(HlsRenditionFallbackPolicy())
 
             ExoPlayer.Builder(context)
                 .setRenderersFactory(renderersFactory)

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerLibassCompat.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerLibassCompat.kt
@@ -43,7 +43,7 @@ internal fun ExoPlayer.Builder.buildWithAssSupportCompat(
     val mediaSourceFactory = DefaultMediaSourceFactory(
         dataSourceFactory,
         assExtractorsFactory
-    )
+    ).setLoadErrorHandlingPolicy(HlsRenditionFallbackPolicy())
     mediaSourceFactory.setSubtitleParserFactory(assSubtitleParserFactory)
 
     val player = this

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/HlsRenditionFallback.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/HlsRenditionFallback.kt
@@ -1,0 +1,13 @@
+package com.nuvio.app.features.player
+
+/**
+ * A missing HLS media segment is specific to the active rendition. When the
+ * master playlist has another eligible track, let Media3 exclude the failing
+ * one rather than make the whole playback terminal.
+ */
+internal fun shouldPreferAlternativeHlsTrack(
+    responseCode: Int?,
+    isMediaSegment: Boolean,
+    alternativeTrackAvailable: Boolean,
+): Boolean =
+    responseCode == 404 && isMediaSegment && alternativeTrackAvailable

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/HlsRenditionFallbackTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/HlsRenditionFallbackTest.kt
@@ -1,0 +1,36 @@
+package com.nuvio.app.features.player
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class HlsRenditionFallbackTest {
+    @Test
+    fun mediaSegment404WithAlternativePrefersAnotherTrack() {
+        assertTrue(
+            shouldPreferAlternativeHlsTrack(
+                responseCode = 404,
+                isMediaSegment = true,
+                alternativeTrackAvailable = true,
+            )
+        )
+    }
+
+    @Test
+    fun manifestErrorsAndMissingAlternativesDoNotTriggerTrackFallback() {
+        assertFalse(
+            shouldPreferAlternativeHlsTrack(
+                responseCode = 404,
+                isMediaSegment = false,
+                alternativeTrackAvailable = true,
+            )
+        )
+        assertFalse(
+            shouldPreferAlternativeHlsTrack(
+                responseCode = 404,
+                isMediaSegment = true,
+                alternativeTrackAvailable = false,
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
Prefer track fallback when an HLS media segment returns HTTP 404 and another rendition is available. The policy recognizes HTTP response errors wrapped by the data source so Media3 can exclude the failing rendition instead of ending playback.

## PR type
- [x] Behavior bug/regression fix

## Why
A rendition-local segment 404 can currently become fatal even though the HLS master playlist has a playable alternative. This restores expected playback recovery.

## Issue or approval
Fixes #1844

## UI / behavior impact
- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries
Only HLS media-segment 404 fallback selection is changed. Manifest errors and streams without an alternative rendition remain on the existing error path.

## Testing
Added focused common test coverage for the fallback predicate. The Android host-test build was started, but the full module compilation was intentionally not awaited because this is a small, parity change and the equivalent focused NuvioTV test passed.

## Screenshots / Video (UI changes only)
Not a UI change.

## Breaking changes
None.

## Linked issues
Fixes #1844