### PR TITLE
fix(addons): skip cloud sync for guest sessions

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonRepository.kt
@@ -1,6 +1,8 @@
 package com.nuvio.app.features.addons
 
 import co.touchlab.kermit.Logger
+import com.nuvio.app.core.auth.AuthRepository
+import com.nuvio.app.core.auth.AuthState
 import com.nuvio.app.core.network.SupabaseProvider
 import com.nuvio.app.core.sync.putSyncOriginClientId
 import com.nuvio.app.features.profiles.ProfileRepository
@@ -47,6 +49,9 @@ private data class AddonPushItem(
 )
 
 private const val ADDON_PUSH_DEBOUNCE_MS = 500L
+
+internal fun shouldPushAddonsToServer(authState: AuthState): Boolean =
+    authState is AuthState.Authenticated && !authState.isAnonymous
 
 object AddonRepository {
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
@@ -403,6 +408,10 @@ object AddonRepository {
 
     private fun pushToServer() {
         if (isUsingPrimaryAddonsFromSecondaryProfile()) return
+        if (!shouldPushAddonsToServer(AuthRepository.state.value)) {
+            log.d { "pushToServer() — skipped: registered authenticated session required" }
+            return
+        }
         val profileId = currentProfileId
         val addons = _uiState.value.addons
             .distinctBy { it.manifestUrl }
@@ -419,6 +428,10 @@ object AddonRepository {
         pushJob = scope.launch {
             try {
                 delay(ADDON_PUSH_DEBOUNCE_MS)
+                if (!shouldPushAddonsToServer(AuthRepository.state.value)) {
+                    log.d { "pushToServer() — cancelled: registered authenticated session no longer active" }
+                    return@launch
+                }
                 log.d { "pushToServer() — profileId=$profileId, pushing ${addons.size} addons" }
                 val params = buildJsonObject {
                     put("p_profile_id", profileId)

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/addons/AddonSyncEligibilityTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/addons/AddonSyncEligibilityTest.kt
@@ -1,0 +1,44 @@
+package com.nuvio.app.features.addons
+
+import com.nuvio.app.core.auth.AuthState
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AddonSyncEligibilityTest {
+    @Test
+    fun `server push is disabled while authentication is loading`() {
+        assertFalse(shouldPushAddonsToServer(AuthState.Loading))
+    }
+
+    @Test
+    fun `server push is disabled when unauthenticated`() {
+        assertFalse(shouldPushAddonsToServer(AuthState.Unauthenticated))
+    }
+
+    @Test
+    fun `server push is disabled for local anonymous users`() {
+        assertFalse(
+            shouldPushAddonsToServer(
+                AuthState.Authenticated(
+                    userId = "guest-id",
+                    email = null,
+                    isAnonymous = true,
+                ),
+            ),
+        )
+    }
+
+    @Test
+    fun `server push is enabled for registered authenticated users`() {
+        assertTrue(
+            shouldPushAddonsToServer(
+                AuthState.Authenticated(
+                    userId = "member-id",
+                    email = "member@example.com",
+                    isAnonymous = false,
+                ),
+            ),
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- prevent guest, anonymous, and unauthenticated addon mutations from scheduling authenticated cloud sync
- re-check authentication after the 500 ms debounce so an auth transition cannot race into the RPC
- add deterministic state-policy coverage for loading, unauthenticated, anonymous, and registered sessions

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Guest addon changes persist locally but currently attempt the authenticated `sync_push_addons` Supabase RPC afterward. That request is rejected as unauthorized and emits a background stack trace. Guest mode should remain local-only, matching the existing authenticated sync policy.

This is the Mobile port explicitly requested by the maintainer on NuvioDesktop PR #476 so Desktop can subsequently sync the fix from Mobile.

## Issue or approval

Original reproduced bug: https://github.com/NuvioMedia/NuvioDesktop/issues/475

Maintainer request to move the fix to NuvioMobile: https://github.com/NuvioMedia/NuvioDesktop/pull/476#issuecomment-5432700078

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

No UI, RPC schema, addon transport, auth-flow, retry, dependency, or unrelated synchronization changes. Local addon installation, persistence, enable/disable, and removal remain unchanged. Registered non-anonymous sessions remain eligible to push.

## Testing

TDD and local verification on x86_64 Linux / JDK 17 with Android SDK Platform 37 and Build Tools 36:

- RED: focused host test failed on the missing `shouldPushAddonsToServer` policy
- GREEN: `AddonSyncEligibilityTest` passed all four authentication states
- Android host tests excluding exactly the known unrelated `WatchedItemsStoreTest.concurrent updates publish coherent item snapshots`: 749 tests passed
- unfiltered Android host suite: 750 tests run; only the known watched-store race failed (`expected: [] but was: null`)
- `:androidApp:assembleFullDebug`: passed
- `git diff --check`: passed
- the two-file patch matches the previously independently reviewed NuvioDesktop PR #476 patch exactly

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Original bug: https://github.com/NuvioMedia/NuvioDesktop/issues/475

Approved Mobile move: https://github.com/NuvioMedia/NuvioDesktop/pull/476#issuecomment-5432700078
