### PR TITLE
i18n(el): translate delayed addon content state strings

### DIFF
--- a/composeApp/src/commonMain/composeResources/values-el/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-el/strings.xml
@@ -408,6 +408,7 @@
     <string name="settings_homescreen_display_name">Εμφανιζόμενο όνομα</string>
     <string name="settings_homescreen_empty_message">Εγκαταστήστε ένα πρόσθετο με καταλόγους συμβατούς με πίνακα για να διαμορφώσετε τις γραμμές αρχικής οθόνης.</string>
     <string name="settings_homescreen_empty_title">Δεν υπάρχουν κατάλογοι αρχικής</string>
+    <string name="settings_homescreen_load_failed_title">Αδυναμία φόρτωσης καταλόγων αρχικής</string>
     <string name="settings_homescreen_hero_source">Πηγή hero</string>
     <string name="settings_homescreen_hidden">Κρυφό</string>
     <string name="settings_homescreen_keep_home_focused">Διατήρηση εστίασης στην Αρχική</string>
@@ -955,6 +956,7 @@
     <string name="app_exit_title">Έξοδος από εφαρμογή</string>
     <string name="catalog_empty_message">Αυτός ο κατάλογος δεν επέστρεψε κανένα στοιχείο.</string>
     <string name="catalog_empty_title">Δεν βρέθηκαν τίτλοι</string>
+    <string name="catalog_load_failed_title">Αδυναμία φόρτωσης αυτού του καταλόγου</string>
     <string name="details_check_connection">Ελέγξτε τη σύνδεση Wi-Fi ή κινητών δεδομένων και δοκιμάστε ξανά.</string>
     <string name="details_director">Σκηνοθέτης</string>
     <string name="details_failed_to_load">Αποτυχία φόρτωσης</string>
@@ -992,6 +994,7 @@
     <string name="home_empty_no_active_addons_message">Εγκαταστήστε και επικυρώστε τουλάχιστον ένα πρόσθετο πριν φορτώσετε γραμμές καταλόγου στην Αρχική.</string>
     <string name="home_empty_no_rows_message">Τα εγκατεστημένα πρόσθετα δεν παρέχουν αυτή τη στιγμή καταλόγους συμβατούς με πίνακα χωρίς απαιτούμενα extras.</string>
     <string name="home_empty_no_rows_title">Δεν υπάρχουν διαθέσιμες γραμμές αρχικής</string>
+    <string name="home_load_failed_title">Αδυναμία φόρτωσης αρχικής</string>
     <string name="home_view_details">Προβολή λεπτομερειών</string>
     <string name="meta_section_actions_description">Έλεγχοι αναπαραγωγής και αποθήκευσης.</string>
     <string name="meta_section_actions_title">Ενέργειες</string>
@@ -1326,6 +1329,8 @@
     <string name="cloud_library_load_failed">Δεν ήταν δυνατή η φόρτωση της βιβλιοθήκης Cloud %1$s</string>
     <string name="cloud_library_no_files_message">Αυτό το στοιχείο δεν εκθέτει ένα αναπαίξιμο αρχείο βίντεο.</string>
     <string name="cloud_library_no_files_title">Δεν υπάρχουν αναπαίξιμα αρχεία</string>
+    <string name="cloud_library_no_matches_message">Κανένα αναπαίξιμο αρχείο Cloud δεν ταιριάζει με τα τρέχοντα φίλτρα.</string>
+    <string name="cloud_library_no_matches_title">Δεν υπάρχουν αντίστοιχα αρχεία</string>
     <string name="cloud_library_no_playable_files">Δεν υπάρχουν αναπαίξιμα αρχεία</string>
     <string name="cloud_library_play_disabled">Η βιβλιοθήκη Cloud είναι απενεργοποιημένη.</string>
     <string name="cloud_library_play_failed">Δεν ήταν δυνατή η αναπαραγωγή αυτού του αρχείου Cloud.</string>


### PR DESCRIPTION
## Summary

Completes the Greek (el) localization for the delayed addon content states added in `fix(ui): handle delayed addon content states` (Fixes #1819) by adding the **5 missing strings**:

- `settings_homescreen_load_failed_title` — Couldn't load Home catalogs
- `catalog_load_failed_title` — Couldn't load this catalog
- `home_load_failed_title` — Couldn't load Home
- `cloud_library_no_matches_message` — No playable cloud files match the current filters.
- `cloud_library_no_matches_title` — No matching files

Translations follow the existing Greek terminology: the "Couldn't load…" titles use the established "Αδυναμία φόρτωσης…" pattern already used by `discover_empty_load_failed_title`, `streams_empty_load_failed_title` and `catalog_load_failed`; "αρχικής" matches the existing "Δεν υπάρχουν κατάλογοι αρχικής" / "Δεν υπάρχουν διαθέσιμες γραμμές αρχικής"; and `cloud_library_no_matches_message` reuses the exact wording already used for the identical English text in `cloud_library_empty_message`.

Note: the English source for the three "Couldn't…" strings contains corrupted characters (`CouldnέΑβt` instead of `Couldn't`). The Greek translations use the intended meaning.

## PR type

<!-- Check exactly one. PRs outside these types are not accepted. -->
- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [x] Translation/localization only
- [ ] Approved larger or directional change

## Why

The Greek translation was missing the keys for the new delayed-content error states, so Greek users would see English fallback text when Home, a catalog, or the Cloud library fails to load.

## Issue or approval

No linked issue: translation/localization update, which is explicitly allowed by `CONTRIBUTING.md` without an issue.

## UI / behavior impact

<!-- Check every box that applies. At least one must be checked. -->
- [x] No UI change
- [x] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

<!-- ALL boxes must be checked or the PR will be closed without review. -->
- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only `composeApp/src/commonMain/composeResources/values-el/strings.xml` was changed. No other files, no code changes.

## Testing

- Verified the file parses as valid XML.
- Programmatically compared all string keys against `values/strings.xml`: **2205/2205 keys present, 0 missing, 0 duplicates** (including plurals).
- Reviewed every new translation for consistency with existing Greek terminology (e.g., "Αδυναμία φόρτωσης…" matching `discover_empty_load_failed_title` / `streams_empty_load_failed_title`, "αρχικής" matching "Δεν υπάρχουν κατάλογοι αρχικής").
- Confirmed no format placeholders are required in the new strings (none of the source strings contain any).

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - translation/localization update (allowed by `CONTRIBUTING.md`).