### PR TITLE
fix(startup): unify launch overlay and cold-start state

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/AppGate.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/AppGate.kt
@@ -3,6 +3,8 @@ package com.nuvio.app
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.MutableTransitionState
 import androidx.compose.animation.core.tween
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.scaleIn
@@ -143,7 +145,29 @@ internal fun AppGate(
         )
     }
 
-    var gateScreen by rememberSaveable { mutableStateOf(AppGateScreen.Loading.name) }
+    val initialGateScreen = remember {
+        val currentProfiles = ProfileRepository.state.value.profiles
+        val currentProfileState = ProfileRepository.state.value
+        val remembered = if (
+            currentProfileState.rememberLastProfileEnabled &&
+            currentProfileState.hasEverSelectedProfile
+        ) {
+            currentProfiles.find { it.profileIndex == ProfileRepository.activeProfileId }?.takeUnless { it.pinEnabled }
+        } else if (currentProfiles.size == 1 && !currentProfiles.first().pinEnabled) {
+            currentProfiles.first()
+        } else {
+            null
+        }
+
+        if (remembered != null) {
+            AppGateScreen.Main.name
+        } else if (currentProfiles.isNotEmpty()) {
+            AppGateScreen.ProfileSelection.name
+        } else {
+            AppGateScreen.Loading.name
+        }
+    }
+    var gateScreen by rememberSaveable { mutableStateOf(initialGateScreen) }
     var editingProfile by remember { mutableStateOf<NuvioProfile?>(null) }
     var autoSkipProfileSelection by rememberSaveable { mutableStateOf(false) }
     var profileSelectionLoading by rememberSaveable { mutableStateOf(false) }
@@ -254,7 +278,9 @@ internal fun AppGate(
         if (!renderMainContent) {
             appGateController?.beginContentReload()
         }
-        ProfileRepository.selectProfile(profile.profileIndex)
+        if (ProfileRepository.activeProfileId != profile.profileIndex) {
+            ProfileRepository.selectProfile(profile.profileIndex)
+        }
         if (sync) {
             SyncManager.pullAllForProfile(profile.profileIndex)
         }
@@ -270,7 +296,11 @@ internal fun AppGate(
         }
 
         rememberedStartupProfile(profiles)?.let { profile ->
-            selectProfile(profile, sync = syncOnEnter)
+            if (ProfileRepository.activeProfileId != profile.profileIndex) {
+                selectProfile(profile, sync = syncOnEnter)
+            } else if (syncOnEnter) {
+                SyncManager.pullAllForProfile(profile.profileIndex)
+            }
             gateScreen = AppGateScreen.Main.name
             autoSkipProfileSelection = false
             return
@@ -283,7 +313,11 @@ internal fun AppGate(
                 gateScreen = AppGateScreen.ProfileSelection.name
                 return
             }
-            selectProfile(onlyProfile, sync = syncOnEnter)
+            if (ProfileRepository.activeProfileId != onlyProfile.profileIndex) {
+                selectProfile(onlyProfile, sync = syncOnEnter)
+            } else if (syncOnEnter) {
+                SyncManager.pullAllForProfile(onlyProfile.profileIndex)
+            }
             gateScreen = AppGateScreen.Main.name
             autoSkipProfileSelection = false
         } else {
@@ -335,6 +369,9 @@ internal fun AppGate(
         val authenticatedState = authState as? AuthState.Authenticated ?: return@LaunchedEffect
         ProfileRepository.ensureLoaded(authenticatedState.userId)
         ProfileRepository.pullProfiles()
+        ProfileRepository.state.value.activeProfile?.let { active ->
+            SyncManager.pullAllForProfile(active.profileIndex)
+        }
     }
 
     LaunchedEffect(
@@ -413,20 +450,23 @@ internal fun AppGate(
             targetState = gateScreen,
             label = "app_gate",
             transitionSpec = {
-                (fadeIn(tween(400)) + scaleIn(tween(400), initialScale = 0.94f))
-                    .togetherWith(fadeOut(tween(250)))
+                if (
+                    (initialState == AppGateScreen.Loading.name && targetState == AppGateScreen.Main.name) ||
+                    (initialState == AppGateScreen.Main.name && targetState == AppGateScreen.Loading.name)
+                ) {
+                    EnterTransition.None togetherWith ExitTransition.None
+                } else {
+                    (fadeIn(tween(400)) + scaleIn(tween(400), initialScale = 0.94f))
+                        .togetherWith(fadeOut(tween(250)))
+                }
             },
         ) { currentGate ->
             when (currentGate) {
                 AppGateScreen.Loading.name -> {
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(MaterialTheme.nuvio.colors.background),
-                        contentAlignment = Alignment.Center,
-                    ) {
-                        NuvioLoadingIndicator(color = MaterialTheme.nuvio.colors.accent)
-                    }
+                    AppLaunchOverlay(
+                        profile = profileState.activeProfile ?: profileState.profiles.firstOrNull(),
+                        modifier = Modifier.fillMaxSize(),
+                    )
                 }
                 AppGateScreen.Auth.name -> {
                     AuthScreen(modifier = Modifier.fillMaxSize())

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/MainAppContent.kt
@@ -476,7 +476,7 @@ internal fun MainAppContent(
         if (!ownsAppRuntime) return@LaunchedEffect
         NetworkStatusRepository.ensureStarted()
         EpisodeReleaseNotificationsRepository.refreshAsync()
-        kotlinx.coroutines.delay(5_000)
+        kotlinx.coroutines.delay(2_000)
         initialHomeReady = true
     }
 
@@ -484,6 +484,9 @@ internal fun MainAppContent(
         if (!ownsAppRuntime) return@LaunchedEffect
         val condition = networkStatusUiState.condition
         if (!networkToastBaselineReady) {
+            if (condition == NetworkCondition.Checking || condition == NetworkCondition.Unknown) {
+                return@LaunchedEffect
+            }
             networkToastBaselineReady = true
             lastNetworkToastCondition = condition.name
             return@LaunchedEffect

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/network/NetworkStatusRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/network/NetworkStatusRepository.kt
@@ -75,7 +75,7 @@ object NetworkStatusRepository {
     fun ensureStarted() {
         if (started) return
         started = true
-        requestRefresh(force = true)
+        requestRefresh(force = true, confirmFailures = true)
     }
 
     fun requestForegroundRefresh() {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/home/HomeScreen.kt
@@ -801,16 +801,23 @@ fun HomeScreen(
     val addonManifestsLoading = enabledAddons.any { it.isRefreshing }
     val addonManifestErrorMessage = enabledAddons.firstEnabledManifestError()
     val isResolvingHeroSources = addonManifestsLoading || homeUiState.isLoading
-    var firstCatalogReported by remember { mutableStateOf(false) }
-
-    LaunchedEffect(homeUiState.sections.firstOrNull()?.key, onFirstCatalogRendered) {
-        if (firstCatalogReported || homeUiState.sections.isEmpty()) return@LaunchedEffect
-        firstCatalogReported = true
-        onFirstCatalogRendered?.invoke()
-    }
-
     val visibleCollections = remember(collections) {
         collections.filter { it.folders.isNotEmpty() }
+    }
+    var firstCatalogReported by remember { mutableStateOf(false) }
+
+    LaunchedEffect(
+        homeUiState.sections.firstOrNull()?.key,
+        visibleCollections.isNotEmpty(),
+        onFirstCatalogRendered,
+    ) {
+        if (firstCatalogReported) return@LaunchedEffect
+        val hasAnyVisibleContent = homeUiState.sections.isNotEmpty() ||
+            visibleCollections.isNotEmpty()
+        if (hasAnyVisibleContent) {
+            firstCatalogReported = true
+            onFirstCatalogRendered?.invoke()
+        }
     }
     val collectionsMap = remember(visibleCollections) {
         visibleCollections.associateBy { "collection_${it.id}" }


### PR DESCRIPTION
## Summary

Use cached startup state earlier and keep the initial launch experience consistent while the app determines profile, home-content, and network readiness.

This PR:

- derives the initial app-gate destination from cached profile state;
- uses the existing launch overlay instead of an intermediate black spinner;
- treats either catalog sections or visible collections as initial Home content;
- waits for a meaningful network condition before establishing the notification baseline;
- confirms failures during the first network refresh; and
- shortens the final Home readiness fallback from five seconds to two seconds.

These are the four shared `commonMain` changes staged in NuvioMobile PR #1850 from the original implementation in [NuvioDesktop PR #546](https://github.com/NuvioMedia/NuvioDesktop/pull/546), rebased onto the latest `cmp-rewrite`.

The Desktop-only companion is [NuvioDesktop PR #581](https://github.com/NuvioMedia/NuvioDesktop/pull/581).

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On a cold launch, startup state could be resolved in separate stages instead of using the cached profile and available Home content immediately. This could expose an intermediate black spinner, delay Home readiness, and surface a misleading network message while the initial condition was still being determined.

The new flow recognizes usable cached profile state immediately, keeps the launch overlay consistent, and only reports a network transition after a meaningful baseline exists.

## Issue or approval

Fixes #1853

Issue #1853 was automatically closed by a false-positive triage rule. Its wording was corrected, the `needs-info` label was removed automatically, and reopening was requested.

The original implementation and the maintainer request to move the shared work to Mobile are documented in [NuvioDesktop PR #546](https://github.com/NuvioMedia/NuvioDesktop/pull/546) and NuvioMobile PR #1850.

Desktop companion: [NuvioDesktop PR #581](https://github.com/NuvioMedia/NuvioDesktop/pull/581)

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only these shared startup paths were changed:

- app-gate initial routing and loading presentation;
- initial Home readiness;
- initial network-status baseline and failure confirmation.

No dependencies, architecture, navigation structure, profile UX, native platform entry points, or unrelated Home/network behavior were changed.

Desktop integration note: current Desktop `Dev` contains newer profile-switch and repository-warming work in `AppGate.kt`. When these shared changes are synchronized into Desktop, that newer path should be preserved during conflict resolution. This does not affect this PR against `cmp-rewrite`.

## Testing

- Ran `.\gradlew.bat --offline --console=plain :composeApp:testAndroidHostTest --tests "com.nuvio.app.features.home.HomeScreenTest" --tests "com.nuvio.app.features.profiles.ProfileSelectionRoutingTest" :composeApp:compileAndroidMain`.
- Built and installed Full Debug with `.\gradlew.bat --offline --console=plain :androidApp:installFullDebug`.
- Cold-launched the app on a Pixel 7 emulator running Android 16 / API 36.
- Confirmed there was no intermediate black spinner or misleading “Cannot reach servers” message, Home loaded normally, and the app remained responsive.
- Windows skipped iOS-only targets as expected; iOS runtime behavior was not manually verified.

## Screenshots / Video

The original combined implementation and its before/after recordings are preserved in [NuvioDesktop PR #546](https://github.com/NuvioMedia/NuvioDesktop/pull/546):

### Before

https://github.com/user-attachments/assets/544a4391-1448-4c8c-93c3-86b753865c29

### After

https://github.com/user-attachments/assets/98bceed7-17f8-4890-957f-59a62014d7d7

Those recordings show the shared launch-gate behavior on Desktop. The same `commonMain` change was manually verified on Android as described above.

## Breaking changes

None.

## Linked issues

Fixes #1853

Desktop companion: [NuvioDesktop PR #581](https://github.com/NuvioMedia/NuvioDesktop/pull/581)
