### PR TITLE
fix(streams): render description emoji in color

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/streams/StreamSubtitleEmojiFontFamily.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/streams/StreamSubtitleEmojiFontFamily.android.kt
@@ -1,0 +1,5 @@
+package com.nuvio.app.features.streams
+
+import androidx.compose.ui.text.font.FontFamily
+
+internal actual val streamSubtitleEmojiFontFamily: FontFamily? = null

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamCard.kt
@@ -122,6 +122,8 @@ internal fun StreamCard(
                 Text(
                     text = subtitle,
                     style = MaterialTheme.typography.bodySmall.copy(
+                        fontFamily = streamSubtitleEmojiFontFamily
+                            ?: MaterialTheme.typography.bodySmall.fontFamily,
                         fontSize = 12.sp,
                         lineHeight = 18.sp,
                     ),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamSubtitleEmojiFontFamily.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamSubtitleEmojiFontFamily.kt
@@ -1,0 +1,5 @@
+package com.nuvio.app.features.streams
+
+import androidx.compose.ui.text.font.FontFamily
+
+internal expect val streamSubtitleEmojiFontFamily: FontFamily?

--- a/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/streams/StreamSubtitleEmojiFontFamily.desktop.kt
+++ b/composeApp/src/desktopMain/kotlin/com/nuvio/app/features/streams/StreamSubtitleEmojiFontFamily.desktop.kt
@@ -1,0 +1,12 @@
+package com.nuvio.app.features.streams
+
+import androidx.compose.ui.text.ExperimentalTextApi
+import androidx.compose.ui.text.font.FontFamily
+
+@OptIn(ExperimentalTextApi::class)
+internal actual val streamSubtitleEmojiFontFamily: FontFamily? =
+    if (System.getProperty("os.name").orEmpty().startsWith("Windows")) {
+        FontFamily("Segoe UI Emoji")
+    } else {
+        null
+    }

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/streams/StreamSubtitleEmojiFontFamily.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/streams/StreamSubtitleEmojiFontFamily.ios.kt
@@ -1,0 +1,5 @@
+package com.nuvio.app.features.streams
+
+import androidx.compose.ui.text.font.FontFamily
+
+internal actual val streamSubtitleEmojiFontFamily: FontFamily? = null


### PR DESCRIPTION
## Summary

- Add an optional platform-specific font for stream-description emoji rendering.
- Use Segoe UI Emoji only on Windows Desktop while preserving the existing subtitle typography on Android/TV, iOS, macOS, and Linux.
- Submit the change through NuvioMobile because the affected stream-card UI lives in `commonMain`. Per maintainer guidance, shared-code changes should originate in Mobile before flowing to NuvioDesktop.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On Windows Desktop, emoji supplied in addon stream descriptions are rendered as monochrome text glyphs instead of color emoji. The same AIOStreams configuration and custom Tamtaro description template render the emoji in color on Android.

The stream subtitle inherits Nuvio's bundled text font. This change lets only the verified Windows rendering path select Segoe UI Emoji, without changing the subtitle data or other platform typography.

## Issue or approval

Fixes #1858

## UI / behavior impact

- [ ] No UI change
- [x] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Changes only the font used to draw `stream.streamSubtitle` on Windows Desktop.
- Does not modify stream parsing, addon output, AIOStreams/Tamtaro templates, Nuvio's Stream Name or Stream Description templates, debrid handling, metadata, stream titles, badges, or logo images.
- Android/TV and iOS return no font override.
- macOS and Linux return no font override because the issue was not reproduced or tested on those platforms.
- Adds no dependencies and includes no unrelated UI polish or behavior changes.

## Testing

- Manually reproduced the monochrome emoji on Windows Desktop using AIOStreams with a custom Tamtaro description template.
- Manually verified the Windows result after the change: description emoji render in color and the remaining subtitle text stays readable.
- Manually checked the same configuration on Android; stream descriptions and ordinary text remain correct.
- Desktop: `.\gradlew.bat :composeApp:compileKotlinDesktop :composeApp:desktopTest --console=plain`
- Shared Mobile targets: `.\gradlew.bat :composeApp:compileAndroidMain :composeApp:testAndroid :composeApp:compileIosMainKotlinMetadata --console=plain`

Both focused Gradle runs completed successfully.

## Screenshots / Video

Before — monochrome emoji:

![Before](https://github.com/user-attachments/assets/5c48a0c1-b74c-4649-9300-99704a3b022e)

After — Windows color emoji:

![After](https://github.com/user-attachments/assets/ac638154-1448-4a7c-a503-54f4284dfc05)

## Breaking changes

None.

## Linked issues

Fixes #1858
