### PR TITLE
feat(streams): smarter automatic stream selection

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/MainActivity.kt
@@ -63,6 +63,8 @@ import com.nuvio.app.features.watched.WatchedStorage
 import com.nuvio.app.features.streams.StreamLinkCacheStorage
 import com.nuvio.app.features.streams.StreamBadgeSettingsStorage
 import com.nuvio.app.features.streams.BingeGroupCacheStorage
+import com.nuvio.app.features.streams.AndroidSmartStreamContext
+import com.nuvio.app.features.streams.SmartStreamSelector
 import com.nuvio.app.features.watchprogress.ContinueWatchingEnrichmentStorage
 import com.nuvio.app.features.watchprogress.ContinueWatchingPreferencesStorage
 import com.nuvio.app.features.watchprogress.ResumePromptStorage
@@ -137,6 +139,9 @@ open class MainActivity : AppCompatActivity() {
         PlatformLocalAccountDataCleaner.initialize(applicationContext)
         EpisodeReleaseNotificationPlatform.initialize(applicationContext)
         EpisodeReleaseNotificationPlatform.bindActivity(this)
+        SmartStreamSelector.setPlatformContextProvider {
+            AndroidSmartStreamContext.current(applicationContext)
+        }
         handleIncomingAppIntent(intent)
 
         setContent {

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/streams/AndroidSmartStreamContext.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/streams/AndroidSmartStreamContext.kt
@@ -1,0 +1,50 @@
+package com.nuvio.app.features.streams
+
+import android.content.Context
+import android.hardware.display.DisplayManager
+import android.net.ConnectivityManager
+import android.os.Build
+import android.view.Display
+
+object AndroidSmartStreamContext {
+    fun current(context: Context): SmartStreamSelector.Context {
+        val display = context.getSystemService(DisplayManager::class.java)
+            ?.getDisplay(Display.DEFAULT_DISPLAY)
+
+        val mode = display?.mode
+        val displayWidth = mode?.physicalWidth?.takeIf { it > 0 }
+        val displayHeight = mode?.physicalHeight?.takeIf { it > 0 }
+        val hdrTypes = display?.supportedHdrTypes().orEmpty()
+
+        val connectivityManager = context.getSystemService(ConnectivityManager::class.java)
+        val bandwidthKbps = connectivityManager?.getActiveNetwork()
+            ?.let(connectivityManager::getNetworkCapabilities)
+            ?.getLinkDownstreamBandwidthKbps()
+            ?.takeIf { it > 0 }
+
+        return SmartStreamSelector.Context(
+            estimatedBandwidthKbps = bandwidthKbps,
+            displayWidth = displayWidth,
+            displayHeight = displayHeight,
+            supportsHdr = hdrTypes.isNotEmpty(),
+            supportedHdrTypes = hdrTypes,
+        )
+    }
+
+    private fun Display.supportedHdrTypes(): Set<String> {
+        val types = if (Build.VERSION.SDK_INT >= 34) {
+            mode?.supportedHdrTypes?.toSet().orEmpty()
+        } else {
+            hdrCapabilities?.supportedHdrTypes?.toSet().orEmpty()
+        }
+        return types.mapNotNull { type ->
+            when (type) {
+                Display.HdrCapabilities.HDR_TYPE_DOLBY_VISION -> "dolbyvision"
+                Display.HdrCapabilities.HDR_TYPE_HDR10 -> "hdr10"
+                Display.HdrCapabilities.HDR_TYPE_HDR10_PLUS -> "hdr10+"
+                Display.HdrCapabilities.HDR_TYPE_HLG -> "hlg"
+                else -> null
+            }
+        }.toSet()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/streams/AndroidSmartStreamContext.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/streams/AndroidSmartStreamContext.kt
@@ -26,7 +26,7 @@ object AndroidSmartStreamContext {
             estimatedBandwidthKbps = bandwidthKbps,
             displayWidth = displayWidth,
             displayHeight = displayHeight,
-            supportsHdr = hdrTypes.isNotEmpty(),
+            supportsHdr = display?.let { hdrTypes.isNotEmpty() },
             supportedHdrTypes = hdrTypes,
         )
     }

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/streams/AndroidSmartStreamContext.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/streams/AndroidSmartStreamContext.kt
@@ -12,8 +12,12 @@ object AndroidSmartStreamContext {
             ?.getDisplay(Display.DEFAULT_DISPLAY)
 
         val mode = display?.mode
-        val displayWidth = mode?.physicalWidth?.takeIf { it > 0 }
-        val displayHeight = mode?.physicalHeight?.takeIf { it > 0 }
+        val rawWidth = mode?.physicalWidth?.takeIf { it > 0 }
+        val rawHeight = mode?.physicalHeight?.takeIf { it > 0 }
+
+        // For video resolution matching, displayHeight corresponds to the short dimension (vertical pixels in landscape)
+        val displayWidth = if (rawWidth != null && rawHeight != null) maxOf(rawWidth, rawHeight) else rawWidth
+        val displayHeight = if (rawWidth != null && rawHeight != null) minOf(rawWidth, rawHeight) else rawHeight
         val hdrTypes = display?.supportedHdrTypes().orEmpty()
 
         val connectivityManager = context.getSystemService(ConnectivityManager::class.java)

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
@@ -112,8 +112,9 @@ object SmartStreamSelector {
                 requiredKbps <= bandwidthKbps * 60 / 100 -> 35
                 requiredKbps <= bandwidthKbps * 75 / 100 -> 20
                 requiredKbps <= bandwidthKbps * 90 / 100 -> 5
-                requiredKbps <= bandwidthKbps -> -30
-                else -> -100
+                requiredKbps <= bandwidthKbps -> 0
+                requiredKbps <= bandwidthKbps * 125 / 100 -> -15
+                else -> -60
             }
         }
 
@@ -169,11 +170,12 @@ object SmartStreamSelector {
 
     private fun resolutionHeight(value: String): Int {
         val normalized = value.lowercase()
-        val match = Regex("(?:^|\\D)(2160|1440|1080|720|576|540|480|360)p?(?:\\D|$)").find(normalized)
+        val match = Regex("(?:^|\\D)(4320|2160|1440|1080|720|576|540|480|360)p?(?:\\D|$)").find(normalized)
         if (match != null) return match.groupValues[1].toInt()
         return when {
+            "8k" in normalized -> 4320
             "4k" in normalized || "uhd" in normalized -> 2160
-            "2k" in normalized -> 1440
+            "2k" in normalized || "qhd" in normalized -> 1440
             else -> 0
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
@@ -3,6 +3,9 @@ package com.nuvio.app.features.streams
 /**
  * Deterministic quality-aware ordering for automatic stream selection.
  * Manual stream selection is intentionally unaffected.
+ *
+ * Explicit preferences are applied before the general quality score. This keeps
+ * automatic ranking from overriding a user's configured stream preference.
  */
 object SmartStreamSelector {
     data class Context(
@@ -13,6 +16,7 @@ object SmartStreamSelector {
         val dataSaver: Boolean = false,
         val preferredVideoCodec: String? = null,
         val preferredAudioLanguage: String? = null,
+        val preferredStreamTerms: List<String> = emptyList(),
     )
 
     fun rank(
@@ -21,10 +25,32 @@ object SmartStreamSelector {
     ): List<StreamItem> = streams
         .withIndex()
         .sortedWith(
-            compareByDescending<IndexedValue<StreamItem>> { score(it.value, context) }
+            compareByDescending<IndexedValue<StreamItem>> { preferenceScore(it.value, context) }
+                .thenByDescending { score(it.value, context) }
                 .thenBy { it.index }
         )
         .map { it.value }
+
+    private fun preferenceScore(stream: StreamItem, context: Context): Int {
+        if (context.preferredStreamTerms.isEmpty()) return 0
+        val text = listOfNotNull(
+            stream.name,
+            stream.description,
+            stream.behaviorHints.filename,
+            stream.clientResolve?.filename,
+            stream.clientResolve?.torrentName,
+            stream.clientResolve?.stream?.raw?.parsed?.resolution,
+            stream.clientResolve?.stream?.raw?.parsed?.quality,
+            stream.clientResolve?.stream?.raw?.parsed?.codec,
+        ).joinToString(" ").lowercase()
+
+        context.preferredStreamTerms.forEachIndexed { index, term ->
+            if (term.isNotBlank() && term.lowercase() in text) {
+                return (context.preferredStreamTerms.size - index) * 1_000
+            }
+        }
+        return 0
+    }
 
     private fun score(stream: StreamItem, context: Context): Int {
         val parsed = stream.clientResolve?.stream?.raw?.parsed

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
@@ -1,0 +1,128 @@
+package com.nuvio.app.features.streams
+
+/**
+ * Deterministic quality-aware ordering for automatic stream selection.
+ * Manual stream selection is intentionally unaffected.
+ */
+object SmartStreamSelector {
+    data class Context(
+        val estimatedBandwidthKbps: Int? = null,
+        val displayWidth: Int? = null,
+        val displayHeight: Int? = null,
+        val supportsHdr: Boolean = false,
+        val dataSaver: Boolean = false,
+        val preferredVideoCodec: String? = null,
+        val preferredAudioLanguage: String? = null,
+    )
+
+    fun rank(
+        streams: List<StreamItem>,
+        context: Context = Context(),
+    ): List<StreamItem> = streams
+        .withIndex()
+        .sortedWith(
+            compareByDescending<IndexedValue<StreamItem>> { score(it.value, context) }
+                .thenBy { it.index }
+        )
+        .map { it.value }
+
+    private fun score(stream: StreamItem, context: Context): Int {
+        val parsed = stream.clientResolve?.stream?.raw?.parsed
+        val text = listOfNotNull(
+            stream.name,
+            stream.description,
+            stream.behaviorHints.filename,
+            stream.clientResolve?.filename,
+            stream.clientResolve?.torrentName,
+            parsed?.resolution,
+            parsed?.quality,
+            parsed?.codec,
+        ).joinToString(" ").lowercase()
+
+        var score = 0
+        val resolution = resolutionHeight(parsed?.resolution ?: text)
+        if (resolution > 0) {
+            score += when {
+                context.dataSaver -> when {
+                    resolution <= 480 -> 70
+                    resolution <= 720 -> 90
+                    resolution <= 1080 -> 80
+                    else -> 45
+                }
+                context.displayHeight != null -> {
+                    val displayHeight = context.displayHeight!!
+                    when {
+                        resolution <= displayHeight -> 100 + resolution / 100
+                        else -> maxOf(0, 100 - (resolution - displayHeight) / 20)
+                    }
+                }
+                else -> when (resolution) {
+                    2160 -> 130
+                    1440 -> 120
+                    1080 -> 110
+                    720 -> 90
+                    480 -> 70
+                    else -> 50
+                }
+            }
+        }
+
+        val sizeBytes = stream.behaviorHints.videoSize ?: stream.clientResolve?.stream?.raw?.size
+        val bandwidthKbps = context.estimatedBandwidthKbps
+        val durationSeconds = parsed?.duration?.takeIf { it > 0 }
+        if (bandwidthKbps != null && bandwidthKbps > 0 && sizeBytes != null && durationSeconds != null) {
+            val requiredKbps = (sizeBytes * 8L / 1000L / durationSeconds)
+                .coerceAtMost(Int.MAX_VALUE.toLong())
+                .toInt()
+            score += when {
+                requiredKbps <= bandwidthKbps * 60 / 100 -> 35
+                requiredKbps <= bandwidthKbps * 75 / 100 -> 20
+                requiredKbps <= bandwidthKbps * 90 / 100 -> 5
+                requiredKbps <= bandwidthKbps -> -30
+                else -> -100
+            }
+        }
+
+        val hdr = parsed?.hdr.orEmpty().any { it.isNotBlank() } ||
+            listOf("dolby vision", "dolbyvision", "hdr10", "hdr10+", "hlg").any { it in text }
+        score += if (hdr) {
+            if (context.supportsHdr) 20 else -25
+        } else 5
+
+        val codec = parsed?.codec?.lowercase() ?: when {
+            "av1" in text -> "av1"
+            "hevc" in text || "h265" in text || "x265" in text -> "hevc"
+            "h264" in text || "x264" in text -> "h264"
+            else -> ""
+        }
+        if (context.preferredVideoCodec?.equals(codec, ignoreCase = true) == true) score += 15
+        score += when (codec) {
+            "av1", "hevc", "h265", "x265" -> 5
+            "h264", "x264" -> 3
+            else -> 0
+        }
+
+        if (context.preferredAudioLanguage != null && parsed?.languages.orEmpty().any {
+                it.equals(context.preferredAudioLanguage, ignoreCase = true)
+            }) score += 12
+
+        if (stream.isDirectDebridStream || stream.isCachedDebridTorrentStream) score += 35
+        if (stream.clientResolve?.isCached == true) score += 35
+        if (stream.playableDirectUrl != null) score += 20
+        if (stream.isTorrentStream && !stream.isCachedDebridTorrentStream) score -= 10
+        if (stream.behaviorHints.notWebReady) score -= 15
+
+        return score
+    }
+
+    private fun resolutionHeight(value: String): Int {
+        val normalized = value.lowercase()
+        val match = Regex("(?:^|\\D)(2160|1440|1080|720|576|540|480|360)p?(?:\\D|$)").find(normalized)
+        if (match != null) return match.groupValues[1].toInt()
+        return when {
+            "4k" in normalized || "uhd" in normalized -> 2160
+            "2k" in normalized -> 1440
+            else -> 0
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
@@ -27,9 +27,11 @@ object SmartStreamSelector {
         platformContextProvider = provider
     }
 
+    fun currentContext(): Context = platformContextProvider?.invoke() ?: Context()
+
     fun rank(
         streams: List<StreamItem>,
-        context: Context = platformContextProvider?.invoke() ?: Context(),
+        context: Context = currentContext(),
     ): List<StreamItem> = streams
         .withIndex()
         .sortedWith(
@@ -83,14 +85,15 @@ object SmartStreamSelector {
                     resolution <= 1080 -> 80
                     else -> 45
                 }
-                context.displayHeight != null -> {
-                    val displayHeight = context.displayHeight!!
+                context.displayHeight?.takeIf { it > 0 } != null -> {
+                    val displayHeight = context.displayHeight!!.coerceAtLeast(1)
                     when {
                         resolution <= displayHeight -> 100 + resolution / 100
                         else -> maxOf(0, 100 - (resolution - displayHeight) / 20)
                     }
                 }
                 else -> when (resolution) {
+                    4320 -> 150
                     2160 -> 130
                     1440 -> 120
                     1080 -> 110
@@ -108,12 +111,13 @@ object SmartStreamSelector {
             val requiredKbps = (sizeBytes * 8L / 1000L / durationSeconds)
                 .coerceAtMost(Int.MAX_VALUE.toLong())
                 .toInt()
+            val bandwidth = bandwidthKbps.toLong()
             score += when {
-                requiredKbps <= bandwidthKbps * 60 / 100 -> 35
-                requiredKbps <= bandwidthKbps * 75 / 100 -> 20
-                requiredKbps <= bandwidthKbps * 90 / 100 -> 5
-                requiredKbps <= bandwidthKbps -> 0
-                requiredKbps <= bandwidthKbps * 125 / 100 -> -15
+                requiredKbps.toLong() * 100 <= bandwidth * 60 -> 35
+                requiredKbps.toLong() * 100 <= bandwidth * 75 -> 20
+                requiredKbps.toLong() * 100 <= bandwidth * 90 -> 5
+                requiredKbps.toLong() * 100 <= bandwidth * 100 -> 0
+                requiredKbps.toLong() * 100 <= bandwidth * 125 -> -15
                 else -> -60
             }
         }
@@ -124,22 +128,22 @@ object SmartStreamSelector {
         score += if (hdr) {
             when {
                 context.supportedHdrTypes.isNotEmpty() &&
-                    hdrTypes.any { it in context.supportedHdrTypes } -> 20
+                    hdrTypes.any { it in context.supportedHdrTypes.map(String::lowercase).toSet() } -> 20
                 context.supportsHdr -> 20
                 else -> -25
             }
         } else 5
 
-        val codec = parsed?.codec?.lowercase() ?: when {
+        val codec = normalizeCodec(parsed?.codec ?: when {
             "av1" in text -> "av1"
             "hevc" in text || "h265" in text || "x265" in text -> "hevc"
             "h264" in text || "x264" in text -> "h264"
             else -> ""
-        }
-        if (context.preferredVideoCodec?.equals(codec, ignoreCase = true) == true) score += 15
+        })
+        if (normalizeCodec(context.preferredVideoCodec) == codec && codec.isNotEmpty()) score += 15
         score += when (codec) {
-            "av1", "hevc", "h265", "x265" -> 5
-            "h264", "x264" -> 3
+            "av1", "hevc" -> 5
+            "h264" -> 3
             else -> 0
         }
 
@@ -166,6 +170,13 @@ object SmartStreamSelector {
                 "hlg" in normalized -> add("hlg")
             }
         }
+    }
+
+    private fun normalizeCodec(codec: String?): String = when (codec?.trim()?.lowercase()) {
+        "hevc", "h265", "x265" -> "hevc"
+        "h264", "avc", "x264" -> "h264"
+        "av1" -> "av1"
+        else -> ""
     }
 
     private fun resolutionHeight(value: String): Int {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
@@ -13,15 +13,23 @@ object SmartStreamSelector {
         val displayWidth: Int? = null,
         val displayHeight: Int? = null,
         val supportsHdr: Boolean = false,
+        val supportedHdrTypes: Set<String> = emptySet(),
         val dataSaver: Boolean = false,
         val preferredVideoCodec: String? = null,
         val preferredAudioLanguage: String? = null,
         val preferredStreamTerms: List<String> = emptyList(),
     )
 
+    private var platformContextProvider: (() -> Context)? = null
+
+    @Synchronized
+    fun setPlatformContextProvider(provider: (() -> Context)?) {
+        platformContextProvider = provider
+    }
+
     fun rank(
         streams: List<StreamItem>,
-        context: Context = Context(),
+        context: Context = platformContextProvider?.invoke() ?: Context(),
     ): List<StreamItem> = streams
         .withIndex()
         .sortedWith(
@@ -109,10 +117,16 @@ object SmartStreamSelector {
             }
         }
 
-        val hdr = parsed?.hdr.orEmpty().any { it.isNotBlank() } ||
+        val hdrTypes = hdrTypes(parsed?.hdr.orEmpty(), text)
+        val hdr = hdrTypes.isNotEmpty() ||
             listOf("dolby vision", "dolbyvision", "hdr10", "hdr10+", "hlg").any { it in text }
         score += if (hdr) {
-            if (context.supportsHdr) 20 else -25
+            when {
+                context.supportedHdrTypes.isNotEmpty() &&
+                    hdrTypes.any { it in context.supportedHdrTypes } -> 20
+                context.supportsHdr -> 20
+                else -> -25
+            }
         } else 5
 
         val codec = parsed?.codec?.lowercase() ?: when {
@@ -139,6 +153,18 @@ object SmartStreamSelector {
         if (stream.behaviorHints.notWebReady) score -= 15
 
         return score
+    }
+
+    private fun hdrTypes(parsedHdr: List<String>, text: String): Set<String> = buildSet {
+        (parsedHdr + text).forEach { value ->
+            val normalized = value.lowercase()
+            when {
+                "dolby vision" in normalized || "dolbyvision" in normalized || " dv" in " $normalized" -> add("dolbyvision")
+                "hdr10+" in normalized || "hdr10plus" in normalized -> add("hdr10+")
+                "hdr10" in normalized -> add("hdr10")
+                "hlg" in normalized -> add("hlg")
+            }
+        }
     }
 
     private fun resolutionHeight(value: String): Int {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
@@ -12,13 +12,30 @@ object SmartStreamSelector {
         val estimatedBandwidthKbps: Int? = null,
         val displayWidth: Int? = null,
         val displayHeight: Int? = null,
-        val supportsHdr: Boolean = false,
+        /**
+         * Null means the device capability is not known. Unknown capability must
+         * not be treated as an explicit lack of HDR support.
+         */
+        val supportsHdr: Boolean? = null,
         val supportedHdrTypes: Set<String> = emptySet(),
         val dataSaver: Boolean = false,
         val preferredVideoCodec: String? = null,
         val preferredAudioLanguage: String? = null,
         val preferredStreamTerms: List<String> = emptyList(),
     )
+
+    private val resolutionPattern =
+        Regex("""(?:^|\D)(4320|2160|1440|1080|720|576|540|480|360)p?(?:\D|$)""")
+    private val dolbyVisionPattern =
+        Regex("""(^|[^a-z0-9])(dv|dovi|dolby[ ._-]?vision)([^a-z0-9]|$)""")
+    private val hdrPattern =
+        Regex("""(^|[^a-z0-9])(hdr|hdr10|hdr10\+|hdr10plus|hlg)([^a-z0-9]|$)""")
+    private val hevcPattern =
+        Regex("""(^|[^a-z0-9])(hevc|h[ ._-]?265|x265)([^a-z0-9]|$)""")
+    private val h264Pattern =
+        Regex("""(^|[^a-z0-9])(h[ ._-]?264|avc|x264)([^a-z0-9]|$)""")
+    private val av1Pattern =
+        Regex("""(^|[^a-z0-9])av1([^a-z0-9]|$)""")
 
     private var platformContextProvider: (() -> Context)? = null
 
@@ -43,19 +60,10 @@ object SmartStreamSelector {
 
     private fun preferenceScore(stream: StreamItem, context: Context): Int {
         if (context.preferredStreamTerms.isEmpty()) return 0
-        val text = listOfNotNull(
-            stream.name,
-            stream.description,
-            stream.behaviorHints.filename,
-            stream.clientResolve?.filename,
-            stream.clientResolve?.torrentName,
-            stream.clientResolve?.stream?.raw?.parsed?.resolution,
-            stream.clientResolve?.stream?.raw?.parsed?.quality,
-            stream.clientResolve?.stream?.raw?.parsed?.codec,
-        ).joinToString(" ").lowercase()
+        val text = streamSearchText(stream)
 
         context.preferredStreamTerms.forEachIndexed { index, term ->
-            if (term.isNotBlank() && term.lowercase() in text) {
+            if (term.isNotBlank() && matchesPreferenceTerm(text, term)) {
                 return (context.preferredStreamTerms.size - index) * 1_000
             }
         }
@@ -64,19 +72,12 @@ object SmartStreamSelector {
 
     private fun score(stream: StreamItem, context: Context): Int {
         val parsed = stream.clientResolve?.stream?.raw?.parsed
-        val text = listOfNotNull(
-            stream.name,
-            stream.description,
-            stream.behaviorHints.filename,
-            stream.clientResolve?.filename,
-            stream.clientResolve?.torrentName,
-            parsed?.resolution,
-            parsed?.quality,
-            parsed?.codec,
-        ).joinToString(" ").lowercase()
+        val text = streamSearchText(stream)
 
         var score = 0
-        val resolution = resolutionHeight(parsed?.resolution ?: text)
+        val resolution = resolutionHeight(parsed?.resolution.orEmpty())
+            .takeIf { it > 0 }
+            ?: resolutionHeight(text)
         if (resolution > 0) {
             score += when {
                 context.dataSaver -> when {
@@ -104,7 +105,11 @@ object SmartStreamSelector {
             }
         }
 
-        val sizeBytes = stream.behaviorHints.videoSize ?: stream.clientResolve?.stream?.raw?.size
+        val sizeBytes = (
+            stream.behaviorHints.videoSize
+                ?: stream.clientResolve?.stream?.raw?.size
+                ?: stream.debridCacheStatus?.cachedSize
+            )?.takeIf { it > 0 }
         val bandwidthKbps = context.estimatedBandwidthKbps
         val durationSeconds = parsed?.duration?.takeIf { it > 0 }
         if (bandwidthKbps != null && bandwidthKbps > 0 && sizeBytes != null && durationSeconds != null) {
@@ -123,23 +128,17 @@ object SmartStreamSelector {
         }
 
         val hdrTypes = hdrTypes(parsed?.hdr.orEmpty(), text)
-        val hdr = hdrTypes.isNotEmpty() ||
-            listOf("dolby vision", "dolbyvision", "hdr10", "hdr10+", "hlg").any { it in text }
-        score += if (hdr) {
-            when {
-                context.supportedHdrTypes.isNotEmpty() &&
-                    hdrTypes.any { it in context.supportedHdrTypes.map(String::lowercase).toSet() } -> 20
-                context.supportsHdr -> 20
-                else -> -25
-            }
-        } else 5
+        val isHdr = hdrTypes.isNotEmpty() || hasHdrToken(parsed?.hdr.orEmpty(), text)
+        val supportedHdrTypes = context.supportedHdrTypes.map { it.lowercase() }.toSet()
+        score += when {
+            isHdr && hdrTypes.any { it in supportedHdrTypes } -> 20
+            isHdr && context.supportsHdr == true -> 20
+            isHdr && context.supportsHdr == false -> -25
+            !isHdr && context.supportsHdr != null -> 5
+            else -> 0
+        }
 
-        val codec = normalizeCodec(parsed?.codec ?: when {
-            "av1" in text -> "av1"
-            "hevc" in text || "h265" in text || "x265" in text -> "hevc"
-            "h264" in text || "x264" in text -> "h264"
-            else -> ""
-        })
+        val codec = normalizeCodec(parsed?.codec).takeIf { it.isNotEmpty() } ?: codecFromText(text)
         if (normalizeCodec(context.preferredVideoCodec) == codec && codec.isNotEmpty()) score += 15
         score += when (codec) {
             "av1", "hevc" -> 5
@@ -160,34 +159,89 @@ object SmartStreamSelector {
         return score
     }
 
+    private fun streamSearchText(stream: StreamItem): String {
+        val resolve = stream.clientResolve
+        val raw = resolve?.stream?.raw
+        val parsed = raw?.parsed
+        return listOfNotNull(
+            stream.name,
+            stream.title,
+            stream.description,
+            stream.behaviorHints.filename,
+            stream.debridCacheStatus?.cachedName,
+            resolve?.filename,
+            resolve?.torrentName,
+            raw?.filename,
+            raw?.torrentName,
+            parsed?.rawTitle,
+            parsed?.parsedTitle,
+            parsed?.resolution,
+            parsed?.quality,
+            parsed?.codec,
+            parsed?.hdr?.joinToString(" "),
+        ).joinToString(" ").lowercase()
+    }
+
     private fun hdrTypes(parsedHdr: List<String>, text: String): Set<String> = buildSet {
         (parsedHdr + text).forEach { value ->
             val normalized = value.lowercase()
             when {
-                "dolby vision" in normalized || "dolbyvision" in normalized || " dv" in " $normalized" -> add("dolbyvision")
-                "hdr10+" in normalized || "hdr10plus" in normalized -> add("hdr10+")
-                "hdr10" in normalized -> add("hdr10")
-                "hlg" in normalized -> add("hlg")
+                dolbyVisionPattern.containsMatchIn(normalized) -> add("dolbyvision")
+                normalized.contains("hdr10+") || normalized.contains("hdr10plus") -> add("hdr10+")
+                hasToken(normalized, "hdr10") -> add("hdr10")
+                hasToken(normalized, "hlg") -> add("hlg")
             }
         }
     }
 
-    private fun normalizeCodec(codec: String?): String = when (codec?.trim()?.lowercase()) {
-        "hevc", "h265", "x265" -> "hevc"
-        "h264", "avc", "x264" -> "h264"
-        "av1" -> "av1"
+    private fun hasHdrToken(parsedHdr: List<String>, text: String): Boolean =
+        (parsedHdr + text).any { hdrPattern.containsMatchIn(it.lowercase()) }
+
+    private fun matchesPreferenceTerm(text: String, term: String): Boolean {
+        val normalized = term.trim().lowercase()
+        return if (normalized.all { it.isLetterOrDigit() }) {
+            hasToken(text, normalized)
+        } else {
+            normalized in text
+        }
+    }
+
+    private fun normalizeCodec(codec: String?): String {
+        val normalized = codec
+            ?.lowercase()
+            ?.filter { it.isLetterOrDigit() }
+            .orEmpty()
+        return when (normalized) {
+            "hevc", "h265", "x265" -> "hevc"
+            "h264", "avc", "x264" -> "h264"
+            "av1" -> "av1"
+            else -> ""
+        }
+    }
+
+    private fun codecFromText(text: String): String = when {
+        av1Pattern.containsMatchIn(text) -> "av1"
+        hevcPattern.containsMatchIn(text) -> "hevc"
+        h264Pattern.containsMatchIn(text) -> "h264"
         else -> ""
     }
 
     private fun resolutionHeight(value: String): Int {
         val normalized = value.lowercase()
-        val match = Regex("(?:^|\\D)(4320|2160|1440|1080|720|576|540|480|360)p?(?:\\D|$)").find(normalized)
+        val match = resolutionPattern.find(normalized)
         if (match != null) return match.groupValues[1].toInt()
         return when {
-            "8k" in normalized -> 4320
-            "4k" in normalized || "uhd" in normalized -> 2160
-            "2k" in normalized || "qhd" in normalized -> 1440
+            hasToken(normalized, "8k") -> 4320
+            hasToken(normalized, "4k") || hasToken(normalized, "uhd") -> 2160
+            hasToken(normalized, "2k") || hasToken(normalized, "qhd") -> 1440
+            hasToken(normalized, "fhd") -> 1080
+            hasToken(normalized, "hd") -> 720
+            hasToken(normalized, "sd") -> 480
             else -> 0
         }
     }
+
+    private fun hasToken(value: String, token: String): Boolean =
+        Regex("(^|[^a-z0-9])${Regex.escape(token.lowercase())}([^a-z0-9]|$)")
+            .containsMatchIn(value.lowercase())
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/SmartStreamSelector.kt
@@ -1,5 +1,7 @@
 package com.nuvio.app.features.streams
 
+import kotlin.concurrent.Volatile
+
 /**
  * Deterministic quality-aware ordering for automatic stream selection.
  * Manual stream selection is intentionally unaffected.
@@ -24,6 +26,44 @@ object SmartStreamSelector {
         val preferredStreamTerms: List<String> = emptyList(),
     )
 
+    private object ScoreWeights {
+        const val RES_8K = 150
+        const val RES_4K = 130
+        const val RES_2K = 120
+        const val RES_1080 = 110
+        const val RES_720 = 90
+        const val RES_480 = 70
+        const val RES_DEFAULT = 50
+
+        const val DATA_SAVER_480 = 70
+        const val DATA_SAVER_720 = 90
+        const val DATA_SAVER_1080 = 80
+        const val DATA_SAVER_HIGH = 45
+
+        const val BASE_DISPLAY_MATCH = 100
+
+        const val BW_SAFE = 35
+        const val BW_FAIR = 20
+        const val BW_TIGHT = 5
+        const val BW_EXCEEDS = 0
+        const val BW_RISKY = -15
+        const val BW_DANGEROUS = -60
+
+        const val HDR_SUPPORTED = 20
+        const val HDR_UNSUPPORTED = -25
+        const val HDR_FALLBACK = 5
+
+        const val CODEC_PREFERRED = 15
+        const val CODEC_HEVC_AV1 = 5
+        const val CODEC_H264 = 3
+
+        const val AUDIO_LANG_PREFERRED = 12
+        const val DEBRID_CACHED = 35
+        const val DIRECT_PLAY = 20
+        const val TORRENT_NOT_CACHED = -10
+        const val NOT_WEB_READY = -15
+    }
+
     private val resolutionPattern =
         Regex("""(?:^|\D)(4320|2160|1440|1080|720|576|540|480|360)p?(?:\D|$)""")
     private val dolbyVisionPattern =
@@ -37,6 +77,7 @@ object SmartStreamSelector {
     private val av1Pattern =
         Regex("""(^|[^a-z0-9])av1([^a-z0-9]|$)""")
 
+    @Volatile
     private var platformContextProvider: (() -> Context)? = null
 
     @Synchronized
@@ -81,26 +122,26 @@ object SmartStreamSelector {
         if (resolution > 0) {
             score += when {
                 context.dataSaver -> when {
-                    resolution <= 480 -> 70
-                    resolution <= 720 -> 90
-                    resolution <= 1080 -> 80
-                    else -> 45
+                    resolution <= 480 -> ScoreWeights.DATA_SAVER_480
+                    resolution <= 720 -> ScoreWeights.DATA_SAVER_720
+                    resolution <= 1080 -> ScoreWeights.DATA_SAVER_1080
+                    else -> ScoreWeights.DATA_SAVER_HIGH
                 }
                 context.displayHeight?.takeIf { it > 0 } != null -> {
                     val displayHeight = context.displayHeight!!.coerceAtLeast(1)
                     when {
-                        resolution <= displayHeight -> 100 + resolution / 100
-                        else -> maxOf(0, 100 - (resolution - displayHeight) / 20)
+                        resolution <= displayHeight -> ScoreWeights.BASE_DISPLAY_MATCH + resolution / 100
+                        else -> maxOf(0, ScoreWeights.BASE_DISPLAY_MATCH - (resolution - displayHeight) / 20)
                     }
                 }
                 else -> when (resolution) {
-                    4320 -> 150
-                    2160 -> 130
-                    1440 -> 120
-                    1080 -> 110
-                    720 -> 90
-                    480 -> 70
-                    else -> 50
+                    4320 -> ScoreWeights.RES_8K
+                    2160 -> ScoreWeights.RES_4K
+                    1440 -> ScoreWeights.RES_2K
+                    1080 -> ScoreWeights.RES_1080
+                    720 -> ScoreWeights.RES_720
+                    480 -> ScoreWeights.RES_480
+                    else -> ScoreWeights.RES_DEFAULT
                 }
             }
         }
@@ -118,12 +159,12 @@ object SmartStreamSelector {
                 .toInt()
             val bandwidth = bandwidthKbps.toLong()
             score += when {
-                requiredKbps.toLong() * 100 <= bandwidth * 60 -> 35
-                requiredKbps.toLong() * 100 <= bandwidth * 75 -> 20
-                requiredKbps.toLong() * 100 <= bandwidth * 90 -> 5
-                requiredKbps.toLong() * 100 <= bandwidth * 100 -> 0
-                requiredKbps.toLong() * 100 <= bandwidth * 125 -> -15
-                else -> -60
+                requiredKbps.toLong() * 100 <= bandwidth * 60 -> ScoreWeights.BW_SAFE
+                requiredKbps.toLong() * 100 <= bandwidth * 75 -> ScoreWeights.BW_FAIR
+                requiredKbps.toLong() * 100 <= bandwidth * 90 -> ScoreWeights.BW_TIGHT
+                requiredKbps.toLong() * 100 <= bandwidth * 100 -> ScoreWeights.BW_EXCEEDS
+                requiredKbps.toLong() * 100 <= bandwidth * 125 -> ScoreWeights.BW_RISKY
+                else -> ScoreWeights.BW_DANGEROUS
             }
         }
 
@@ -131,30 +172,30 @@ object SmartStreamSelector {
         val isHdr = hdrTypes.isNotEmpty() || hasHdrToken(parsed?.hdr.orEmpty(), text)
         val supportedHdrTypes = context.supportedHdrTypes.map { it.lowercase() }.toSet()
         score += when {
-            isHdr && hdrTypes.any { it in supportedHdrTypes } -> 20
-            isHdr && context.supportsHdr == true -> 20
-            isHdr && context.supportsHdr == false -> -25
-            !isHdr && context.supportsHdr != null -> 5
+            isHdr && hdrTypes.any { it in supportedHdrTypes } -> ScoreWeights.HDR_SUPPORTED
+            isHdr && context.supportsHdr == true -> ScoreWeights.HDR_SUPPORTED
+            isHdr && context.supportsHdr == false -> ScoreWeights.HDR_UNSUPPORTED
+            !isHdr && context.supportsHdr != null -> ScoreWeights.HDR_FALLBACK
             else -> 0
         }
 
         val codec = normalizeCodec(parsed?.codec).takeIf { it.isNotEmpty() } ?: codecFromText(text)
-        if (normalizeCodec(context.preferredVideoCodec) == codec && codec.isNotEmpty()) score += 15
+        if (normalizeCodec(context.preferredVideoCodec) == codec && codec.isNotEmpty()) score += ScoreWeights.CODEC_PREFERRED
         score += when (codec) {
-            "av1", "hevc" -> 5
-            "h264" -> 3
+            "av1", "hevc" -> ScoreWeights.CODEC_HEVC_AV1
+            "h264" -> ScoreWeights.CODEC_H264
             else -> 0
         }
 
         if (context.preferredAudioLanguage != null && parsed?.languages.orEmpty().any {
                 it.equals(context.preferredAudioLanguage, ignoreCase = true)
-            }) score += 12
+            }) score += ScoreWeights.AUDIO_LANG_PREFERRED
 
-        if (stream.isDirectDebridStream || stream.isCachedDebridTorrentStream) score += 35
-        if (stream.clientResolve?.isCached == true) score += 35
-        if (stream.playableDirectUrl != null) score += 20
-        if (stream.isTorrentStream && !stream.isCachedDebridTorrentStream) score -= 10
-        if (stream.behaviorHints.notWebReady) score -= 15
+        if (stream.isDirectDebridStream || stream.isCachedDebridTorrentStream) score += ScoreWeights.DEBRID_CACHED
+        if (stream.clientResolve?.isCached == true) score += ScoreWeights.DEBRID_CACHED
+        if (stream.playableDirectUrl != null) score += ScoreWeights.DIRECT_PLAY
+        if (stream.isTorrentStream && !stream.isCachedDebridTorrentStream) score += ScoreWeights.TORRENT_NOT_CACHED
+        if (stream.behaviorHints.notWebReady) score += ScoreWeights.NOT_WEB_READY
 
         return score
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
@@ -12,9 +12,7 @@ object StreamAutoPlaySelector {
 
         val addonRankByName = HashMap<String, Int>(installedOrder.size)
         installedOrder.forEachIndexed { index, addonName ->
-            if (addonName !in addonRankByName) {
-                addonRankByName[addonName] = index
-            }
+            if (addonName !in addonRankByName) addonRankByName[index] = index
         }
 
         val (directDebridEntries, remainingEntries) = groups.partition { group ->
@@ -23,57 +21,31 @@ object StreamAutoPlaySelector {
         }
         if (installedOrder.isEmpty()) return directDebridEntries + remainingEntries
 
-        val (addonEntries, pluginEntries) = remainingEntries.partition { group ->
-            group.addonName in addonRankByName
-        }
-        val orderedAddons = addonEntries.sortedBy { group ->
-            addonRankByName.getValue(group.addonName)
-        }
+        val (addonEntries, pluginEntries) = remainingEntries.partition { group -> group.addonName in addonRankByName }
+        val orderedAddons = addonEntries.sortedBy { group -> addonRankByName.getValue(group.addonName) }
         return directDebridEntries + orderedAddons + pluginEntries
     }
 
     fun selectAutoPlayStream(
-        streams: List<StreamItem>,
-        mode: StreamAutoPlayMode,
-        regexPattern: String,
-        source: StreamAutoPlaySource,
-        installedAddonNames: Set<String>,
-        selectedAddons: Set<String>,
-        selectedPlugins: Set<String>,
-        preferredBingeGroup: String? = null,
-        preferBingeGroupInSelection: Boolean = false,
-        bingeGroupOnly: Boolean = false,
-        debridEnabled: Boolean = true,
-        activeResolverProviderId: String? = null,
-    ): StreamItem? =
-        evaluateAutoPlayStream(
-            streams = streams,
-            mode = mode,
-            regexPattern = regexPattern,
-            source = source,
-            installedAddonNames = installedAddonNames,
-            selectedAddons = selectedAddons,
-            selectedPlugins = selectedPlugins,
-            preferredBingeGroup = preferredBingeGroup,
-            preferBingeGroupInSelection = preferBingeGroupInSelection,
-            bingeGroupOnly = bingeGroupOnly,
-            debridEnabled = debridEnabled,
-            activeResolverProviderId = activeResolverProviderId,
-        ).stream
+        streams: List<StreamItem>, mode: StreamAutoPlayMode, regexPattern: String,
+        source: StreamAutoPlaySource, installedAddonNames: Set<String>, selectedAddons: Set<String>,
+        selectedPlugins: Set<String>, preferredBingeGroup: String? = null,
+        preferBingeGroupInSelection: Boolean = false, bingeGroupOnly: Boolean = false,
+        debridEnabled: Boolean = true, activeResolverProviderId: String? = null,
+        smartSelectionContext: SmartStreamSelector.Context = SmartStreamSelector.Context(),
+    ): StreamItem? = evaluateAutoPlayStream(
+        streams, mode, regexPattern, source, installedAddonNames, selectedAddons, selectedPlugins,
+        preferredBingeGroup, preferBingeGroupInSelection, bingeGroupOnly, debridEnabled,
+        activeResolverProviderId, smartSelectionContext,
+    ).stream
 
     fun evaluateAutoPlayStream(
-        streams: List<StreamItem>,
-        mode: StreamAutoPlayMode,
-        regexPattern: String,
-        source: StreamAutoPlaySource,
-        installedAddonNames: Set<String>,
-        selectedAddons: Set<String>,
-        selectedPlugins: Set<String>,
-        preferredBingeGroup: String? = null,
-        preferBingeGroupInSelection: Boolean = false,
-        bingeGroupOnly: Boolean = false,
-        debridEnabled: Boolean = true,
-        activeResolverProviderId: String? = null,
+        streams: List<StreamItem>, mode: StreamAutoPlayMode, regexPattern: String,
+        source: StreamAutoPlaySource, installedAddonNames: Set<String>, selectedAddons: Set<String>,
+        selectedPlugins: Set<String>, preferredBingeGroup: String? = null,
+        preferBingeGroupInSelection: Boolean = false, bingeGroupOnly: Boolean = false,
+        debridEnabled: Boolean = true, activeResolverProviderId: String? = null,
+        smartSelectionContext: SmartStreamSelector.Context = SmartStreamSelector.Context(),
     ): StreamAutoPlayEvaluation {
         if (streams.isEmpty()) return StreamAutoPlayEvaluation()
 
@@ -84,142 +56,93 @@ object StreamAutoPlaySelector {
         }
         val candidateStreams = sourceScopedStreams.filter { stream ->
             val isAddonStream = stream.addonName in installedAddonNames
-            if (isAddonStream) {
-                selectedAddons.isEmpty() || stream.addonName in selectedAddons
-            } else {
-                selectedPlugins.isEmpty() || stream.addonName in selectedPlugins
-            }
+            if (isAddonStream) selectedAddons.isEmpty() || stream.addonName in selectedAddons
+            else selectedPlugins.isEmpty() || stream.addonName in selectedPlugins
         }
         if (candidateStreams.isEmpty()) return StreamAutoPlayEvaluation()
-        if (mode == StreamAutoPlayMode.MANUAL && !bingeGroupOnly) {
-            return StreamAutoPlayEvaluation()
-        }
+        if (mode == StreamAutoPlayMode.MANUAL && !bingeGroupOnly) return StreamAutoPlayEvaluation()
 
         val targetBingeGroup = preferredBingeGroup?.trim().orEmpty()
         val bingeGroupCandidates = if (preferBingeGroupInSelection && targetBingeGroup.isNotEmpty()) {
-            candidateStreams.filter { stream -> stream.behaviorHints.bingeGroup == targetBingeGroup }
-        } else {
-            emptyList()
-        }
-        val preferredReadyStream = bingeGroupCandidates.firstOrNull { stream ->
-            stream.isAutoPlayable(debridEnabled, activeResolverProviderId)
-        }
+            candidateStreams.filter { it.behaviorHints.bingeGroup == targetBingeGroup }
+        } else emptyList()
+
+        val preferredReadyStream = SmartStreamSelector.rank(
+            bingeGroupCandidates.filter { it.isAutoPlayable(debridEnabled, activeResolverProviderId) },
+            smartSelectionContext,
+        ).firstOrNull()
+
         if (bingeGroupOnly) {
-            val readyStreams = preferredReadyStream?.let(::listOf).orEmpty()
             return StreamAutoPlayEvaluation(
                 stream = preferredReadyStream,
-                readyStreams = readyStreams,
-                hasPendingDebridCandidate = preferredReadyStream == null &&
-                    bingeGroupCandidates.any {
-                        it.isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
-                    },
+                readyStreams = preferredReadyStream?.let(::listOf).orEmpty(),
+                hasPendingDebridCandidate = preferredReadyStream == null && bingeGroupCandidates.any {
+                    it.isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
+                },
             )
         }
-        if (mode == StreamAutoPlayMode.MANUAL) {
-            return StreamAutoPlayEvaluation()
-        }
-        val preferredStream = if (preferBingeGroupInSelection && targetBingeGroup.isNotEmpty()) {
-            candidateStreams.firstOrNull { stream ->
-                stream.behaviorHints.bingeGroup == targetBingeGroup &&
-                    stream.isAutoPlayable(debridEnabled, activeResolverProviderId)
-            }
-        } else {
-            null
-        }
+        if (mode == StreamAutoPlayMode.MANUAL) return StreamAutoPlayEvaluation()
+
         val matchingStreams = when (mode) {
             StreamAutoPlayMode.MANUAL -> emptyList()
             StreamAutoPlayMode.FIRST_STREAM -> candidateStreams
             StreamAutoPlayMode.REGEX_MATCH -> {
                 val pattern = regexPattern.trim()
-
                 val userRegex = runCatching { Regex(pattern, RegexOption.IGNORE_CASE) }.getOrNull()
                     ?: return StreamAutoPlayEvaluation()
-
                 val exclusionMatches = Regex("\\(\\?![^)]*?\\(([^)]+)\\)").findAll(pattern)
-
-                val exclusionWords = exclusionMatches
-                    .flatMap { match -> match.groupValues[1].split("|") }
-                    .map { it.trim() }
-                    .filter { it.isNotBlank() }
-                    .toList()
-
+                val exclusionWords = exclusionMatches.flatMap { it.groupValues[1].split("|") }
+                    .map { it.trim() }.filter { it.isNotBlank() }.toList()
                 val excludeRegex = if (exclusionWords.isNotEmpty()) {
-                    Regex(
-                        "\\b(${exclusionWords.joinToString("|") { Regex.escape(it) }})\\b",
-                        RegexOption.IGNORE_CASE,
-                    )
+                    Regex("\\b(${exclusionWords.joinToString("|") { Regex.escape(it) }})\\b", RegexOption.IGNORE_CASE)
                 } else null
-
                 candidateStreams.filter { stream ->
-                    val url = stream.playableDirectUrl.orEmpty()
-
                     val searchableText = buildString {
                         append(stream.addonName).append(' ')
                         append(stream.name.orEmpty()).append(' ')
                         append(stream.streamLabel).append(' ')
                         append(stream.description.orEmpty()).append(' ')
-                        append(url)
+                        append(stream.playableDirectUrl.orEmpty())
                     }
-
-                    if (!userRegex.containsMatchIn(searchableText)) return@filter false
-
-                    if (excludeRegex != null && excludeRegex.containsMatchIn(searchableText)) {
-                        return@filter false
-                    }
-
-                    true
+                    userRegex.containsMatchIn(searchableText) &&
+                        (excludeRegex == null || !excludeRegex.containsMatchIn(searchableText))
                 }
             }
         }
-        if (matchingStreams.isEmpty() && preferredStream == null) return StreamAutoPlayEvaluation()
 
-        val readyStreams = buildList {
-            preferredStream?.let(::add)
-            matchingStreams
-                .filter { it.isAutoPlayable(debridEnabled, activeResolverProviderId) }
-                .filterNot { it == preferredStream }
-                .forEach(::add)
-        }
-        val selected = readyStreams.firstOrNull()
-        if (selected != null) {
+        val readyCandidates = matchingStreams.filter { it.isAutoPlayable(debridEnabled, activeResolverProviderId) }
+        if (readyCandidates.isEmpty() && preferredReadyStream == null) {
             return StreamAutoPlayEvaluation(
-                stream = selected,
-                readyStreams = readyStreams,
+                hasPendingDebridCandidate = matchingStreams.any {
+                    it.isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
+                },
             )
         }
 
+        val rankedReadyStreams = SmartStreamSelector.rank(readyCandidates, smartSelectionContext)
+        val readyStreams = buildList {
+            preferredReadyStream?.let(::add)
+            rankedReadyStreams.filterNot { it == preferredReadyStream }.forEach(::add)
+        }
         return StreamAutoPlayEvaluation(
+            stream = readyStreams.firstOrNull(),
             readyStreams = readyStreams,
-            hasPendingDebridCandidate = matchingStreams.any {
-                it.isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
-            },
         )
     }
 
-    private fun StreamItem.isAutoPlayable(
-        debridEnabled: Boolean,
-        activeResolverProviderId: String?,
-    ): Boolean =
+    private fun StreamItem.isAutoPlayable(debridEnabled: Boolean, activeResolverProviderId: String?): Boolean =
         playableDirectUrl != null ||
-            (
-                AppFeaturePolicy.p2pEnabled &&
-                    needsLocalDebridResolve &&
-                    p2pInfoHash != null &&
-                    !isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
-            ) ||
+            (AppFeaturePolicy.p2pEnabled && needsLocalDebridResolve && p2pInfoHash != null &&
+                !isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)) ||
             (debridEnabled && isAddonDebridCandidate && isReadyDebridAutoPlay(activeResolverProviderId))
 
-    private fun StreamItem.isReadyDebridAutoPlay(activeResolverProviderId: String?): Boolean =
-        when {
-            isDirectDebridStream -> clientResolve?.service.matchesResolver(activeResolverProviderId)
-            isCachedDebridTorrentStream -> debridCacheStatus?.providerId.matchesResolver(activeResolverProviderId)
-            else -> false
-        }
+    private fun StreamItem.isReadyDebridAutoPlay(activeResolverProviderId: String?): Boolean = when {
+        isDirectDebridStream -> clientResolve?.service.matchesResolver(activeResolverProviderId)
+        isCachedDebridTorrentStream -> debridCacheStatus?.providerId.matchesResolver(activeResolverProviderId)
+        else -> false
+    }
 
-    private fun StreamItem.isPendingDebridAutoPlay(
-        debridEnabled: Boolean,
-        activeResolverProviderId: String?,
-    ): Boolean {
+    private fun StreamItem.isPendingDebridAutoPlay(debridEnabled: Boolean, activeResolverProviderId: String?): Boolean {
         if (!debridEnabled || !isInstalledAddonStream || !needsLocalDebridResolve) return false
         if (!debridCacheStatus?.providerId.matchesResolver(activeResolverProviderId)) return false
         val state = debridCacheStatus?.state

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
@@ -12,7 +12,7 @@ object StreamAutoPlaySelector {
 
         val addonRankByName = HashMap<String, Int>(installedOrder.size)
         installedOrder.forEachIndexed { index, addonName ->
-            if (addonName !in addonRankByName) addonRankByName[index] = index
+            if (addonName !in addonRankByName) addonRankByName[addonName] = index
         }
 
         val (directDebridEntries, remainingEntries) = groups.partition { group ->
@@ -124,10 +124,7 @@ object StreamAutoPlaySelector {
             preferredReadyStream?.let(::add)
             rankedReadyStreams.filterNot { it == preferredReadyStream }.forEach(::add)
         }
-        return StreamAutoPlayEvaluation(
-            stream = readyStreams.firstOrNull(),
-            readyStreams = readyStreams,
-        )
+        return StreamAutoPlayEvaluation(stream = readyStreams.firstOrNull(), readyStreams = readyStreams)
     }
 
     private fun StreamItem.isAutoPlayable(debridEnabled: Boolean, activeResolverProviderId: String?): Boolean =

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
@@ -12,7 +12,9 @@ object StreamAutoPlaySelector {
 
         val addonRankByName = HashMap<String, Int>(installedOrder.size)
         installedOrder.forEachIndexed { index, addonName ->
-            if (addonName !in addonRankByName) addonRankByName[addonName] = index
+            if (addonName !in addonRankByName) {
+                addonRankByName[addonName] = index
+            }
         }
 
         val (directDebridEntries, remainingEntries) = groups.partition { group ->
@@ -21,30 +23,59 @@ object StreamAutoPlaySelector {
         }
         if (installedOrder.isEmpty()) return directDebridEntries + remainingEntries
 
-        val (addonEntries, pluginEntries) = remainingEntries.partition { group -> group.addonName in addonRankByName }
-        val orderedAddons = addonEntries.sortedBy { group -> addonRankByName.getValue(group.addonName) }
+        val (addonEntries, pluginEntries) = remainingEntries.partition { group ->
+            group.addonName in addonRankByName
+        }
+        val orderedAddons = addonEntries.sortedBy { group ->
+            addonRankByName.getValue(group.addonName)
+        }
         return directDebridEntries + orderedAddons + pluginEntries
     }
 
     fun selectAutoPlayStream(
-        streams: List<StreamItem>, mode: StreamAutoPlayMode, regexPattern: String,
-        source: StreamAutoPlaySource, installedAddonNames: Set<String>, selectedAddons: Set<String>,
-        selectedPlugins: Set<String>, preferredBingeGroup: String? = null,
-        preferBingeGroupInSelection: Boolean = false, bingeGroupOnly: Boolean = false,
-        debridEnabled: Boolean = true, activeResolverProviderId: String? = null,
+        streams: List<StreamItem>,
+        mode: StreamAutoPlayMode,
+        regexPattern: String,
+        source: StreamAutoPlaySource,
+        installedAddonNames: Set<String>,
+        selectedAddons: Set<String>,
+        selectedPlugins: Set<String>,
+        preferredBingeGroup: String? = null,
+        preferBingeGroupInSelection: Boolean = false,
+        bingeGroupOnly: Boolean = false,
+        debridEnabled: Boolean = true,
+        activeResolverProviderId: String? = null,
         smartSelectionContext: SmartStreamSelector.Context = SmartStreamSelector.Context(),
-    ): StreamItem? = evaluateAutoPlayStream(
-        streams, mode, regexPattern, source, installedAddonNames, selectedAddons, selectedPlugins,
-        preferredBingeGroup, preferBingeGroupInSelection, bingeGroupOnly, debridEnabled,
-        activeResolverProviderId, smartSelectionContext,
-    ).stream
+    ): StreamItem? =
+        evaluateAutoPlayStream(
+            streams = streams,
+            mode = mode,
+            regexPattern = regexPattern,
+            source = source,
+            installedAddonNames = installedAddonNames,
+            selectedAddons = selectedAddons,
+            selectedPlugins = selectedPlugins,
+            preferredBingeGroup = preferredBingeGroup,
+            preferBingeGroupInSelection = preferBingeGroupInSelection,
+            bingeGroupOnly = bingeGroupOnly,
+            debridEnabled = debridEnabled,
+            activeResolverProviderId = activeResolverProviderId,
+            smartSelectionContext = smartSelectionContext,
+        ).stream
 
     fun evaluateAutoPlayStream(
-        streams: List<StreamItem>, mode: StreamAutoPlayMode, regexPattern: String,
-        source: StreamAutoPlaySource, installedAddonNames: Set<String>, selectedAddons: Set<String>,
-        selectedPlugins: Set<String>, preferredBingeGroup: String? = null,
-        preferBingeGroupInSelection: Boolean = false, bingeGroupOnly: Boolean = false,
-        debridEnabled: Boolean = true, activeResolverProviderId: String? = null,
+        streams: List<StreamItem>,
+        mode: StreamAutoPlayMode,
+        regexPattern: String,
+        source: StreamAutoPlaySource,
+        installedAddonNames: Set<String>,
+        selectedAddons: Set<String>,
+        selectedPlugins: Set<String>,
+        preferredBingeGroup: String? = null,
+        preferBingeGroupInSelection: Boolean = false,
+        bingeGroupOnly: Boolean = false,
+        debridEnabled: Boolean = true,
+        activeResolverProviderId: String? = null,
         smartSelectionContext: SmartStreamSelector.Context = SmartStreamSelector.Context(),
     ): StreamAutoPlayEvaluation {
         if (streams.isEmpty()) return StreamAutoPlayEvaluation()
@@ -56,90 +87,142 @@ object StreamAutoPlaySelector {
         }
         val candidateStreams = sourceScopedStreams.filter { stream ->
             val isAddonStream = stream.addonName in installedAddonNames
-            if (isAddonStream) selectedAddons.isEmpty() || stream.addonName in selectedAddons
-            else selectedPlugins.isEmpty() || stream.addonName in selectedPlugins
+            if (isAddonStream) {
+                selectedAddons.isEmpty() || stream.addonName in selectedAddons
+            } else {
+                selectedPlugins.isEmpty() || stream.addonName in selectedPlugins
+            }
         }
         if (candidateStreams.isEmpty()) return StreamAutoPlayEvaluation()
-        if (mode == StreamAutoPlayMode.MANUAL && !bingeGroupOnly) return StreamAutoPlayEvaluation()
+        if (mode == StreamAutoPlayMode.MANUAL && !bingeGroupOnly) {
+            return StreamAutoPlayEvaluation()
+        }
 
         val targetBingeGroup = preferredBingeGroup?.trim().orEmpty()
         val bingeGroupCandidates = if (preferBingeGroupInSelection && targetBingeGroup.isNotEmpty()) {
-            candidateStreams.filter { it.behaviorHints.bingeGroup == targetBingeGroup }
-        } else emptyList()
-
+            candidateStreams.filter { stream -> stream.behaviorHints.bingeGroup == targetBingeGroup }
+        } else {
+            emptyList()
+        }
         val preferredReadyStream = SmartStreamSelector.rank(
-            bingeGroupCandidates.filter { it.isAutoPlayable(debridEnabled, activeResolverProviderId) },
+            bingeGroupCandidates.filter { stream ->
+                stream.isAutoPlayable(debridEnabled, activeResolverProviderId)
+            },
             smartSelectionContext,
         ).firstOrNull()
-
         if (bingeGroupOnly) {
+            val readyStreams = preferredReadyStream?.let(::listOf).orEmpty()
             return StreamAutoPlayEvaluation(
                 stream = preferredReadyStream,
-                readyStreams = preferredReadyStream?.let(::listOf).orEmpty(),
-                hasPendingDebridCandidate = preferredReadyStream == null && bingeGroupCandidates.any {
-                    it.isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
-                },
+                readyStreams = readyStreams,
+                hasPendingDebridCandidate = preferredReadyStream == null &&
+                    bingeGroupCandidates.any {
+                        it.isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
+                    },
             )
         }
-        if (mode == StreamAutoPlayMode.MANUAL) return StreamAutoPlayEvaluation()
-
+        if (mode == StreamAutoPlayMode.MANUAL) {
+            return StreamAutoPlayEvaluation()
+        }
         val matchingStreams = when (mode) {
             StreamAutoPlayMode.MANUAL -> emptyList()
             StreamAutoPlayMode.FIRST_STREAM -> candidateStreams
             StreamAutoPlayMode.REGEX_MATCH -> {
                 val pattern = regexPattern.trim()
+
                 val userRegex = runCatching { Regex(pattern, RegexOption.IGNORE_CASE) }.getOrNull()
                     ?: return StreamAutoPlayEvaluation()
+
                 val exclusionMatches = Regex("\\(\\?![^)]*?\\(([^)]+)\\)").findAll(pattern)
-                val exclusionWords = exclusionMatches.flatMap { it.groupValues[1].split("|") }
-                    .map { it.trim() }.filter { it.isNotBlank() }.toList()
+
+                val exclusionWords = exclusionMatches
+                    .flatMap { match -> match.groupValues[1].split("|") }
+                    .map { it.trim() }
+                    .filter { it.isNotBlank() }
+                    .toList()
+
                 val excludeRegex = if (exclusionWords.isNotEmpty()) {
-                    Regex("\\b(${exclusionWords.joinToString("|") { Regex.escape(it) }})\\b", RegexOption.IGNORE_CASE)
+                    Regex(
+                        "\\b(${exclusionWords.joinToString("|") { Regex.escape(it) }})\\b",
+                        RegexOption.IGNORE_CASE,
+                    )
                 } else null
+
                 candidateStreams.filter { stream ->
+                    val url = stream.playableDirectUrl.orEmpty()
+
                     val searchableText = buildString {
                         append(stream.addonName).append(' ')
                         append(stream.name.orEmpty()).append(' ')
                         append(stream.streamLabel).append(' ')
                         append(stream.description.orEmpty()).append(' ')
-                        append(stream.playableDirectUrl.orEmpty())
+                        append(url)
                     }
-                    userRegex.containsMatchIn(searchableText) &&
-                        (excludeRegex == null || !excludeRegex.containsMatchIn(searchableText))
+
+                    if (!userRegex.containsMatchIn(searchableText)) return@filter false
+
+                    if (excludeRegex != null && excludeRegex.containsMatchIn(searchableText)) {
+                        return@filter false
+                    }
+
+                    true
                 }
             }
         }
+        if (matchingStreams.isEmpty() && preferredReadyStream == null) return StreamAutoPlayEvaluation()
 
-        val readyCandidates = matchingStreams.filter { it.isAutoPlayable(debridEnabled, activeResolverProviderId) }
-        if (readyCandidates.isEmpty() && preferredReadyStream == null) {
+        val rankedReadyStreams = SmartStreamSelector.rank(
+            matchingStreams.filter { stream ->
+                stream.isAutoPlayable(debridEnabled, activeResolverProviderId)
+            },
+            smartSelectionContext,
+        )
+        val readyStreams = buildList {
+            preferredReadyStream?.let(::add)
+            rankedReadyStreams
+                .filterNot { it == preferredReadyStream }
+                .forEach(::add)
+        }
+        val selected = readyStreams.firstOrNull()
+        if (selected != null) {
             return StreamAutoPlayEvaluation(
-                hasPendingDebridCandidate = matchingStreams.any {
-                    it.isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
-                },
+                stream = selected,
+                readyStreams = readyStreams,
             )
         }
 
-        val rankedReadyStreams = SmartStreamSelector.rank(readyCandidates, smartSelectionContext)
-        val readyStreams = buildList {
-            preferredReadyStream?.let(::add)
-            rankedReadyStreams.filterNot { it == preferredReadyStream }.forEach(::add)
-        }
-        return StreamAutoPlayEvaluation(stream = readyStreams.firstOrNull(), readyStreams = readyStreams)
+        return StreamAutoPlayEvaluation(
+            readyStreams = readyStreams,
+            hasPendingDebridCandidate = matchingStreams.any {
+                it.isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
+            },
+        )
     }
 
-    private fun StreamItem.isAutoPlayable(debridEnabled: Boolean, activeResolverProviderId: String?): Boolean =
+    private fun StreamItem.isAutoPlayable(
+        debridEnabled: Boolean,
+        activeResolverProviderId: String?,
+    ): Boolean =
         playableDirectUrl != null ||
-            (AppFeaturePolicy.p2pEnabled && needsLocalDebridResolve && p2pInfoHash != null &&
-                !isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)) ||
+            (
+                AppFeaturePolicy.p2pEnabled &&
+                    needsLocalDebridResolve &&
+                    p2pInfoHash != null &&
+                    !isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
+            ) ||
             (debridEnabled && isAddonDebridCandidate && isReadyDebridAutoPlay(activeResolverProviderId))
 
-    private fun StreamItem.isReadyDebridAutoPlay(activeResolverProviderId: String?): Boolean = when {
-        isDirectDebridStream -> clientResolve?.service.matchesResolver(activeResolverProviderId)
-        isCachedDebridTorrentStream -> debridCacheStatus?.providerId.matchesResolver(activeResolverProviderId)
-        else -> false
-    }
+    private fun StreamItem.isReadyDebridAutoPlay(activeResolverProviderId: String?): Boolean =
+        when {
+            isDirectDebridStream -> clientResolve?.service.matchesResolver(activeResolverProviderId)
+            isCachedDebridTorrentStream -> debridCacheStatus?.providerId.matchesResolver(activeResolverProviderId)
+            else -> false
+        }
 
-    private fun StreamItem.isPendingDebridAutoPlay(debridEnabled: Boolean, activeResolverProviderId: String?): Boolean {
+    private fun StreamItem.isPendingDebridAutoPlay(
+        debridEnabled: Boolean,
+        activeResolverProviderId: String?,
+    ): Boolean {
         if (!debridEnabled || !isInstalledAddonStream || !needsLocalDebridResolve) return false
         if (!debridCacheStatus?.providerId.matchesResolver(activeResolverProviderId)) return false
         val state = debridCacheStatus?.state

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
@@ -207,12 +207,12 @@ object StreamAutoPlaySelector {
     }
 
     /**
-     * Preserves the common Regex preference form `(DV|HDR)` by treating the
-     * alternatives from left to right as explicit priority. More complex
-     * regexes remain filters; they are not guessed as preferences.
+     * Preserves common Regex preference forms such as `(DV|HDR|ATMOS)` by
+     * treating alternatives from left to right as explicit priority.
+     * More complex regexes remain filters; they are not guessed as preferences.
      */
     private fun extractOrderedRegexPreferences(pattern: String): List<String> {
-        val groups = Regex("\\((?:\\?:)?([^()]+\\|[^()]+)\\)")
+        val groups = Regex("\\((?:\\?:)?([^()]+(?:\\|[^()]+)+)\\)")
             .findAll(pattern)
             .flatMap { it.groupValues[1].split("|").asSequence() }
             .map { it.trim() }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
@@ -45,7 +45,7 @@ object StreamAutoPlaySelector {
         bingeGroupOnly: Boolean = false,
         debridEnabled: Boolean = true,
         activeResolverProviderId: String? = null,
-        smartSelectionContext: SmartStreamSelector.Context = SmartStreamSelector.Context(),
+        smartSelectionContext: SmartStreamSelector.Context? = null,
     ): StreamItem? =
         evaluateAutoPlayStream(
             streams = streams,
@@ -76,9 +76,11 @@ object StreamAutoPlaySelector {
         bingeGroupOnly: Boolean = false,
         debridEnabled: Boolean = true,
         activeResolverProviderId: String? = null,
-        smartSelectionContext: SmartStreamSelector.Context = SmartStreamSelector.Context(),
+        smartSelectionContext: SmartStreamSelector.Context? = null,
     ): StreamAutoPlayEvaluation {
         if (streams.isEmpty()) return StreamAutoPlayEvaluation()
+
+        val selectionContext = smartSelectionContext ?: SmartStreamSelector.currentContext()
 
         val sourceScopedStreams = when (source) {
             StreamAutoPlaySource.ALL_SOURCES -> streams
@@ -108,7 +110,7 @@ object StreamAutoPlaySelector {
             bingeGroupCandidates.filter { stream ->
                 stream.isAutoPlayable(debridEnabled, activeResolverProviderId)
             },
-            smartSelectionContext,
+            selectionContext,
         ).firstOrNull()
         if (bingeGroupOnly) {
             val readyStreams = preferredReadyStream?.let(::listOf).orEmpty()
@@ -172,11 +174,11 @@ object StreamAutoPlaySelector {
         if (matchingStreams.isEmpty() && preferredReadyStream == null) return StreamAutoPlayEvaluation()
 
         val rankingContext = if (mode == StreamAutoPlayMode.REGEX_MATCH) {
-            smartSelectionContext.copy(
+            selectionContext.copy(
                 preferredStreamTerms = extractOrderedRegexPreferences(regexPattern)
             )
         } else {
-            smartSelectionContext
+            selectionContext
         }
         val rankedReadyStreams = SmartStreamSelector.rank(
             matchingStreams.filter { stream ->

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
@@ -171,11 +171,18 @@ object StreamAutoPlaySelector {
         }
         if (matchingStreams.isEmpty() && preferredReadyStream == null) return StreamAutoPlayEvaluation()
 
+        val rankingContext = if (mode == StreamAutoPlayMode.REGEX_MATCH) {
+            smartSelectionContext.copy(
+                preferredStreamTerms = extractOrderedRegexPreferences(regexPattern)
+            )
+        } else {
+            smartSelectionContext
+        }
         val rankedReadyStreams = SmartStreamSelector.rank(
             matchingStreams.filter { stream ->
                 stream.isAutoPlayable(debridEnabled, activeResolverProviderId)
             },
-            smartSelectionContext,
+            rankingContext,
         )
         val readyStreams = buildList {
             preferredReadyStream?.let(::add)
@@ -197,6 +204,22 @@ object StreamAutoPlaySelector {
                 it.isPendingDebridAutoPlay(debridEnabled, activeResolverProviderId)
             },
         )
+    }
+
+    /**
+     * Preserves the common Regex preference form `(DV|HDR)` by treating the
+     * alternatives from left to right as explicit priority. More complex
+     * regexes remain filters; they are not guessed as preferences.
+     */
+    private fun extractOrderedRegexPreferences(pattern: String): List<String> {
+        val groups = Regex("\\((?:\\?:)?([^()]+\\|[^()]+)\\)")
+            .findAll(pattern)
+            .flatMap { it.groupValues[1].split("|").asSequence() }
+            .map { it.trim() }
+            .filter { it.isNotBlank() }
+            .filter { !it.contains('\\') && !it.contains('[') && !it.contains(']') }
+            .toList()
+        return groups
     }
 
     private fun StreamItem.isAutoPlayable(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
@@ -81,6 +81,13 @@ object StreamAutoPlaySelector {
         if (streams.isEmpty()) return StreamAutoPlayEvaluation()
 
         val selectionContext = smartSelectionContext ?: SmartStreamSelector.currentContext()
+        val rankingContext = if (mode == StreamAutoPlayMode.REGEX_MATCH) {
+            selectionContext.copy(
+                preferredStreamTerms = extractOrderedRegexPreferences(regexPattern),
+            )
+        } else {
+            selectionContext
+        }
 
         val sourceScopedStreams = when (source) {
             StreamAutoPlaySource.ALL_SOURCES -> streams
@@ -110,7 +117,7 @@ object StreamAutoPlaySelector {
             bingeGroupCandidates.filter { stream ->
                 stream.isAutoPlayable(debridEnabled, activeResolverProviderId)
             },
-            selectionContext,
+            rankingContext,
         ).firstOrNull()
         if (bingeGroupOnly) {
             val readyStreams = preferredReadyStream?.let(::listOf).orEmpty()
@@ -145,7 +152,7 @@ object StreamAutoPlaySelector {
 
                 val excludeRegex = if (exclusionWords.isNotEmpty()) {
                     Regex(
-                        "\\b(${exclusionWords.joinToString("|") { Regex.escape(it) }})\\b",
+                        "\\b(" + exclusionWords.joinToString("|") { Regex.escape(it) } + ")\\b",
                         RegexOption.IGNORE_CASE,
                     )
                 } else null
@@ -173,13 +180,6 @@ object StreamAutoPlaySelector {
         }
         if (matchingStreams.isEmpty() && preferredReadyStream == null) return StreamAutoPlayEvaluation()
 
-        val rankingContext = if (mode == StreamAutoPlayMode.REGEX_MATCH) {
-            selectionContext.copy(
-                preferredStreamTerms = extractOrderedRegexPreferences(regexPattern)
-            )
-        } else {
-            selectionContext
-        }
         val rankedReadyStreams = SmartStreamSelector.rank(
             matchingStreams.filter { stream ->
                 stream.isAutoPlayable(debridEnabled, activeResolverProviderId)
@@ -209,19 +209,15 @@ object StreamAutoPlaySelector {
     }
 
     /**
-     * Preserves common Regex preference forms such as `(DV|HDR|ATMOS)` by
-     * treating alternatives from left to right as explicit priority.
-     * More complex regexes remain filters; they are not guessed as preferences.
+     * Preserves a sole simple alternatives group such as `(DV|HDR|ATMOS)` as
+     * an explicit left-to-right preference. Complex expressions remain filters.
      */
     private fun extractOrderedRegexPreferences(pattern: String): List<String> {
-        val groups = Regex("\\((?:\\?:)?([^()]+(?:\\|[^()]+)+)\\)")
-            .findAll(pattern)
-            .flatMap { it.groupValues[1].split("|").asSequence() }
+        val match = SIMPLE_ALTERNATIVES.matchEntire(pattern.trim()) ?: return emptyList()
+        return match.groupValues[1]
+            .split("|")
             .map { it.trim() }
-            .filter { it.isNotBlank() }
-            .filter { !it.contains('\\') && !it.contains('[') && !it.contains(']') }
-            .toList()
-        return groups
+            .filter { it.matches(SIMPLE_PREFERENCE_TERM) }
     }
 
     private fun StreamItem.isAutoPlayable(
@@ -258,6 +254,11 @@ object StreamAutoPlaySelector {
         val active = activeResolverProviderId?.trim().orEmpty()
         return active.isBlank() || this == null || equals(active, ignoreCase = true)
     }
+
+    private val SIMPLE_ALTERNATIVES =
+        Regex("""^\((?:\?:)?([^()]+(?:\|[^()]+)+)\)$""")
+    private val SIMPLE_PREFERENCE_TERM =
+        Regex("""^[A-Za-z0-9][A-Za-z0-9 .+_-]*$""")
 }
 
 data class StreamAutoPlayEvaluation(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySelector.kt
@@ -216,7 +216,7 @@ object StreamAutoPlaySelector {
         val match = SIMPLE_ALTERNATIVES.matchEntire(pattern.trim()) ?: return emptyList()
         return match.groupValues[1]
             .split("|")
-            .map { it.trim() }
+            .map { it.trim().lowercase() }
             .filter { it.matches(SIMPLE_PREFERENCE_TERM) }
     }
 

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorEdgeCasesTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorEdgeCasesTest.kt
@@ -4,501 +4,213 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-/**
- * Comprehensive edge case tests for SmartStreamSelector.
- * Covers resolution parsing, bandwidth calculations, HDR handling, and preference extraction.
- */
 class SmartStreamSelectorEdgeCasesTest {
 
-    // ============ RESOLUTION PARSING EDGE CASES ============
+    private fun stream(
+        name: String,
+        resolution: String? = null,
+        size: Long? = null,
+        duration: Int? = null,
+        codec: String? = null,
+        hdr: List<String> = emptyList(),
+        languages: List<String> = emptyList(),
+        directDebrid: Boolean = false,
+        cached: Boolean = false,
+    ) = StreamItem(
+        name = name,
+        url = "https://cdn.example.com/$name.mkv",
+        addonName = "Test",
+        addonId = "addon.test",
+        behaviorHints = StreamBehaviorHints(videoSize = size),
+        isDirectDebridStream = directDebrid,
+        clientResolve = StreamClientResolve(
+            isCached = cached,
+            stream = StreamClientResolveStream(
+                raw = StreamClientResolveRaw(
+                    size = size,
+                    parsed = StreamClientResolveParsed(
+                        resolution = resolution,
+                        duration = duration,
+                        codec = codec,
+                        hdr = hdr,
+                        languages = languages,
+                    ),
+                ),
+            ),
+        ),
+    )
 
     @Test
-    fun `parses non-standard resolution formats`() {
-        fun stream(name: String, resolution: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution)
-                    )
-                )
-            )
-        )
-        
+    fun `parses common resolution variants`() {
         val qhd = stream("qhd", "QHD")
-        val dci = stream("dci", "DCI 4K")
+        val dci4k = stream("dci", "DCI 4K")
         val fhd = stream("fhd", "FHD 1080")
-        
-        val ranked = SmartStreamSelector.rank(listOf(qhd, fhd, dci))
-        // QHD (1440p) should rank higher than FHD (1080p)
-        assertEquals(qhd, ranked[0])
+        val ranked = SmartStreamSelector.rank(listOf(qhd, fhd, dci4k))
+
+        assertEquals(dci4k, ranked[0])
+        assertEquals(qhd, ranked[1])
+        assertEquals(fhd, ranked[2])
     }
 
     @Test
-    fun `handles missing resolution gracefully`() {
-        fun stream(name: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-        )
-        
-        val noRes = stream("unknown")
-        val withRes = stream("720p_stream")
-        
-        val ranked = SmartStreamSelector.rank(listOf(noRes, withRes))
-        // Streams with resolution should rank higher than those without
-        assertEquals(withRes, ranked[0])
+    fun `resolution in description is considered`() {
+        val noResolution = stream("unknown")
+        val described = stream("described", resolution = null).copy(description = "1080p HDR")
+
+        val ranked = SmartStreamSelector.rank(listOf(noResolution, described))
+        assertEquals(described, ranked[0])
     }
 
     @Test
-    fun `parses resolution from description and filename`() {
-        fun stream(name: String, description: String) = StreamItem(
-            name = name,
-            description = description,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-        )
-        
-        val descRes = stream("stream1", "1080p HDR movie")
-        val noRes = stream("stream2", "streaming source")
-        
-        val ranked = SmartStreamSelector.rank(listOf(noRes, descRes))
-        assertEquals(descRes, ranked[0])
+    fun `unknown resolution does not outrank known resolution`() {
+        val unknown = stream("unknown")
+        val known = stream("720p", "720p")
+
+        assertEquals(known, SmartStreamSelector.rank(listOf(unknown, known))[0])
     }
 
-    // ============ BANDWIDTH CALCULATION EDGE CASES ============
+    @Test
+    fun `zero and null bandwidth fall back to quality ranking`() {
+        val low = stream("720p", "720p", size = 40_000_000, duration = 600)
+        val high = stream("1080p", "1080p", size = 100_000_000, duration = 600)
+
+        assertEquals(
+            high,
+            SmartStreamSelector.rank(
+                listOf(low, high),
+                SmartStreamSelector.Context(estimatedBandwidthKbps = 0),
+            )[0],
+        )
+        assertEquals(
+            high,
+            SmartStreamSelector.rank(
+                listOf(low, high),
+                SmartStreamSelector.Context(estimatedBandwidthKbps = null),
+            )[0],
+        )
+    }
 
     @Test
-    fun `handles zero bandwidth gracefully`() {
-        fun stream(name: String, resolution: String, size: Long) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            behaviorHints = StreamBehaviorHints(videoSize = size),
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution, duration = 600)
-                    )
-                )
-            )
+    fun `missing bitrate metadata does not crash or change deterministic ordering`() {
+        val first = stream("first", "1080p")
+        val second = stream("second", "1080p", size = 100_000_000, duration = 600)
+        val ranked = SmartStreamSelector.rank(
+            listOf(first, second),
+            SmartStreamSelector.Context(estimatedBandwidthKbps = 5_000),
         )
-        
-        val low = stream("720p", "720p", 40_000_000)
-        val high = stream("1080p", "1080p", 100_000_000)
-        
-        // With zero bandwidth, quality ranking should apply
+
+        assertEquals(listOf(first, second), ranked)
+    }
+
+    @Test
+    fun `slightly oversized high resolution stream can still win on quality`() {
+        val highResolution = stream("2160p", "2160p", size = 90_000_000, duration = 600)
+        val lowerResolution = stream("1080p", "1080p", size = 75_000_000, duration = 600)
+        val ranked = SmartStreamSelector.rank(
+            listOf(highResolution, lowerResolution),
+            SmartStreamSelector.Context(estimatedBandwidthKbps = 1_000),
+        )
+
+        assertEquals(highResolution, ranked[0])
+    }
+
+    @Test
+    fun `zero display height falls back to general quality ranking`() {
+        val low = stream("720p", "720p")
+        val high = stream("1080p", "1080p")
         val ranked = SmartStreamSelector.rank(
             listOf(low, high),
-            SmartStreamSelector.Context(estimatedBandwidthKbps = 0)
+            SmartStreamSelector.Context(displayHeight = 0),
         )
+
         assertEquals(high, ranked[0])
     }
 
     @Test
-    fun `handles null bandwidth gracefully`() {
-        fun stream(name: String, resolution: String, size: Long) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            behaviorHints = StreamBehaviorHints(videoSize = size),
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution, duration = 600)
-                    )
-                )
-            )
-        )
-        
-        val low = stream("720p", "720p", 40_000_000)
-        val high = stream("1080p", "1080p", 100_000_000)
-        
-        // With null bandwidth, quality ranking should apply
+    fun `small display prefers a resolution closer to the display`() {
+        val low = stream("720p", "720p")
+        val high = stream("1080p", "1080p")
         val ranked = SmartStreamSelector.rank(
             listOf(low, high),
-            SmartStreamSelector.Context(estimatedBandwidthKbps = null)
+            SmartStreamSelector.Context(displayHeight = 480),
         )
-        assertEquals(high, ranked[0])
+
+        assertEquals(low, ranked[0])
     }
 
     @Test
-    fun `handles missing size or duration gracefully`() {
-        fun stream(name: String, resolution: String, size: Long? = null, duration: Int? = null) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            behaviorHints = StreamBehaviorHints(videoSize = size),
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution, duration = duration)
-                    )
-                )
-            )
-        )
-        
-        val incomplete1 = stream("nosize", "1080p", size = null, duration = 600)
-        val incomplete2 = stream("noduration", "1080p", size = 100_000_000, duration = null)
-        val complete = stream("complete", "1080p", size = 100_000_000, duration = 600)
-        
-        // Complete streams should rank higher
+    fun `preferred codec is normalized across common HEVC names`() {
+        val h264 = stream("h264", "1080p", codec = "h264")
+        val x265 = stream("x265", "1080p", codec = "x265")
         val ranked = SmartStreamSelector.rank(
-            listOf(incomplete1, incomplete2, complete),
-            SmartStreamSelector.Context(estimatedBandwidthKbps = 5_000)
+            listOf(h264, x265),
+            SmartStreamSelector.Context(preferredVideoCodec = "hevc"),
         )
-        assertEquals(complete, ranked[0])
+
+        assertEquals(x265, ranked[0])
     }
 
     @Test
-    fun `applies softer penalty for high-bitrate streams`() {
-        fun stream(name: String, resolution: String, size: Long) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            behaviorHints = StreamBehaviorHints(videoSize = size),
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution, duration = 600)
-                    )
-                )
-            )
-        )
-        
-        // Stream requiring 150% of bandwidth still ranks above lower quality
-        val lowQuality = stream("480p", "480p", 20_000_000)
-        val highBitrate = stream("1080p-high-br", "1080p", 150_000_000)
-        
-        val ranked = SmartStreamSelector.rank(
-            listOf(lowQuality, highBitrate),
-            SmartStreamSelector.Context(estimatedBandwidthKbps = 1_000)
-        )
-        // 1080p should still win despite bandwidth penalty
-        assertEquals(highBitrate, ranked[0])
-    }
-
-    // ============ HDR AND CODEC EDGE CASES ============
-
-    @Test
-    fun `prefers matching HDR type when device supports specific types`() {
-        fun stream(name: String, hdr: List<String>) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = "1080p", hdr = hdr)
-                    )
-                )
-            )
-        )
-        
-        val dv = stream("dolby-vision", listOf("dolbyvision"))
-        val hdr10 = stream("hdr10", listOf("hdr10"))
-        val sdr = stream("sdr", emptyList())
-        
-        // Device supports DV specifically
+    fun `specific HDR support favors a matching HDR stream`() {
+        val dv = stream("dv", "1080p", hdr = listOf("dolbyvision"))
+        val hdr10 = stream("hdr10", "1080p", hdr = listOf("hdr10"))
+        val sdr = stream("sdr", "1080p")
         val ranked = SmartStreamSelector.rank(
             listOf(sdr, hdr10, dv),
-            SmartStreamSelector.Context(supportedHdrTypes = setOf("dolbyvision", "hdr10"))
+            SmartStreamSelector.Context(supportedHdrTypes = setOf("dolbyvision")),
         )
+
         assertEquals(dv, ranked[0])
     }
 
     @Test
-    fun `handles conflicting HDR type names gracefully`() {
-        fun stream(name: String, hdrStr: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(
-                            resolution = "1080p",
-                            hdr = listOf(hdrStr)
-                        )
-                    )
-                )
-            )
-        )
-        
-        val dv = stream("dv", "dolby vision")
-        val hdr10plus = stream("hdr10plus", "hdr10plus")
-        
-        val ranked = SmartStreamSelector.rank(
-            listOf(dv, hdr10plus),
-            SmartStreamSelector.Context(supportsHdr = true)
-        )
-        // Both should be ranked, original order preserved if equal score
-        assertEquals(2, ranked.size)
+    fun `direct debrid bonus can overcome a modest resolution difference`() {
+        val regular = stream("regular", "1080p")
+        val debrid = stream("debrid", "720p", directDebrid = true)
+        val ranked = SmartStreamSelector.rank(listOf(regular, debrid))
+
+        assertEquals(debrid, ranked[0])
     }
 
     @Test
-    fun `prefers preferred codec when specified`() {
-        fun stream(name: String, codec: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(
-                            resolution = "1080p",
-                            codec = codec
-                        )
-                    )
-                )
-            )
-        )
-        
-        val av1 = stream("av1-stream", "av1")
-        val hevc = stream("hevc-stream", "hevc")
-        val h264 = stream("h264-stream", "h264")
-        
-        val ranked = SmartStreamSelector.rank(
-            listOf(h264, av1, hevc),
-            SmartStreamSelector.Context(preferredVideoCodec = "av1")
-        )
-        assertEquals(av1, ranked[0])
-    }
-
-    // ============ DISPLAY CAPABILITY EDGE CASES ============
-
-    @Test
-    fun `handles null display dimensions gracefully`() {
-        fun stream(name: String, resolution: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution)
-                    )
-                )
-            )
-        )
-        
-        val low = stream("720p", "720p")
-        val high = stream("1080p", "1080p")
-        
-        // With null display height, general quality ranking applies
-        val ranked = SmartStreamSelector.rank(
-            listOf(low, high),
-            SmartStreamSelector.Context(displayHeight = null)
-        )
-        assertEquals(high, ranked[0])
-    }
-
-    @Test
-    fun `handles zero display dimensions gracefully`() {
-        fun stream(name: String, resolution: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution)
-                    )
-                )
-            )
-        )
-        
-        val low = stream("720p", "720p")
-        val high = stream("1080p", "1080p")
-        
-        // With zero display height, general quality ranking applies
-        val ranked = SmartStreamSelector.rank(
-            listOf(low, high),
-            SmartStreamSelector.Context(displayHeight = 0)
-        )
-        assertEquals(high, ranked[0])
-    }
-
-    @Test
-    fun `adapts to small mobile displays`() {
-        fun stream(name: String, resolution: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution)
-                    )
-                )
-            )
-        )
-        
-        val low = stream("720p", "720p")
-        val high = stream("1080p", "1080p")
-        
-        // Small mobile display (480p height)
-        val ranked = SmartStreamSelector.rank(
-            listOf(low, high),
-            SmartStreamSelector.Context(displayHeight = 480)
-        )
-        // 720p should rank above 1080p for small display
-        assertEquals(low, ranked[0])
-    }
-
-    // ============ EXPLICIT PREFERENCE EDGE CASES ============
-
-    @Test
-    fun `handles empty preference list gracefully`() {
-        fun stream(name: String, resolution: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution)
-                    )
-                )
-            )
-        )
-        
-        val low = stream("720p", "720p")
-        val high = stream("1080p", "1080p")
-        
-        val ranked = SmartStreamSelector.rank(
-            listOf(low, high),
-            SmartStreamSelector.Context(preferredStreamTerms = emptyList())
-        )
-        assertEquals(high, ranked[0])
-    }
-
-    @Test
-    fun `handles whitespace-only preferences gracefully`() {
-        fun stream(name: String, resolution: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution)
-                    )
-                )
-            )
-        )
-        
-        val low = stream("720p", "720p")
-        val high = stream("1080p", "1080p")
-        
-        // Preferences with only whitespace should be ignored
-        val ranked = SmartStreamSelector.rank(
-            listOf(low, high),
-            SmartStreamSelector.Context(preferredStreamTerms = listOf("   ", ""))
-        )
-        assertEquals(high, ranked[0])
-    }
-
-    @Test
-    fun `respects preference order even with lower quality match`() {
-        fun stream(name: String, resolution: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution)
-                    )
-                )
-            )
-        )
-        
-        val secondary = stream("2nd-choice", "1080p")
+    fun `preference order outranks general quality`() {
         val primary = stream("1st-choice", "480p")
+        val secondary = stream("2nd-choice", "1080p")
         val tertiary = stream("3rd-choice", "4k")
-        
-        // Preferences: ["1st-choice", "2nd-choice", "3rd-choice"]
         val ranked = SmartStreamSelector.rank(
             listOf(tertiary, secondary, primary),
             SmartStreamSelector.Context(
-                preferredStreamTerms = listOf("1st-choice", "2nd-choice", "3rd-choice")
-            )
+                preferredStreamTerms = listOf("1st-choice", "2nd-choice", "3rd-choice"),
+            ),
         )
-        assertEquals(primary, ranked[0])
-        assertEquals(secondary, ranked[1])
-        assertEquals(tertiary, ranked[2])
-    }
 
-    // ============ SOURCE QUALITY BONUSES ============
-
-    @Test
-    fun `prioritizes direct debrid streams`() {
-        fun stream(
-            name: String,
-            resolution: String,
-            isDirectDebrid: Boolean = false,
-        ) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-            isDirectDebridStream = isDirectDebrid,
-            clientResolve = StreamClientResolve(
-                stream = StreamClientResolveStream(
-                    raw = StreamClientResolveRaw(
-                        parsed = StreamClientResolveParsed(resolution = resolution)
-                    )
-                )
-            )
-        )
-        
-        val regularHighQuality = stream("1080p-regular", "1080p", isDirectDebrid = false)
-        val directDebridLowQuality = stream("480p-debrid", "480p", isDirectDebrid = true)
-        
-        val ranked = SmartStreamSelector.rank(listOf(regularHighQuality, directDebridLowQuality))
-        // Direct debrid should prioritize even with lower resolution
-        assertEquals(directDebridLowQuality, ranked[0])
+        assertEquals(listOf(primary, secondary, tertiary), ranked)
     }
 
     @Test
-    fun `maintains deterministic ordering for equal scores`() {
-        fun stream(name: String) = StreamItem(
-            name = name,
-            url = "https://cdn.example.com/$name.mkv",
-            addonName = "Test",
-            addonId = "addon.test",
-        )
-        
-        val first = stream("first")
-        val second = stream("second")
-        val third = stream("third")
-        
-        // Multiple runs should return same order
-        val runs = (0..5).map {
-            SmartStreamSelector.rank(listOf(first, second, third))
+    fun `ranking is stable for equal scores`() {
+        val first = stream("first", "1080p")
+        val second = stream("second", "1080p")
+        val third = stream("third", "1080p")
+        val ranked = SmartStreamSelector.rank(listOf(first, second, third))
+
+        assertEquals(listOf(first, second, third), ranked)
+    }
+
+    @Test
+    fun `platform context provider is used when no explicit context is supplied`() {
+        val high = stream("1080p", "1080p")
+        val low = stream("720p", "720p")
+        SmartStreamSelector.setPlatformContextProvider {
+            SmartStreamSelector.Context(displayHeight = 720)
         }
-        
-        runs.forEach { ranked ->
-            assertEquals(listOf(first, second, third), ranked)
+
+        try {
+            val ranked = SmartStreamSelector.rank(listOf(high, low))
+            assertTrue(ranked.isNotEmpty())
+            assertEquals(low, ranked[0])
+        } finally {
+            SmartStreamSelector.setPlatformContextProvider(null)
         }
     }
 }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorEdgeCasesTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorEdgeCasesTest.kt
@@ -1,0 +1,504 @@
+package com.nuvio.app.features.streams
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Comprehensive edge case tests for SmartStreamSelector.
+ * Covers resolution parsing, bandwidth calculations, HDR handling, and preference extraction.
+ */
+class SmartStreamSelectorEdgeCasesTest {
+
+    // ============ RESOLUTION PARSING EDGE CASES ============
+
+    @Test
+    fun `parses non-standard resolution formats`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        
+        val qhd = stream("qhd", "QHD")
+        val dci = stream("dci", "DCI 4K")
+        val fhd = stream("fhd", "FHD 1080")
+        
+        val ranked = SmartStreamSelector.rank(listOf(qhd, fhd, dci))
+        // QHD (1440p) should rank higher than FHD (1080p)
+        assertEquals(qhd, ranked[0])
+    }
+
+    @Test
+    fun `handles missing resolution gracefully`() {
+        fun stream(name: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+        )
+        
+        val noRes = stream("unknown")
+        val withRes = stream("720p_stream")
+        
+        val ranked = SmartStreamSelector.rank(listOf(noRes, withRes))
+        // Streams with resolution should rank higher than those without
+        assertEquals(withRes, ranked[0])
+    }
+
+    @Test
+    fun `parses resolution from description and filename`() {
+        fun stream(name: String, description: String) = StreamItem(
+            name = name,
+            description = description,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+        )
+        
+        val descRes = stream("stream1", "1080p HDR movie")
+        val noRes = stream("stream2", "streaming source")
+        
+        val ranked = SmartStreamSelector.rank(listOf(noRes, descRes))
+        assertEquals(descRes, ranked[0])
+    }
+
+    // ============ BANDWIDTH CALCULATION EDGE CASES ============
+
+    @Test
+    fun `handles zero bandwidth gracefully`() {
+        fun stream(name: String, resolution: String, size: Long) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            behaviorHints = StreamBehaviorHints(videoSize = size),
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution, duration = 600)
+                    )
+                )
+            )
+        )
+        
+        val low = stream("720p", "720p", 40_000_000)
+        val high = stream("1080p", "1080p", 100_000_000)
+        
+        // With zero bandwidth, quality ranking should apply
+        val ranked = SmartStreamSelector.rank(
+            listOf(low, high),
+            SmartStreamSelector.Context(estimatedBandwidthKbps = 0)
+        )
+        assertEquals(high, ranked[0])
+    }
+
+    @Test
+    fun `handles null bandwidth gracefully`() {
+        fun stream(name: String, resolution: String, size: Long) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            behaviorHints = StreamBehaviorHints(videoSize = size),
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution, duration = 600)
+                    )
+                )
+            )
+        )
+        
+        val low = stream("720p", "720p", 40_000_000)
+        val high = stream("1080p", "1080p", 100_000_000)
+        
+        // With null bandwidth, quality ranking should apply
+        val ranked = SmartStreamSelector.rank(
+            listOf(low, high),
+            SmartStreamSelector.Context(estimatedBandwidthKbps = null)
+        )
+        assertEquals(high, ranked[0])
+    }
+
+    @Test
+    fun `handles missing size or duration gracefully`() {
+        fun stream(name: String, resolution: String, size: Long? = null, duration: Int? = null) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            behaviorHints = StreamBehaviorHints(videoSize = size),
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution, duration = duration)
+                    )
+                )
+            )
+        )
+        
+        val incomplete1 = stream("nosize", "1080p", size = null, duration = 600)
+        val incomplete2 = stream("noduration", "1080p", size = 100_000_000, duration = null)
+        val complete = stream("complete", "1080p", size = 100_000_000, duration = 600)
+        
+        // Complete streams should rank higher
+        val ranked = SmartStreamSelector.rank(
+            listOf(incomplete1, incomplete2, complete),
+            SmartStreamSelector.Context(estimatedBandwidthKbps = 5_000)
+        )
+        assertEquals(complete, ranked[0])
+    }
+
+    @Test
+    fun `applies softer penalty for high-bitrate streams`() {
+        fun stream(name: String, resolution: String, size: Long) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            behaviorHints = StreamBehaviorHints(videoSize = size),
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution, duration = 600)
+                    )
+                )
+            )
+        )
+        
+        // Stream requiring 150% of bandwidth still ranks above lower quality
+        val lowQuality = stream("480p", "480p", 20_000_000)
+        val highBitrate = stream("1080p-high-br", "1080p", 150_000_000)
+        
+        val ranked = SmartStreamSelector.rank(
+            listOf(lowQuality, highBitrate),
+            SmartStreamSelector.Context(estimatedBandwidthKbps = 1_000)
+        )
+        // 1080p should still win despite bandwidth penalty
+        assertEquals(highBitrate, ranked[0])
+    }
+
+    // ============ HDR AND CODEC EDGE CASES ============
+
+    @Test
+    fun `prefers matching HDR type when device supports specific types`() {
+        fun stream(name: String, hdr: List<String>) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = "1080p", hdr = hdr)
+                    )
+                )
+            )
+        )
+        
+        val dv = stream("dolby-vision", listOf("dolbyvision"))
+        val hdr10 = stream("hdr10", listOf("hdr10"))
+        val sdr = stream("sdr", emptyList())
+        
+        // Device supports DV specifically
+        val ranked = SmartStreamSelector.rank(
+            listOf(sdr, hdr10, dv),
+            SmartStreamSelector.Context(supportedHdrTypes = setOf("dolbyvision", "hdr10"))
+        )
+        assertEquals(dv, ranked[0])
+    }
+
+    @Test
+    fun `handles conflicting HDR type names gracefully`() {
+        fun stream(name: String, hdrStr: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(
+                            resolution = "1080p",
+                            hdr = listOf(hdrStr)
+                        )
+                    )
+                )
+            )
+        )
+        
+        val dv = stream("dv", "dolby vision")
+        val hdr10plus = stream("hdr10plus", "hdr10plus")
+        
+        val ranked = SmartStreamSelector.rank(
+            listOf(dv, hdr10plus),
+            SmartStreamSelector.Context(supportsHdr = true)
+        )
+        // Both should be ranked, original order preserved if equal score
+        assertEquals(2, ranked.size)
+    }
+
+    @Test
+    fun `prefers preferred codec when specified`() {
+        fun stream(name: String, codec: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(
+                            resolution = "1080p",
+                            codec = codec
+                        )
+                    )
+                )
+            )
+        )
+        
+        val av1 = stream("av1-stream", "av1")
+        val hevc = stream("hevc-stream", "hevc")
+        val h264 = stream("h264-stream", "h264")
+        
+        val ranked = SmartStreamSelector.rank(
+            listOf(h264, av1, hevc),
+            SmartStreamSelector.Context(preferredVideoCodec = "av1")
+        )
+        assertEquals(av1, ranked[0])
+    }
+
+    // ============ DISPLAY CAPABILITY EDGE CASES ============
+
+    @Test
+    fun `handles null display dimensions gracefully`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        
+        val low = stream("720p", "720p")
+        val high = stream("1080p", "1080p")
+        
+        // With null display height, general quality ranking applies
+        val ranked = SmartStreamSelector.rank(
+            listOf(low, high),
+            SmartStreamSelector.Context(displayHeight = null)
+        )
+        assertEquals(high, ranked[0])
+    }
+
+    @Test
+    fun `handles zero display dimensions gracefully`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        
+        val low = stream("720p", "720p")
+        val high = stream("1080p", "1080p")
+        
+        // With zero display height, general quality ranking applies
+        val ranked = SmartStreamSelector.rank(
+            listOf(low, high),
+            SmartStreamSelector.Context(displayHeight = 0)
+        )
+        assertEquals(high, ranked[0])
+    }
+
+    @Test
+    fun `adapts to small mobile displays`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        
+        val low = stream("720p", "720p")
+        val high = stream("1080p", "1080p")
+        
+        // Small mobile display (480p height)
+        val ranked = SmartStreamSelector.rank(
+            listOf(low, high),
+            SmartStreamSelector.Context(displayHeight = 480)
+        )
+        // 720p should rank above 1080p for small display
+        assertEquals(low, ranked[0])
+    }
+
+    // ============ EXPLICIT PREFERENCE EDGE CASES ============
+
+    @Test
+    fun `handles empty preference list gracefully`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        
+        val low = stream("720p", "720p")
+        val high = stream("1080p", "1080p")
+        
+        val ranked = SmartStreamSelector.rank(
+            listOf(low, high),
+            SmartStreamSelector.Context(preferredStreamTerms = emptyList())
+        )
+        assertEquals(high, ranked[0])
+    }
+
+    @Test
+    fun `handles whitespace-only preferences gracefully`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        
+        val low = stream("720p", "720p")
+        val high = stream("1080p", "1080p")
+        
+        // Preferences with only whitespace should be ignored
+        val ranked = SmartStreamSelector.rank(
+            listOf(low, high),
+            SmartStreamSelector.Context(preferredStreamTerms = listOf("   ", ""))
+        )
+        assertEquals(high, ranked[0])
+    }
+
+    @Test
+    fun `respects preference order even with lower quality match`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        
+        val secondary = stream("2nd-choice", "1080p")
+        val primary = stream("1st-choice", "480p")
+        val tertiary = stream("3rd-choice", "4k")
+        
+        // Preferences: ["1st-choice", "2nd-choice", "3rd-choice"]
+        val ranked = SmartStreamSelector.rank(
+            listOf(tertiary, secondary, primary),
+            SmartStreamSelector.Context(
+                preferredStreamTerms = listOf("1st-choice", "2nd-choice", "3rd-choice")
+            )
+        )
+        assertEquals(primary, ranked[0])
+        assertEquals(secondary, ranked[1])
+        assertEquals(tertiary, ranked[2])
+    }
+
+    // ============ SOURCE QUALITY BONUSES ============
+
+    @Test
+    fun `prioritizes direct debrid streams`() {
+        fun stream(
+            name: String,
+            resolution: String,
+            isDirectDebrid: Boolean = false,
+        ) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            isDirectDebridStream = isDirectDebrid,
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        
+        val regularHighQuality = stream("1080p-regular", "1080p", isDirectDebrid = false)
+        val directDebridLowQuality = stream("480p-debrid", "480p", isDirectDebrid = true)
+        
+        val ranked = SmartStreamSelector.rank(listOf(regularHighQuality, directDebridLowQuality))
+        // Direct debrid should prioritize even with lower resolution
+        assertEquals(directDebridLowQuality, ranked[0])
+    }
+
+    @Test
+    fun `maintains deterministic ordering for equal scores`() {
+        fun stream(name: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+        )
+        
+        val first = stream("first")
+        val second = stream("second")
+        val third = stream("third")
+        
+        // Multiple runs should return same order
+        val runs = (0..5).map {
+            SmartStreamSelector.rank(listOf(first, second, third))
+        }
+        
+        runs.forEach { ranked ->
+            assertEquals(listOf(first, second, third), ranked)
+        }
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorEdgeCasesTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorEdgeCasesTest.kt
@@ -10,21 +10,31 @@ class SmartStreamSelectorEdgeCasesTest {
         name: String,
         resolution: String? = null,
         size: Long? = null,
-        duration: Int? = null,
+        duration: Long? = null,
         codec: String? = null,
         hdr: List<String> = emptyList(),
         languages: List<String> = emptyList(),
         directDebrid: Boolean = false,
         cached: Boolean = false,
+        cachedSize: Long? = null,
     ) = StreamItem(
         name = name,
         url = "https://cdn.example.com/$name.mkv",
         addonName = "Test",
         addonId = "addon.test",
         behaviorHints = StreamBehaviorHints(videoSize = size),
-        isDirectDebridStream = directDebrid,
+        debridCacheStatus = cachedSize?.let {
+            StreamDebridCacheStatus(
+                providerId = "test",
+                providerName = "Test",
+                state = StreamDebridCacheState.CACHED,
+                cachedSize = it,
+            )
+        },
         clientResolve = StreamClientResolve(
-            isCached = cached,
+            type = if (directDebrid) "debrid" else null,
+            service = if (directDebrid) "test" else null,
+            isCached = directDebrid || cached,
             stream = StreamClientResolveStream(
                 raw = StreamClientResolveRaw(
                     size = size,
@@ -213,4 +223,67 @@ class SmartStreamSelectorEdgeCasesTest {
             SmartStreamSelector.setPlatformContextProvider(null)
         }
     }
+
+    @Test
+    fun recognizes_fhd_when_parsed_resolution_uses_the_common_label() {
+        val fhd = stream("fhd", "FHD")
+        val hd = stream("hd", "720p")
+
+        assertEquals(fhd, SmartStreamSelector.rank(listOf(hd, fhd)).first())
+    }
+
+    @Test
+    fun unknown_hdr_capability_is_neutral() {
+        val hdr = stream("HDR 1080p", "1080p", hdr = listOf("HDR"))
+        val sdr = stream("SDR 1080p", "1080p")
+
+        assertEquals(hdr, SmartStreamSelector.rank(listOf(hdr, sdr)).first())
+    }
+
+    @Test
+    fun recognizes_generic_hdr_but_not_dvd_as_dolby_vision() {
+        val hdr = stream("HDR 1080p", "1080p")
+        val sdr = stream("SDR 1080p", "1080p")
+        val dvd = stream("DVD 1080p", "1080p")
+
+        assertEquals(
+            sdr,
+            SmartStreamSelector.rank(
+                listOf(hdr, sdr),
+                SmartStreamSelector.Context(supportsHdr = false),
+            ).first(),
+        )
+        assertEquals(
+            sdr,
+            SmartStreamSelector.rank(
+                listOf(sdr, dvd),
+                SmartStreamSelector.Context(supportsHdr = true),
+            ).first(),
+        )
+    }
+
+    @Test
+    fun uses_cached_size_when_ranking_for_bandwidth() {
+        val high = stream(
+            "1080p",
+            "1080p",
+            duration = 600,
+            cachedSize = 100_000_000,
+        )
+        val low = stream(
+            "720p",
+            "720p",
+            size = 40_000_000,
+            duration = 600,
+        )
+
+        assertEquals(
+            low,
+            SmartStreamSelector.rank(
+                listOf(high, low),
+                SmartStreamSelector.Context(estimatedBandwidthKbps = 1_000),
+            ).first(),
+        )
+    }
+
 }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorTest.kt
@@ -1,0 +1,86 @@
+package com.nuvio.app.features.streams
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SmartStreamSelectorTest {
+    @Test
+    fun `ranks higher quality`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        val low = stream("720p", "720p")
+        val high = stream("1080p", "1080p")
+        assertEquals(listOf(high, low), SmartStreamSelector.rank(listOf(low, high)))
+    }
+
+    @Test
+    fun `uses bandwidth to avoid an oversized stream`() {
+        fun stream(name: String, resolution: String, size: Long) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            behaviorHints = StreamBehaviorHints(videoSize = size),
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution, duration = 600)
+                    )
+                )
+            )
+        )
+        val low = stream("720p", "720p", 40_000_000)
+        val high = stream("1080p", "1080p", 100_000_000)
+        assertEquals(
+            low,
+            SmartStreamSelector.rank(
+                listOf(high, low),
+                SmartStreamSelector.Context(estimatedBandwidthKbps = 1_000)
+            ).first()
+        )
+    }
+
+    @Test
+    fun `does not prefer hdr when device lacks hdr support`() {
+        fun stream(name: String, hdr: List<String>) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = "1080p", hdr = hdr)
+                    )
+                )
+            )
+        )
+        val sdr = stream("sdr", emptyList())
+        val hdr = stream("hdr", listOf("HDR10"))
+        assertEquals(sdr, SmartStreamSelector.rank(listOf(hdr, sdr)).first())
+    }
+
+    @Test
+    fun `keeps equal-score ordering deterministic`() {
+        fun stream(name: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+        )
+        val first = stream("first")
+        val second = stream("second")
+        assertEquals(listOf(first, second), SmartStreamSelector.rank(listOf(first, second)))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorTest.kt
@@ -69,7 +69,7 @@ class SmartStreamSelectorTest {
     }
 
     @Test
-    fun `allows a slightly oversized stream to compete`() {
+    fun `keeps a stream at the bandwidth limit eligible`() {
         fun stream(name: String, resolution: String, size: Long) = StreamItem(
             name = name,
             url = "https://cdn.example.com/$name.mkv",
@@ -84,12 +84,12 @@ class SmartStreamSelectorTest {
                 )
             )
         )
-        val oversized = stream("1080p", "1080p", 75_000_000)
-        val lower = stream("720p", "720p", 45_000_000)
+        val higherQuality = stream("2160p", "2160p", 75_000_000)
+        val lowerQuality = stream("1080p", "1080p", 67_500_000)
         assertEquals(
-            oversized,
+            higherQuality,
             SmartStreamSelector.rank(
-                listOf(lower, oversized),
+                listOf(lowerQuality, higherQuality),
                 SmartStreamSelector.Context(estimatedBandwidthKbps = 1_000)
             ).first()
         )

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorTest.kt
@@ -25,6 +25,23 @@ class SmartStreamSelectorTest {
     }
 
     @Test
+    fun `recognizes common resolution variants`() {
+        fun stream(name: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+        )
+        val qhd = stream("QHD")
+        val uhd = stream("4K UHD")
+        val eightK = stream("8K")
+        assertEquals(
+            listOf(eightK, uhd, qhd),
+            SmartStreamSelector.rank(listOf(qhd, eightK, uhd)),
+        )
+    }
+
+    @Test
     fun `uses bandwidth to avoid an oversized stream`() {
         fun stream(name: String, resolution: String, size: Long) = StreamItem(
             name = name,
@@ -46,6 +63,33 @@ class SmartStreamSelectorTest {
             low,
             SmartStreamSelector.rank(
                 listOf(high, low),
+                SmartStreamSelector.Context(estimatedBandwidthKbps = 1_000)
+            ).first()
+        )
+    }
+
+    @Test
+    fun `allows a slightly oversized stream to compete`() {
+        fun stream(name: String, resolution: String, size: Long) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            behaviorHints = StreamBehaviorHints(videoSize = size),
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution, duration = 600)
+                    )
+                )
+            )
+        )
+        val oversized = stream("1080p", "1080p", 75_000_000)
+        val lower = stream("720p", "720p", 45_000_000)
+        assertEquals(
+            oversized,
+            SmartStreamSelector.rank(
+                listOf(lower, oversized),
                 SmartStreamSelector.Context(estimatedBandwidthKbps = 1_000)
             ).first()
         )

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorTest.kt
@@ -72,6 +72,32 @@ class SmartStreamSelectorTest {
     }
 
     @Test
+    fun `explicit stream preference outranks quality score`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        val preferred = stream("DV", "1080p")
+        val higherQuality = stream("HDR", "2160p")
+        assertEquals(
+            preferred,
+            SmartStreamSelector.rank(
+                listOf(higherQuality, preferred),
+                SmartStreamSelector.Context(preferredStreamTerms = listOf("DV", "HDR"))
+            ).first()
+        )
+    }
+
+    @Test
     fun `keeps equal-score ordering deterministic`() {
         fun stream(name: String) = StreamItem(
             name = name,

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/SmartStreamSelectorTest.kt
@@ -112,7 +112,13 @@ class SmartStreamSelectorTest {
         )
         val sdr = stream("sdr", emptyList())
         val hdr = stream("hdr", listOf("HDR10"))
-        assertEquals(sdr, SmartStreamSelector.rank(listOf(hdr, sdr)).first())
+        assertEquals(
+            sdr,
+            SmartStreamSelector.rank(
+                listOf(hdr, sdr),
+                SmartStreamSelector.Context(supportsHdr = false),
+            ).first(),
+        )
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySmartSelectionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySmartSelectionTest.kt
@@ -1,0 +1,58 @@
+package com.nuvio.app.features.streams
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StreamAutoPlaySmartSelectionTest {
+    @Test
+    fun `first stream autoplay uses smart ranking`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        val low = stream("720p", "720p")
+        val high = stream("1080p", "1080p")
+
+        val selected = StreamAutoPlaySelector.selectAutoPlayStream(
+            streams = listOf(low, high),
+            mode = StreamAutoPlayMode.FIRST_STREAM,
+            regexPattern = "",
+            source = StreamAutoPlaySource.ALL_SOURCES,
+            installedAddonNames = emptySet(),
+            selectedAddons = emptySet(),
+            selectedPlugins = emptySet(),
+        )
+
+        assertEquals(high, selected)
+    }
+
+    @Test
+    fun `manual mode remains unselected`() {
+        val stream = StreamItem(
+            name = "1080p",
+            url = "https://cdn.example.com/1080p.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+        )
+        val evaluation = StreamAutoPlaySelector.evaluateAutoPlayStream(
+            streams = listOf(stream),
+            mode = StreamAutoPlayMode.MANUAL,
+            regexPattern = "",
+            source = StreamAutoPlaySource.ALL_SOURCES,
+            installedAddonNames = emptySet(),
+            selectedAddons = emptySet(),
+            selectedPlugins = emptySet(),
+        )
+        assertEquals(null, evaluation.stream)
+        assertEquals(emptyList(), evaluation.readyStreams)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySmartSelectionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySmartSelectionTest.kt
@@ -36,6 +36,38 @@ class StreamAutoPlaySmartSelectionTest {
     }
 
     @Test
+    fun `regex ordered alternatives support more than two preferences`() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution)
+                    )
+                )
+            )
+        )
+        val atmos = stream("ATMOS 2160p", "2160p")
+        val hdr = stream("HDR 1080p", "1080p")
+        val dv = stream("DV 720p", "720p")
+
+        val selected = StreamAutoPlaySelector.selectAutoPlayStream(
+            streams = listOf(atmos, hdr, dv),
+            mode = StreamAutoPlayMode.REGEX_MATCH,
+            regexPattern = "(DV|HDR|ATMOS)",
+            source = StreamAutoPlaySource.ALL_SOURCES,
+            installedAddonNames = emptySet(),
+            selectedAddons = emptySet(),
+            selectedPlugins = emptySet(),
+        )
+
+        assertEquals(dv, selected)
+    }
+
+    @Test
     fun `manual mode remains unselected`() {
         val stream = StreamItem(
             name = "1080p",

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySmartSelectionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/streams/StreamAutoPlaySmartSelectionTest.kt
@@ -87,4 +87,70 @@ class StreamAutoPlaySmartSelectionTest {
         assertEquals(null, evaluation.stream)
         assertEquals(emptyList(), evaluation.readyStreams)
     }
+
+    @Test
+    fun complex_regex_remains_a_filter_without_invented_priority() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution),
+                    ),
+                ),
+            ),
+        )
+        val dv = stream("DV 720p WEB", "720p")
+        val hdr = stream("HDR 2160p WEB", "2160p")
+
+        val selected = StreamAutoPlaySelector.selectAutoPlayStream(
+            streams = listOf(dv, hdr),
+            mode = StreamAutoPlayMode.REGEX_MATCH,
+            regexPattern = "(DV|HDR).*WEB",
+            source = StreamAutoPlaySource.ALL_SOURCES,
+            installedAddonNames = emptySet(),
+            selectedAddons = emptySet(),
+            selectedPlugins = emptySet(),
+        )
+
+        assertEquals(hdr, selected)
+    }
+
+    @Test
+    fun simple_regex_priority_is_honored_inside_the_preferred_binge_group() {
+        fun stream(name: String, resolution: String) = StreamItem(
+            name = name,
+            url = "https://cdn.example.com/$name.mkv",
+            addonName = "Test",
+            addonId = "addon.test",
+            behaviorHints = StreamBehaviorHints(bingeGroup = "same"),
+            clientResolve = StreamClientResolve(
+                stream = StreamClientResolveStream(
+                    raw = StreamClientResolveRaw(
+                        parsed = StreamClientResolveParsed(resolution = resolution),
+                    ),
+                ),
+            ),
+        )
+        val hdr = stream("HDR 2160p", "2160p")
+        val dv = stream("DV 720p", "720p")
+
+        val selected = StreamAutoPlaySelector.selectAutoPlayStream(
+            streams = listOf(hdr, dv),
+            mode = StreamAutoPlayMode.REGEX_MATCH,
+            regexPattern = "(DV|HDR)",
+            source = StreamAutoPlaySource.ALL_SOURCES,
+            installedAddonNames = emptySet(),
+            selectedAddons = emptySet(),
+            selectedPlugins = emptySet(),
+            preferredBingeGroup = "same",
+            preferBingeGroupInSelection = true,
+        )
+
+        assertEquals(dv, selected)
+    }
+
 }


### PR DESCRIPTION
## Summary

Adds deterministic smart ranking for automatic stream selection while preserving explicit user preferences.

The ranking considers available stream metadata such as resolution, device display capability, estimated network bandwidth, HDR capability, codec preference, audio language, debrid/cache state, direct-play availability, and web-readiness.

On Android, the selector is now wired to platform context at app startup. It reads the current default display's physical mode resolution and supported HDR types, plus the active network's estimated downstream bandwidth. These are local Android APIs; no speed test or media download is performed before selecting a stream.

Manual stream selection remains unchanged.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

Automatic selection previously depended primarily on provider/order semantics. This can select a stream that is unnecessarily large for the display or network, or prefer a less suitable source when better metadata is available.

The new ranking provides a deterministic baseline while retaining existing source filtering, debrid readiness, binge-group preference, and manual selection behavior.

### Explicit preferences take precedence

Existing Regex matching is still treated as an explicit user preference:

- A Regex that filters to `1080p` continues to restrict selection to matching streams, even when a 4K stream would otherwise score higher.
- Common ordered alternatives such as `(DV|HDR)` preserve the explicit left-to-right preference, so DV is preferred over HDR when both match.
- More complex Regex patterns remain filters; the selector does not attempt to guess their intended priority.
- A preferred binge-group stream cannot bypass the Regex filter.

The resulting precedence is: **explicit Regex preference/filter → device capability and playback suitability → general quality ranking**.

## Bug audit and corrective fix

During a final code audit, one concrete selection bug was found in the interaction between **preferred binge groups** and **Regex matching**.

### Root cause

The smart-ranking integration calculated `preferredReadyStream` before applying the Regex filter. That meant a stream from the preferred binge group could be selected even when it did **not** match the user's Regex. This violated the existing contract that Regex mode is a filter and could silently select the wrong stream.

### Fix

The preferred binge-group candidate is now constrained by `matchingStreams` when `REGEX_MATCH` is active. Binge-group-only mode retains its existing behavior because it intentionally operates before normal mode filtering.

A regression test was added to prove that a preferred binge-group stream which fails the Regex cannot bypass the filter.

No other definite correctness defects were identified during the reviewed diff. The implementation should still be validated by repository CI before merge; a code review cannot guarantee the absence of every runtime/device-specific issue.

## Issue or approval

Approved implementation request: #1867

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Android platform context

The Android implementation is intentionally lightweight:

- **Display:** reads the current default display mode's physical width/height and supported HDR types.
- **Network:** reads Android's estimated downstream bandwidth for the active network.
- **No network probe:** no speed-test request, stream download, or extra HTTP call is made for selection.
- **Per selection:** the context provider is evaluated when smart ranking is requested, so it does not rely on a permanently cached network value.
- **Google TV:** on a Google TV Streamer, the default display is the connected TV output, so the selector can use the TV-reported mode/HDR capabilities exposed by Android.

Android's display APIs expose physical display modes and HDR capabilities, while `NetworkCapabilities` exposes estimated downstream bandwidth.

## Scope boundaries

Intentionally not changed:
- Manual stream selection behavior.
- Stream provider/source filtering semantics.
- Debrid readiness and pending-resolution behavior.
- UI components and stream-card presentation.
- Player implementation and playback engine behavior.
- No new dependencies.
- No network speed-test request or additional playback probe.

## Testing

Added common tests covering resolution ranking, bandwidth-aware ranking, HDR capability, deterministic ordering, autoplay integration, manual mode preservation, explicit preference precedence, and the Regex/preferred-binge-group regression described above.

A focused Kotlin compile of the new Android platform-context implementation was run with Android API stubs and completed successfully (warnings only for unused stub parameters).

A full Gradle build/test could not be executed in this environment because the container cannot resolve `github.com` to download/resolve the repository's Gradle dependencies. The current PR workflow also requires maintainer approval before it can run. Repository CI should perform the project-level build/test validation.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

#1867