### PR TITLE
fix(details): fix 60-second hang on metadata details page and align loading with Desktop behaviour

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsRepository.kt
@@ -21,13 +21,17 @@ import com.nuvio.app.features.trakt.shouldUseTraktMoreLikeThis
 import com.nuvio.app.features.watchprogress.CurrentDateProvider
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import nuvio.composeapp.generated.resources.*
@@ -46,6 +50,8 @@ object MetaDetailsRepository {
     val uiState: StateFlow<MetaDetailsUiState> = _uiState.asStateFlow()
     private var activeRequestKey: String? = null
     private val cachedMetaByRequestKey = mutableMapOf<String, CachedMetaEntry>()
+    private val inFlightBaseMeta = mutableMapOf<String, Deferred<Pair<MetaDetails, String>?>>()
+    private val inFlightMutex = Mutex()
 
     fun load(type: String, id: String) {
         log.d { "load() called — type=$type id=$id" }
@@ -92,8 +98,9 @@ object MetaDetailsRepository {
                         settingsFingerprint = metaScreenSettingsFingerprint,
                     )
                 }
-                _uiState.value = MetaDetailsUiState(meta = enrichedMeta.withUnreleasedFilter())
-                activeRequestKey = requestKey
+                if (activeRequestKey == requestKey) {
+                    _uiState.value = MetaDetailsUiState(meta = enrichedMeta.withUnreleasedFilter())
+                }
             }
             return
         }
@@ -113,67 +120,27 @@ object MetaDetailsRepository {
         _uiState.value = MetaDetailsUiState(isLoading = true)
 
         scope.launch {
-            val metaLookupId = resolveMetaLookupId(itemId = id, itemType = type)
-            val candidates = findReadyMetaCandidates(type = type, id = metaLookupId)
-
-            if (candidates.isEmpty()) {
-                val tmdbMeta = tryFetchTmdbFallbackMeta(type = type, id = id)
-                if (tmdbMeta != null) {
-                    publishLoadedMeta(
-                        requestKey = requestKey,
-                        meta = tmdbMeta,
-                        fallbackItemId = id,
-                        fallbackItemType = type,
-                        mdbListSettings = mdbListSettings,
-                        metaScreenSettingsFingerprint = metaScreenSettingsFingerprint,
+            val baseResult = fetchBaseMeta(type, id)
+            if (baseResult == null) {
+                log.w { "Failed to load meta for type=$type id=$id" }
+                if (activeRequestKey == requestKey) {
+                    _uiState.value = MetaDetailsUiState(
+                        errorMessage = getString(Res.string.details_load_failed_all_addons),
                     )
-                    return@launch
+                    activeRequestKey = null
                 }
-
-                log.w { "No addon provides meta for type=$type id=$id" }
-                _uiState.value = MetaDetailsUiState(
-                    errorMessage = getString(Res.string.details_no_addon_meta),
-                )
-                activeRequestKey = null
                 return@launch
             }
 
-            for (candidate in candidates) {
-                val result = withTimeoutOrNull(FETCH_TIMEOUT_MS) {
-                    withContext(Dispatchers.Default) {
-                        tryFetchMeta(candidate.manifest, candidate.candidateType, metaLookupId, includeMdbList = false)
-                    }
-                }
-                if (result != null) {
-                    publishLoadedMeta(
-                        requestKey = requestKey,
-                        meta = result,
-                        fallbackItemId = metaLookupId,
-                        fallbackItemType = candidate.candidateType,
-                        mdbListSettings = mdbListSettings,
-                        metaScreenSettingsFingerprint = metaScreenSettingsFingerprint,
-                    )
-                    return@launch
-                }
-            }
-
-            val tmdbMeta = tryFetchTmdbFallbackMeta(type = type, id = id)
-            if (tmdbMeta != null) {
-                publishLoadedMeta(
-                    requestKey = requestKey,
-                    meta = tmdbMeta,
-                    fallbackItemId = id,
-                    fallbackItemType = type,
-                    mdbListSettings = mdbListSettings,
-                    metaScreenSettingsFingerprint = metaScreenSettingsFingerprint,
-                )
-                return@launch
-            }
-
-            _uiState.value = MetaDetailsUiState(
-                errorMessage = getString(Res.string.details_load_failed_all_addons),
+            val (baseMeta, candidateType) = baseResult
+            publishLoadedMeta(
+                requestKey = requestKey,
+                meta = baseMeta,
+                fallbackItemId = id,
+                fallbackItemType = candidateType,
+                mdbListSettings = mdbListSettings,
+                metaScreenSettingsFingerprint = metaScreenSettingsFingerprint,
             )
-            activeRequestKey = null
         }
     }
 
@@ -192,6 +159,8 @@ object MetaDetailsRepository {
     fun clear() {
         activeRequestKey = null
         cachedMetaByRequestKey.clear()
+        inFlightBaseMeta.values.forEach { it.cancel() }
+        inFlightBaseMeta.clear()
         _uiState.value = MetaDetailsUiState()
     }
 
@@ -199,26 +168,55 @@ object MetaDetailsRepository {
         val requestKey = "$type:$id"
         cachedMetaByRequestKey[requestKey]?.let { return it.baseMeta }
 
-        val metaLookupId = resolveMetaLookupId(itemId = id, itemType = type)
-        val candidates = findReadyMetaCandidates(type = type, id = metaLookupId)
+        val baseResult = fetchBaseMeta(type, id) ?: return null
+        val (baseMeta, _) = baseResult
+        if (cacheResult) {
+            cachedMetaByRequestKey[requestKey] = CachedMetaEntry(baseMeta = baseMeta)
+        }
+        return baseMeta
+    }
 
-        for (candidate in candidates) {
-            val result = withTimeoutOrNull(FETCH_TIMEOUT_MS) {
-                tryFetchMeta(candidate.manifest, candidate.candidateType, metaLookupId, includeMdbList = false)
-            }
-            if (result != null) {
-                if (cacheResult) {
-                    cachedMetaByRequestKey[requestKey] = CachedMetaEntry(baseMeta = result)
+    private suspend fun fetchBaseMeta(
+        type: String,
+        id: String,
+    ): Pair<MetaDetails, String>? {
+        val requestKey = "$type:$id"
+        val deferred = inFlightMutex.withLock {
+            inFlightBaseMeta.getOrPut(requestKey) {
+                scope.async(Dispatchers.Default) {
+                    try {
+                        val metaLookupId = resolveMetaLookupId(itemId = id, itemType = type)
+                        val candidates = findReadyMetaCandidates(type = type, id = metaLookupId)
+
+                        for (candidate in candidates) {
+                            val result = withTimeoutOrNull(FETCH_TIMEOUT_MS) {
+                                tryFetchMeta(
+                                    manifest = candidate.manifest,
+                                    type = candidate.candidateType,
+                                    id = metaLookupId,
+                                    includeMdbList = false,
+                                )
+                            }
+                            if (result != null) {
+                                return@async result to candidate.candidateType
+                            }
+                        }
+
+                        val tmdbMeta = tryFetchTmdbFallbackMeta(type = type, id = id)
+                        if (tmdbMeta != null) {
+                            return@async tmdbMeta to type
+                        }
+
+                        null
+                    } finally {
+                        inFlightMutex.withLock {
+                            inFlightBaseMeta.remove(requestKey)
+                        }
+                    }
                 }
-                return result
             }
         }
-
-        return tryFetchTmdbFallbackMeta(type = type, id = id)?.also { result ->
-            if (cacheResult) {
-                cachedMetaByRequestKey[requestKey] = CachedMetaEntry(baseMeta = result)
-            }
-        }
+        return deferred.await()
     }
 
     private const val FETCH_TIMEOUT_MS = 5_000L
@@ -423,7 +421,6 @@ object MetaDetailsRepository {
         }
     }
 
-
     private fun com.nuvio.app.features.addons.AddonsUiState.hasPendingEnabledAddonManifests(): Boolean =
         addons.enabledAddons().any { addon -> addon.manifest == null && addon.isRefreshing }
 
@@ -463,15 +460,21 @@ object MetaDetailsRepository {
         cachedMetaByRequestKey[requestKey] = cachedEntry
 
         if (!shouldEnrichForMetaScreen(meta, fallbackItemId, mdbListSettings)) {
-            _uiState.value = MetaDetailsUiState(meta = meta.withUnreleasedFilter())
-            activeRequestKey = requestKey
+            if (activeRequestKey == requestKey) {
+                _uiState.value = MetaDetailsUiState(meta = meta.withUnreleasedFilter())
+            }
             return
         }
 
-        _uiState.value = MetaDetailsUiState(
-            isLoading = true,
-            meta = meta,
-        )
+        // Emit immediately with TMDB-enriched meta (hero/logo/poster/backdrop are already final
+        // from tryFetchMeta, so no layout shift occurs here — matching Desktop behaviour)
+        if (activeRequestKey == requestKey) {
+            _uiState.value = MetaDetailsUiState(
+                isLoading = true,
+                meta = meta.withUnreleasedFilter(),
+            )
+        }
+
         val enrichedMeta = withContext(Dispatchers.Default) {
             enrichForMetaScreen(
                 requestKey = requestKey,
@@ -486,8 +489,9 @@ object MetaDetailsRepository {
             metaScreenMeta = enrichedMeta,
             metaScreenSettingsFingerprint = metaScreenSettingsFingerprint,
         )
-        _uiState.value = MetaDetailsUiState(meta = enrichedMeta.withUnreleasedFilter())
-        activeRequestKey = requestKey
+        if (activeRequestKey == requestKey) {
+            _uiState.value = MetaDetailsUiState(meta = enrichedMeta.withUnreleasedFilter())
+        }
     }
 
     private suspend fun enrichForMetaScreen(
@@ -505,6 +509,7 @@ object MetaDetailsRepository {
                 settings = settings,
             )
         } ?: meta
+
         val enrichedMeta = applyMoreLikeThisSource(
             meta = mdbListEnrichedMeta,
             fallbackItemId = fallbackItemId,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/details/MetaDetailsRepository.kt
@@ -114,9 +114,9 @@ object MetaDetailsRepository {
 
         scope.launch {
             val metaLookupId = resolveMetaLookupId(itemId = id, itemType = type)
-            val manifests = findReadyMetaManifests(type = type, id = metaLookupId)
+            val candidates = findReadyMetaCandidates(type = type, id = metaLookupId)
 
-            if (manifests.isEmpty()) {
+            if (candidates.isEmpty()) {
                 val tmdbMeta = tryFetchTmdbFallbackMeta(type = type, id = id)
                 if (tmdbMeta != null) {
                     publishLoadedMeta(
@@ -138,16 +138,18 @@ object MetaDetailsRepository {
                 return@launch
             }
 
-            for (manifest in manifests) {
-                val result = withContext(Dispatchers.Default) {
-                    tryFetchMeta(manifest, type, metaLookupId, includeMdbList = false)
+            for (candidate in candidates) {
+                val result = withTimeoutOrNull(FETCH_TIMEOUT_MS) {
+                    withContext(Dispatchers.Default) {
+                        tryFetchMeta(candidate.manifest, candidate.candidateType, metaLookupId, includeMdbList = false)
+                    }
                 }
                 if (result != null) {
                     publishLoadedMeta(
                         requestKey = requestKey,
                         meta = result,
                         fallbackItemId = metaLookupId,
-                        fallbackItemType = type,
+                        fallbackItemType = candidate.candidateType,
                         mdbListSettings = mdbListSettings,
                         metaScreenSettingsFingerprint = metaScreenSettingsFingerprint,
                     )
@@ -198,11 +200,11 @@ object MetaDetailsRepository {
         cachedMetaByRequestKey[requestKey]?.let { return it.baseMeta }
 
         val metaLookupId = resolveMetaLookupId(itemId = id, itemType = type)
-        val manifests = findReadyMetaManifests(type = type, id = metaLookupId)
+        val candidates = findReadyMetaCandidates(type = type, id = metaLookupId)
 
-        for (manifest in manifests) {
+        for (candidate in candidates) {
             val result = withTimeoutOrNull(FETCH_TIMEOUT_MS) {
-                tryFetchMeta(manifest, type, metaLookupId, includeMdbList = false)
+                tryFetchMeta(candidate.manifest, candidate.candidateType, metaLookupId, includeMdbList = false)
             }
             if (result != null) {
                 if (cacheResult) {
@@ -220,9 +222,155 @@ object MetaDetailsRepository {
     }
 
     private const val FETCH_TIMEOUT_MS = 5_000L
-    private const val METADATA_PROVIDER_READY_TIMEOUT_MS = 10_000L
+    private const val METADATA_PROVIDER_READY_TIMEOUT_MS = 1_500L
     private const val TMDB_ENRICH_TIMEOUT_MS = 5_000L
     private const val MDBLIST_ENRICH_TIMEOUT_MS = 5_000L
+
+    internal data class MetaCandidate(
+        val manifest: AddonManifest,
+        val candidateType: String,
+    )
+
+    private suspend fun findReadyMetaCandidates(type: String, id: String): List<MetaCandidate> {
+        AddonRepository.initialize()
+
+        findMetaCandidates(AddonRepository.uiState.value, type, id).takeIf { it.isNotEmpty() }?.let { return it }
+
+        if (!AddonRepository.uiState.value.hasPendingEnabledAddonManifests()) {
+            return emptyList()
+        }
+
+        val readyState = withTimeoutOrNull(METADATA_PROVIDER_READY_TIMEOUT_MS) {
+            AddonRepository.uiState.first { state ->
+                findMetaCandidates(state, type, id).isNotEmpty() ||
+                    !state.hasPendingEnabledAddonManifests()
+            }
+        } ?: AddonRepository.uiState.value
+
+        return findMetaCandidates(readyState, type, id)
+    }
+
+    internal fun findMetaCandidates(
+        state: com.nuvio.app.features.addons.AddonsUiState,
+        type: String,
+        id: String,
+    ): List<MetaCandidate> {
+        val manifests = state.addons.enabledAddons().mapNotNull { it.manifest }
+        val requestedType = type.trim()
+        val inferredType = inferCanonicalType(requestedType, id)
+        val metaResourceManifests = manifests.filter { manifest ->
+            manifest.resources.any { it.name == "meta" }
+        }
+
+        // Priority order (matching NuvioTV MetaRepositoryImpl):
+        // 1) Addons that explicitly support requested type AND explicitly match the ID prefix
+        // 2) Addons that support inferred canonical type AND explicitly match the ID prefix
+        // 3) Top addon in installed order that exposes meta resource and explicitly matches ID prefix
+        // 4) Fallback: Addons that support requested type but have no idPrefixes (accept all IDs)
+        // 5) Fallback: Addons that support inferred canonical type with no idPrefixes
+        // 6) Fallback: Top addon in installed order that exposes meta resource with no idPrefixes
+        val prioritizedCandidates = linkedSetOf<MetaCandidate>()
+
+        manifests.forEach { manifest ->
+            if (manifest.supportsMetaType(requestedType) && manifest.hasExplicitMetaIdPrefix(id)) {
+                prioritizedCandidates.add(MetaCandidate(manifest, requestedType))
+            }
+        }
+
+        if (!inferredType.equals(requestedType, ignoreCase = true)) {
+            manifests.forEach { manifest ->
+                if (manifest.supportsMetaType(inferredType) && manifest.hasExplicitMetaIdPrefix(id)) {
+                    prioritizedCandidates.add(MetaCandidate(manifest, inferredType))
+                }
+            }
+        }
+
+        metaResourceManifests.firstOrNull { it.hasExplicitMetaIdPrefix(id) }?.let { topMetaManifest ->
+            topMetaManifest.supportedCandidateType(requestedType, inferredType)?.let { fallbackType ->
+                prioritizedCandidates.add(MetaCandidate(topMetaManifest, fallbackType))
+            }
+        }
+
+        if (prioritizedCandidates.isEmpty()) {
+            manifests.forEach { manifest ->
+                if (manifest.supportsMetaType(requestedType) && manifest.hasNoMetaIdPrefixes()) {
+                    prioritizedCandidates.add(MetaCandidate(manifest, requestedType))
+                }
+            }
+            if (!inferredType.equals(requestedType, ignoreCase = true)) {
+                manifests.forEach { manifest ->
+                    if (manifest.supportsMetaType(inferredType) && manifest.hasNoMetaIdPrefixes()) {
+                        prioritizedCandidates.add(MetaCandidate(manifest, inferredType))
+                    }
+                }
+            }
+            metaResourceManifests.firstOrNull { it.hasNoMetaIdPrefixes() }?.let { topMetaManifest ->
+                topMetaManifest.supportedCandidateType(requestedType, inferredType)?.let { fallbackType ->
+                    prioritizedCandidates.add(MetaCandidate(topMetaManifest, fallbackType))
+                }
+            }
+        }
+
+        return prioritizedCandidates.toList()
+    }
+
+    private fun AddonManifest.supportsMetaType(type: String): Boolean {
+        val target = type.trim()
+        if (target.isBlank()) return false
+        return resources.any { resource ->
+            resource.name == "meta" && resource.supportsType(target)
+        }
+    }
+
+    private fun com.nuvio.app.features.addons.AddonResource.supportsType(type: String): Boolean {
+        if (types.isEmpty()) return true
+        return types.any { it.equals(type, ignoreCase = true) }
+    }
+
+    private fun AddonManifest.hasExplicitMetaIdPrefix(id: String): Boolean {
+        val metaResource = resources.firstOrNull { it.name == "meta" }
+        if (metaResource?.idPrefixes != null && metaResource.idPrefixes.isNotEmpty()) {
+            return metaResource.idPrefixes.any { prefix -> id.startsWith(prefix, ignoreCase = true) }
+        }
+        if (idPrefixes.isNotEmpty()) {
+            return idPrefixes.any { prefix -> id.startsWith(prefix, ignoreCase = true) }
+        }
+        return false
+    }
+
+    private fun AddonManifest.hasNoMetaIdPrefixes(): Boolean {
+        val metaResource = resources.firstOrNull { it.name == "meta" }
+        val resourcePrefixes = metaResource?.idPrefixes
+        if (resourcePrefixes != null) {
+            return resourcePrefixes.isEmpty()
+        }
+        return idPrefixes.isEmpty()
+    }
+
+    private fun inferCanonicalType(type: String, id: String): String {
+        val normalizedType = type.trim()
+        if (normalizedType.equals("tv", ignoreCase = true)) return "series"
+        val known = setOf("movie", "series", "channel", "anime")
+        if (normalizedType.lowercase() in known) return normalizedType
+
+        val normalizedId = id.lowercase()
+        return when {
+            ":movie:" in normalizedId -> "movie"
+            ":series:" in normalizedId -> "series"
+            ":tv:" in normalizedId -> "series"
+            ":anime:" in normalizedId -> "anime"
+            else -> normalizedType
+        }
+    }
+
+    private fun AddonManifest.supportedCandidateType(requestedType: String, inferredType: String): String? = when {
+        supportsMetaType(requestedType) -> requestedType
+        supportsMetaType(inferredType) -> inferredType
+        else -> null
+    }
+
+    private fun findMetaManifests(state: com.nuvio.app.features.addons.AddonsUiState, type: String, id: String): List<AddonManifest> =
+        findMetaCandidates(state, type, id).map { it.manifest }.distinct()
 
     private suspend fun tryFetchMeta(
         manifest: AddonManifest,
@@ -275,36 +423,6 @@ object MetaDetailsRepository {
         }
     }
 
-    private suspend fun findReadyMetaManifests(type: String, id: String): List<AddonManifest> {
-        AddonRepository.initialize()
-
-        findMetaManifests(AddonRepository.uiState.value, type, id).takeIf { it.isNotEmpty() }?.let { return it }
-
-        if (!AddonRepository.uiState.value.hasPendingEnabledAddonManifests()) {
-            return emptyList()
-        }
-
-        val readyState = withTimeoutOrNull(METADATA_PROVIDER_READY_TIMEOUT_MS) {
-            AddonRepository.uiState.first { state ->
-                findMetaManifests(state, type, id).isNotEmpty() ||
-                    !state.hasPendingEnabledAddonManifests()
-            }
-        } ?: AddonRepository.uiState.value
-
-        return findMetaManifests(readyState, type, id)
-    }
-
-    private fun findMetaManifests(state: com.nuvio.app.features.addons.AddonsUiState, type: String, id: String): List<AddonManifest> =
-        state.addons
-            .enabledAddons()
-            .mapNotNull { it.manifest }
-            .filter { manifest ->
-                manifest.resources.any { resource ->
-                    resource.name == "meta" &&
-                        resource.types.contains(type) &&
-                        (resource.idPrefixes.isEmpty() || resource.idPrefixes.any { id.startsWith(it) })
-                }
-            }
 
     private fun com.nuvio.app.features.addons.AddonsUiState.hasPendingEnabledAddonManifests(): Boolean =
         addons.enabledAddons().any { addon -> addon.manifest == null && addon.isRefreshing }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/MetaDetailsCandidatesTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/details/MetaDetailsCandidatesTest.kt
@@ -1,0 +1,113 @@
+package com.nuvio.app.features.details
+
+import com.nuvio.app.features.addons.AddonManifest
+import com.nuvio.app.features.addons.AddonResource
+import com.nuvio.app.features.addons.AddonsUiState
+import com.nuvio.app.features.addons.ManagedAddon
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MetaDetailsCandidatesTest {
+
+    private fun createAddon(
+        id: String,
+        types: List<String>,
+        idPrefixes: List<String> = emptyList(),
+        resourceTypes: List<String> = types,
+        resourceIdPrefixes: List<String> = idPrefixes,
+    ): ManagedAddon {
+        val manifest = AddonManifest(
+            id = id,
+            name = id,
+            description = "Test addon $id",
+            version = "1.0.0",
+            resources = listOf(
+                AddonResource(
+                    name = "meta",
+                    types = resourceTypes,
+                    idPrefixes = resourceIdPrefixes,
+                )
+            ),
+            types = types,
+            idPrefixes = idPrefixes,
+            transportUrl = "https://$id.example/manifest.json",
+        )
+        return ManagedAddon(
+            manifestUrl = manifest.transportUrl,
+            manifest = manifest,
+            enabled = true,
+        )
+    }
+
+    @Test
+    fun `explicit id prefix match is prioritized before generic empty-prefix addon`() {
+        // Generic addon is installed first in list
+        val genericAddon = createAddon(
+            id = "generic-community-addon",
+            types = listOf("movie", "series"),
+            idPrefixes = emptyList(),
+        )
+        // Cinemeta is installed second in list, but explicitly specifies "tt" prefix
+        val cinemeta = createAddon(
+            id = "cinemeta",
+            types = listOf("movie", "series"),
+            idPrefixes = listOf("tt"),
+        )
+
+        val state = AddonsUiState(addons = listOf(genericAddon, cinemeta))
+        val candidates = MetaDetailsRepository.findMetaCandidates(
+            state = state,
+            type = "movie",
+            id = "tt3915174", // Puss in Boots: The Last Wish
+        )
+
+        assertTrue(candidates.isNotEmpty())
+        assertEquals("cinemeta", candidates.first().manifest.id)
+        assertEquals("movie", candidates.first().candidateType)
+    }
+
+    @Test
+    fun `tv request infers series and pairs with series candidate type`() {
+        val cinemeta = createAddon(
+            id = "cinemeta",
+            types = listOf("movie", "series"),
+            idPrefixes = listOf("tt"),
+        )
+
+        val state = AddonsUiState(addons = listOf(cinemeta))
+        val candidates = MetaDetailsRepository.findMetaCandidates(
+            state = state,
+            type = "tv",
+            id = "tt0944947",
+        )
+
+        assertEquals(1, candidates.size)
+        assertEquals("cinemeta", candidates.first().manifest.id)
+        assertEquals("series", candidates.first().candidateType)
+    }
+
+    @Test
+    fun `fallback to generic empty-prefix addon when no explicit prefix match exists`() {
+        val cinemeta = createAddon(
+            id = "cinemeta",
+            types = listOf("movie", "series"),
+            idPrefixes = listOf("tt"),
+        )
+        val genericAddon = createAddon(
+            id = "generic-addon",
+            types = listOf("movie", "series"),
+            idPrefixes = emptyList(),
+        )
+
+        val state = AddonsUiState(addons = listOf(cinemeta, genericAddon))
+        val candidates = MetaDetailsRepository.findMetaCandidates(
+            state = state,
+            type = "movie",
+            id = "kitsu:12345",
+        )
+
+        assertEquals(1, candidates.size)
+        assertEquals("generic-addon", candidates.first().manifest.id)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1870

Fix a 60-second metadata hang when opening details for titles like *Puss in Boots: The Last Wish* (`tt3915174`), and align Mobile metadata loading behaviour with Desktop/TV.

Previously, community addons without `idPrefixes` (e.g. `[]`) were placed ahead of Cinemeta (which declares `["tt"]`) in the candidate list. Because these addons had no timeout, a single unresponsive addon could freeze the details screen for 60+ seconds. Additionally, type canonicalization was missing, so TV shows with type `"tv"` never matched Cinemeta's `"series"` resource, causing silent fallback to slow community addons.

## PR type

- [x] Reproducible bug fix

## Why

Opening any popular title (movie or series with a `tt` IMDB ID) on Mobile could freeze the details screen for 60 seconds or more. On Desktop/TV the same title opened in under 1 second because those platforms correctly prioritised Cinemeta first with a per-addon timeout.

## Issue or approval

Fixes https://github.com/NuvioMedia/NuvioMobile/issues/1870

## UI / behavior impact

- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- No UI changes.
- No new dependencies.
- Only `MetaDetailsRepository.kt` and a new unit test file `MetaDetailsCandidatesTest.kt` are modified.
- Does not change stream loading, playback, or any other feature.

## Testing

**Unit tests** (`MetaDetailsCandidatesTest.kt`):
- Cinemeta (`tt` prefix) is prioritised before generic community addons — PASS
- Canonical type inference maps `"tv"` → `"series"` for Cinemeta matching — PASS
- Empty-prefix fallback addons are correctly used when no explicit-prefix addon is available — PASS

Run: `./gradlew :composeApp:testAndroidHostTest --tests "com.nuvio.app.features.details.MetaDetailsCandidatesTest"` — BUILD SUCCESSFUL, 3/3 tests passed.

**Manual** (physical Android device via wireless ADB):
- Opened *Puss in Boots: The Last Wish* (`tt3915174`): loads in ~600–800 ms (was 60+ seconds).
- Opened multiple TV series and movies: all load correctly with logo, backdrop, and ratings.
- MdbList ratings and Trakt recommendations fill in after initial render, matching Desktop behaviour.
- No layout shift, no poster/backdrop reload on enrichment completion.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes https://github.com/NuvioMedia/NuvioMobile/issues/1870
