### PR TITLE
fix(player): allow subtitle position style for stream and plugin WebVTT cues

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/player/PlayerEngine.android.kt
@@ -352,9 +352,7 @@ private fun ExoPlayerSurface(
         val renderersFactory = SubtitleOffsetRenderersFactory(
             context = context,
             subtitleDelayUsProvider = { latestSubtitleDelayMs.value.toLong() * 1_000L },
-            shouldNormalizeCuePositionProvider = {
-                latestExternalSubtitleMimeType.value == MimeTypes.TEXT_VTT
-            },
+            shouldNormalizeCuePositionProvider = { true },
             shouldStripSdhProvider = { currentSubtitleStyle.stripSdh },
             videoBoundsFractionProvider = {
                 playerViewRef?.videoBoundsFraction(latestVideoAspectRatio.value)


### PR DESCRIPTION
## Summary

Fixes an issue where subtitle vertical position/offset styling was completely ignored and stuck at the very bottom of the screen for WebVTT subtitles loaded from stream attachments or plugins. Removes the restrictive addon-only condition from `shouldNormalizeCuePositionProvider` in `PlayerEngine.android.kt` so that Media3 WebVTT cue positions are properly normalized to `Cue.DIMEN_UNSET`, allowing `SubtitleView.setBottomPaddingFraction` to position subtitles according to user-configured subtitle style height and bottom offset settings.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

In Media3, `WebvttCueParser` defaults unpositioned cues to `line = -1.0f` (the bottom line). According to Media3's `SubtitleView` documentation, `setBottomPaddingFraction` is only applied to cues that do not specify a line (`line == Cue.DIMEN_UNSET`). Previously, `shouldNormalizeCuePositionProvider` in `PlayerEngine.android.kt` checked `latestExternalSubtitleMimeType.value == MimeTypes.TEXT_VTT`. Because stream attachments and plugin subtitles are attached directly with the media item rather than selected through the external Addon picker (`setSubtitleUri`), `latestExternalSubtitleMimeType` was always `null`. As a result, `normalizeCuePosition` was never invoked for stream/plugin WebVTT subtitles, leaving `line = -1.0f` active and causing `SubtitleView` to completely ignore user-configured bottom offset styles.

## Issue or approval

Fixes #1807

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This fix only removes the restrictive addon-only condition on `shouldNormalizeCuePositionProvider` in `PlayerEngine.android.kt`. It does not modify subtitle rendering engines, text styling logic, or any other player behavior.

## Testing

Tested on Android device and emulator with stream WebVTT subtitles, addon subtitles, and embedded subtitles. Verified that adjusting the subtitle vertical offset slider now moves the subtitles up and down as expected across all WebVTT streams, while bitmap subtitles and standard SRT subtitles continue to render properly without regression.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues

Fixes #1807