### PR TITLE
feat(addons): send canonical UA and X-Nuvio-Network on addon requests

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
@@ -2,6 +2,9 @@ package com.nuvio.app.features.addons
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.net.ConnectivityManager
+import android.net.NetworkCapabilities
+import com.nuvio.app.core.build.AppVersionConfig
 import com.nuvio.app.core.diagnostics.SentryNetworkBreadcrumbInterceptor
 import com.nuvio.app.core.network.IPv4FirstDns
 import kotlinx.coroutines.Dispatchers
@@ -82,9 +85,11 @@ private fun parseEnabledStateLine(line: String): Pair<String, Boolean>? {
 
 internal object AddonHttpClientProvider {
     private const val cacheSizeBytes = 50L * 1024L * 1024L
+    private var appContext: Context? = null
     private var client = buildAddonHttpClient()
 
     fun initialize(context: Context) {
+        appContext = context.applicationContext
         if (client.cache != null) return
         client = buildAddonHttpClient(
             cache = Cache(
@@ -95,6 +100,28 @@ internal object AddonHttpClientProvider {
     }
 
     fun get(): OkHttpClient = client
+}
+
+/** Canonical User-Agent sent on addon requests that do not already carry one. */
+private val ADDON_USER_AGENT = "NuvioMobile/${AppVersionConfig.VERSION_NAME.ifBlank { "dev" }} (Android)"
+
+/**
+ * Returns the transport the device is currently using, or null when it cannot
+ * be determined. Only the main network is considered.
+ */
+private fun currentTransport(): String? {
+    val context = AddonHttpClientProvider.appContext ?: return null
+    val manager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
+        ?: return null
+    val network = manager.activeNetwork ?: return null
+    val capabilities = manager.getNetworkCapabilities(network) ?: return null
+    return when {
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR) -> "cellular"
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI) -> "wifi"
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> "ethernet"
+        capabilities.hasTransport(NetworkCapabilities.TRANSPORT_VPN) -> "vpn"
+        else -> null
+    }
 }
 
 private fun buildAddonHttpClient(cache: Cache? = null): OkHttpClient =
@@ -113,6 +140,23 @@ private fun buildAddonHttpClient(cache: Cache? = null): OkHttpClient =
             }
         }
         .build()
+
+/**
+ * Applies identity headers to an addon request builder: a canonical
+ * User-Agent unless the caller already set one (e.g. plugin runtimes
+ * masquerading as a browser), and the current transport so addon hosts such
+ * as AIOStreams can serve device/network-appropriate results via conditional
+ * variants.
+ */
+private fun Request.Builder.addAddonIdentityHeaders(): Request.Builder {
+    if (header("User-Agent") == null) {
+        header("User-Agent", ADDON_USER_AGENT)
+    }
+    if (header("X-Nuvio-Network") == null) {
+        header("X-Nuvio-Network", currentTransport() ?: "unknown")
+    }
+    return this
+}
 
 private val jsonMediaType = "application/json; charset=utf-8".toMediaType()
 
@@ -190,7 +234,7 @@ private suspend fun executeTextRequest(
 ): String = withContext(Dispatchers.IO) {
     val normalizedMethod = method.uppercase()
     val sanitizedHeaders = headers.withoutAcceptEncoding()
-    val builder = Request.Builder().url(url)
+    val builder = Request.Builder().url(url).addAddonIdentityHeaders()
     sanitizedHeaders.forEach { (key, value) ->
         builder.header(key, value)
     }

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt
@@ -1,8 +1,12 @@
+@file:OptIn(kotlinx.cinterop.ExperimentalForeignApi::class)
+
 package com.nuvio.app.features.addons
 
+import com.nuvio.app.core.build.AppVersionConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.darwin.Darwin
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.HttpRequestBuilder
 import io.ktor.client.request.accept
 import io.ktor.client.request.get
 import io.ktor.client.request.header
@@ -15,12 +19,24 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.isSuccess
+import kotlin.concurrent.Volatile
 import kotlinx.coroutines.runBlocking
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.network_empty_response_body
 import nuvio.composeapp.generated.resources.network_request_failed_http
 import org.jetbrains.compose.resources.getString
 import platform.Foundation.NSUserDefaults
+import platform.Network.nw_interface_type_cellular
+import platform.Network.nw_interface_type_wifi
+import platform.Network.nw_path_get_status
+import platform.Network.nw_path_monitor_create
+import platform.Network.nw_path_monitor_set_queue
+import platform.Network.nw_path_monitor_set_update_handler
+import platform.Network.nw_path_monitor_start
+import platform.Network.nw_path_status_satisfied
+import platform.Network.nw_path_uses_interface_type
+import platform.darwin.DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL
+import platform.darwin.dispatch_queue_create
 
 actual object AddonStorage {
     private const val addonUrlsKey = "installed_manifest_urls"
@@ -71,6 +87,61 @@ private fun parseEnabledStateLine(line: String): Pair<String, Boolean>? {
     return url to enabled
 }
 
+/**
+ * Keeps the last known transport (`cellular`, `wifi`, `other` or `none`)
+ * updated by an NWPathMonitor. The object is initialized lazily on first
+ * request (Kotlin/Native object init is thread-safe, so the monitor is
+ * created exactly once per process). Reading [current] never blocks; before
+ * the first callback fires it reports `unknown`.
+ */
+private object NetworkTransportMonitor {
+    @Volatile
+    var current: String = "unknown"
+        private set
+
+    private val monitor = nw_path_monitor_create()
+    private val queue = dispatch_queue_create(
+        label = "com.nuvio.addons.network-monitor",
+        attr = DISPATCH_QUEUE_SERIAL_WITH_AUTORELEASE_POOL,
+    )
+
+    init {
+        nw_path_monitor_set_queue(monitor, queue)
+        nw_path_monitor_set_update_handler(monitor) { path ->
+            val transport = when {
+                nw_path_get_status(path) != nw_path_status_satisfied -> "none"
+                nw_path_uses_interface_type(path, nw_interface_type_cellular) -> "cellular"
+                nw_path_uses_interface_type(path, nw_interface_type_wifi) -> "wifi"
+                else -> "other"
+            }
+            current = transport
+        }
+        nw_path_monitor_start(monitor)
+        // The monitor is intentionally never cancelled: it lives for the whole
+        // process and is cheap. The field keeps the native handle alive.
+    }
+}
+
+/** Canonical User-Agent sent on addon requests that do not already carry one. */
+private val ADDON_USER_AGENT: String
+    get() = "NuvioMobile/${AppVersionConfig.VERSION_NAME.ifBlank { "dev" }} (iOS)"
+
+/**
+ * Headers applied to Stremio-style addon requests (not to plugin/raw traffic):
+ * a canonical User-Agent unless the caller already set one, and the current
+ * transport so addon hosts such as AIOStreams can serve device/network-
+ * appropriate results via conditional variants.
+ */
+private fun addAddonIdentityHeaders(builder: HttpRequestBuilder): HttpRequestBuilder {
+    if (builder.headers[HttpHeaders.UserAgent] == null) {
+        builder.header(HttpHeaders.UserAgent, ADDON_USER_AGENT)
+    }
+    if (builder.headers["X-Nuvio-Network"] == null) {
+        builder.header("X-Nuvio-Network", NetworkTransportMonitor.current)
+    }
+    return builder
+}
+
 private val addonHttpClient = HttpClient(Darwin) {
     install(HttpTimeout) {
         requestTimeoutMillis = 60_000
@@ -83,6 +154,7 @@ private val addonHttpClient = HttpClient(Darwin) {
 actual suspend fun httpGetText(url: String): String =
     addonHttpClient
         .get(url) {
+            addAddonIdentityHeaders(this)
             accept(ContentType.Application.Json)
         }
         .let { response ->
@@ -99,6 +171,7 @@ actual suspend fun httpGetText(url: String): String =
 actual suspend fun httpPostJson(url: String, body: String): String =
     addonHttpClient
         .post(url) {
+            addAddonIdentityHeaders(this)
             accept(ContentType.Application.Json)
             header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
             setBody(body)
@@ -124,6 +197,9 @@ actual suspend fun httpGetTextWithHeaders(
             headers.forEach { (key, value) ->
                 header(key, value)
             }
+            // Apply identity headers last so a caller-supplied User-Agent is
+            // never duplicated (Ktor's header() appends rather than replaces).
+            addAddonIdentityHeaders(this)
         }
         .let { response ->
             val payload = response.bodyAsText()
@@ -148,6 +224,9 @@ actual suspend fun httpPostJsonWithHeaders(
             headers.forEach { (key, value) ->
                 header(key, value)
             }
+            // Apply identity headers last so a caller-supplied User-Agent is
+            // never duplicated (Ktor's header() appends rather than replaces).
+            addAddonIdentityHeaders(this)
             setBody(body)
         }
         .let { response ->


### PR DESCRIPTION
## Summary

Send identity headers on Stremio-style addon requests so addon hosts (e.g. AIOStreams) can serve device- and network-appropriate results via conditional variants:

- **Android**: `User-Agent: NuvioMobile/<version> (Android)` plus `X-Nuvio-Network`, resolved from `ConnectivityManager` on every request.
- **iOS**: same `User-Agent` plus `X-Nuvio-Network`, backed by an `NWPathMonitor` singleton reporting `cellular` / `wifi` / `other` / `none`.

## Why

Some addon hosts differentiate responses by client and transport (mobile vs desktop, cellular vs Wi-Fi). Without these headers the app is indistinguishable from any other Stremio-compatible client, so hosts cannot tailor streams or UI for NuvioMobile.

## UI / behavior impact

- No user-visible UI changes.
- Addon requests now carry a canonical UA and the network transport header.
- Requests with caller-supplied headers (`httpGetTextWithHeaders`, `httpPostJsonWithHeaders`) keep their own `User-Agent` when present — the identity header is only applied when none was set, so plugin runtimes that masquerade as a browser are unaffected.

## Scope boundaries

- Raw/plugin traffic (`httpRequestRaw`) intentionally does **not** receive identity headers — it preserves current behavior for IPTV/DASH/plugin runtimes.
- No changes to addon install/enable state handling, manifest fetching, or cache policy.
- No new permissions required: `ACCESS_NETWORK_STATE` is already declared.

## Files changed

- `composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt`
- `composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt`

## Testing

- Android: transport resolution reads `ConnectivityManager` with null-safety fallback to `unknown`; caller-supplied UA wins (OkHttp `header()` replaces).
- iOS: `NWPathMonitor` verified against production KMP usage patterns (kaluga, KmpEssentials); handler runs on a dedicated serial dispatch queue; value is `@Volatile` for cross-thread visibility.
- Full KMP compile/device validation pending CI/host build (no JDK/Gradle toolchain in this environment).

## Breaking changes

None.
