### PR TITLE
Fix NetworkOnMainThreadException when starting a download

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/downloads/AndroidDownloadScheduler.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/downloads/AndroidDownloadScheduler.kt
@@ -24,12 +24,14 @@ import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import okhttp3.ConnectionPool
 
 internal class AndroidDownloadScheduler(val context: Context) {
@@ -190,7 +192,7 @@ internal class AndroidDownloadScheduler(val context: Context) {
             else fail(transfer, error)
             retry
         } finally {
-            if (network != null) client.connectionPool.evictAll()
+            if (network != null) withContext(NonCancellable + Dispatchers.IO) { client.connectionPool.evictAll() }
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes a crash on starting a download. `DownloadsTransferJobService` closes the per network `OkHttpClient` connection pool synchronously on `Dispatchers.Main.immediate`, which closes pooled SSL sockets on the main thread and throws `NetworkOnMainThreadException`.

## PR type

- [x] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Starting a download crashes the app with `NetworkOnMainThreadException` whenever the transfer restarts on a network change (a common case: Wi-Fi state changing while a download is running). This is a hard crash, the process is killed after repeated occurrences.

## Issue or approval

Fixes #1892

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the socket eviction call is moved off the main thread. Nothing else in `execute()` or the download flow is touched.

## Testing

- `./gradlew :composeApp:compileAndroidMain` succeeds.
- `./gradlew :composeApp:testAndroidHostTest --tests "com.nuvio.app.features.downloads.*"` passes for the tests that exercise `AndroidDownloadScheduler.execute()` (`scheduledDownloadsArePersistedUserInitiatedTransfers`, `pausedTransferIsNotRestartedBySystemRedelivery`, `completedRenameIsRecoveredAfterProcessDeathBeforeStateCommit`, `backgroundExecutionDoesNotNeedRepositoryOrActivityCallbacks`). One unrelated pre existing test in that class fails locally due to a Robolectric native runtime path issue in my environment, unrelated to this change.
- Reproduced the original crash on device (physical phone, app 0.4.14) with `adb logcat`, confirmed the fix removes the main thread socket close from the `onNetworkChanged` restart path by code inspection.

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

Fixes #1892
