### PR TITLE
fix(addons): persist addon manifests with stale-while-revalidate

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonManifestClock.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonManifestClock.android.kt
@@ -1,0 +1,5 @@
+package com.nuvio.app.features.addons
+
+actual object AddonManifestClock {
+    actual fun nowEpochMs(): Long = System.currentTimeMillis()
+}

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
@@ -28,6 +28,7 @@ actual object AddonStorage {
     private const val preferencesName = "nuvio_addons"
     private const val addonUrlsKey = "installed_manifest_urls"
     private const val addonEnabledStatesKey = "installed_manifest_enabled_states"
+    private const val manifestCacheKey = "addon_manifest_cache"
 
     private var preferences: SharedPreferences? = null
 
@@ -66,6 +67,16 @@ actual object AddonStorage {
         preferences
             ?.edit()
             ?.putString("${addonEnabledStatesKey}_$profileId", payload)
+            ?.apply()
+    }
+
+    actual fun loadManifestCache(profileId: Int): String? =
+        preferences?.getString("${manifestCacheKey}_$profileId", null)
+
+    actual fun saveManifestCache(profileId: Int, json: String) {
+        preferences
+            ?.edit()
+            ?.putString("${manifestCacheKey}_$profileId", json)
             ?.apply()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonManifestCache.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonManifestCache.kt
@@ -1,0 +1,43 @@
+package com.nuvio.app.features.addons
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * Disk TTL for persisted addon manifests before a background revalidation is due.
+ * Mirrors NuvioTV's `AddonRepositoryImpl` `MANIFEST_CACHE_TTL_MS` (6 hours) so a cold
+ * start never depends on the addon server being reachable.
+ */
+internal const val MANIFEST_CACHE_TTL_MS = 6L * 60 * 60 * 1000
+
+@Serializable
+internal data class CachedManifestEntry(
+    val payload: String,
+    val fetchedAtMillis: Long,
+)
+
+@Serializable
+internal data class ManifestCacheBlob(
+    val entries: Map<String, CachedManifestEntry> = emptyMap(),
+)
+
+/** Serializes the raw manifest.json payloads cached per addon URL. */
+internal object AddonManifestCacheCodec {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun encode(entries: Map<String, CachedManifestEntry>): String =
+        json.encodeToString(ManifestCacheBlob.serializer(), ManifestCacheBlob(entries))
+
+    fun decode(blob: String?): Map<String, CachedManifestEntry> {
+        if (blob.isNullOrBlank()) return emptyMap()
+        return runCatching { json.decodeFromString(ManifestCacheBlob.serializer(), blob).entries }
+            .getOrDefault(emptyMap())
+    }
+}
+
+internal expect object AddonManifestClock {
+    fun nowEpochMs(): Long
+}
+
+internal fun CachedManifestEntry.isStale(nowMillis: Long): Boolean =
+    nowMillis - fetchedAtMillis >= MANIFEST_CACHE_TTL_MS

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.kt
@@ -5,6 +5,10 @@ internal expect object AddonStorage {
     fun saveInstalledAddonUrls(profileId: Int, urls: List<String>)
     fun loadAddonEnabledStates(profileId: Int): Map<String, Boolean>
     fun saveAddonEnabledStates(profileId: Int, states: Map<String, Boolean>)
+
+    /** Raw manifest payloads persisted per profile as a JSON blob, keyed by manifest URL. */
+    fun loadManifestCache(profileId: Int): String?
+    fun saveManifestCache(profileId: Int, json: String)
 }
 
 data class RawHttpResponse(

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/addons/AddonRepository.kt
@@ -58,6 +58,7 @@ object AddonRepository {
     private var initialized = false
     private var pulledFromServer = false
     private var currentProfileId: Int = 1
+    private var manifestCache: Map<String, CachedManifestEntry> = emptyMap()
     private val activeRefreshJobs = mutableMapOf<String, Job>()
     private val pushJobsByProfile = mutableMapOf<Int, Job>()
 
@@ -70,7 +71,8 @@ object AddonRepository {
 
         val storedUrls = dedupeManifestUrls(AddonStorage.loadInstalledAddonUrls(currentProfileId))
         val enabledByUrl = loadLocalEnabledStates()
-        log.d { "initialize() — local addon count: ${storedUrls.size}" }
+        manifestCache = AddonManifestCacheCodec.decode(AddonStorage.loadManifestCache(currentProfileId))
+        log.d { "initialize() — local addon count: ${storedUrls.size}, cached manifests: ${manifestCache.size}" }
         if (storedUrls.isEmpty()) return
 
         val existingByUrl = _uiState.value.addons.associateBy(ManagedAddon::manifestUrl)
@@ -83,13 +85,7 @@ object AddonRepository {
             },
         )
 
-        storedUrls.forEach { manifestUrl ->
-            val existing = existingByUrl[manifestUrl]
-            val addon = _uiState.value.addons.firstOrNull { it.manifestUrl == manifestUrl }
-            if (addon?.enabled == true && (existing == null || (addon.manifest == null && !addon.isRefreshing))) {
-                refreshAddon(manifestUrl)
-            }
-        }
+        refreshMissingOrStaleManifests()
     }
 
     fun onProfileChanged(profileId: Int) {
@@ -99,6 +95,7 @@ object AddonRepository {
         currentProfileId = effectiveProfileId
         initialized = false
         pulledFromServer = false
+        manifestCache = emptyMap()
         _uiState.value = AddonsUiState()
     }
 
@@ -109,12 +106,16 @@ object AddonRepository {
         currentProfileId = 1
         initialized = false
         pulledFromServer = false
+        manifestCache = emptyMap()
         _uiState.value = AddonsUiState()
     }
 
     suspend fun pullFromServer(profileId: Int) {
         currentProfileId = resolveEffectiveProfileId(profileId)
         log.i { "pullFromServer() — profileId=$profileId, initialized=$initialized, pulledFromServer=$pulledFromServer" }
+        if (!initialized && manifestCache.isEmpty()) {
+            manifestCache = AddonManifestCacheCodec.decode(AddonStorage.loadManifestCache(currentProfileId))
+        }
         runCatching {
             val rows = SupabaseProvider.client.postgrest
                 .from("addons")
@@ -182,13 +183,7 @@ object AddonRepository {
                         },
                     )
                     persist()
-                    localUrls.forEach { url ->
-                        val existing = existingByUrl[url]
-                        val addon = _uiState.value.addons.firstOrNull { it.manifestUrl == url }
-                        if (addon?.enabled == true && (existing == null || (addon.manifest == null && !addon.isRefreshing))) {
-                            refreshAddon(url)
-                        }
-                    }
+                    refreshMissingOrStaleManifests()
                     pulledFromServer = true
                     initialized = true
                     return
@@ -207,13 +202,7 @@ object AddonRepository {
                 },
             )
             persist()
-            urls.forEach { url ->
-                val existing = existingByUrl[url]
-                val addon = _uiState.value.addons.firstOrNull { it.manifestUrl == url }
-                if (addon?.enabled == true && (existing == null || (addon.manifest == null && !addon.isRefreshing))) {
-                    refreshAddon(url)
-                }
-            }
+            refreshMissingOrStaleManifests()
             pulledFromServer = true
             initialized = true
             log.i { "pullFromServer() — applied ${urls.size} addons to state" }
@@ -246,9 +235,11 @@ object AddonRepository {
             return AddAddonResult.Error(getString(Res.string.addon_already_installed))
         }
 
+        var fetchedPayload: String? = null
         val manifest = try {
             withContext(Dispatchers.Default) {
                 val payload = fetchAddonResponseText(manifestUrl)
+                fetchedPayload = payload
                 AddonManifestParser.parse(
                     manifestUrl = manifestUrl,
                     payload = payload,
@@ -269,6 +260,7 @@ object AddonRepository {
             )
         }
         persist()
+        fetchedPayload?.let { upsertManifestCache(manifestUrl, it) }
         pushToServer()
         return AddAddonResult.Success(manifest)
     }
@@ -284,6 +276,7 @@ object AddonRepository {
         }
         if (!changed) return
         persist()
+        removeManifestCacheEntry(manifestUrl)
         pushToServer()
     }
 
@@ -313,7 +306,6 @@ object AddonRepository {
 
     fun setAddonEnabled(manifestUrl: String, enabled: Boolean) {
         if (isUsingPrimaryAddonsFromSecondaryProfile()) return
-        var shouldRefresh = false
         var changed = false
         _uiState.update { current ->
             current.copy(
@@ -322,7 +314,6 @@ object AddonRepository {
                         addon
                     } else {
                         changed = true
-                        shouldRefresh = enabled && addon.manifest == null && !addon.isRefreshing
                         addon.copy(enabled = enabled)
                     }
                 },
@@ -331,7 +322,8 @@ object AddonRepository {
         if (!changed) return
         persist()
         pushToServer()
-        if (shouldRefresh) {
+        val updated = _uiState.value.addons.firstOrNull { it.manifestUrl == manifestUrl } ?: return
+        if (shouldRefreshManifest(updated)) {
             refreshAddon(manifestUrl)
         }
     }
@@ -361,7 +353,7 @@ object AddonRepository {
                         url = manifestUrl,
                         forceRefresh = forceRefresh,
                     )
-                    AddonManifestParser.parse(
+                    payload to AddonManifestParser.parse(
                         manifestUrl = manifestUrl,
                         payload = payload,
                     )
@@ -374,7 +366,8 @@ object AddonRepository {
                                 addon
                             } else {
                                 result.fold(
-                                    onSuccess = { manifest ->
+                                    onSuccess = { (payload, manifest) ->
+                                        upsertManifestCache(manifestUrl, payload)
                                         addon.copy(
                                             manifest = manifest,
                                             isRefreshing = false,
@@ -382,9 +375,14 @@ object AddonRepository {
                                         )
                                     },
                                     onFailure = { error ->
+                                        val message = error.message ?: getString(Res.string.addon_load_manifest_failed)
                                         addon.copy(
                                             isRefreshing = false,
-                                            errorMessage = error.message ?: getString(Res.string.addon_load_manifest_failed),
+                                            // With a usable manifest available (from cache) the addon
+                                            // stays installed and functional; only an explicit manual
+                                            // refresh surfaces the stale error. Background revalidation
+                                            // failures stay silent, matching NuvioTV's behavior.
+                                            errorMessage = if (addon.manifest != null && !forceRefresh) null else message,
                                         )
                                     },
                                 )
@@ -476,6 +474,64 @@ object AddonRepository {
     private fun cancelActiveRefreshes() {
         activeRefreshJobs.values.forEach(Job::cancel)
         activeRefreshJobs.clear()
+    }
+
+    /**
+     * Hydrates enabled addons from the persisted manifest cache and refreshes only what the
+     * network is required for: cache misses (no manifest ever fetched) and entries past the
+     * disk TTL (stale-while-revalidate, in background). Fresh cached entries skip the network.
+     */
+    private fun refreshMissingOrStaleManifests() {
+        _uiState.update { state ->
+            state.copy(addons = state.addons.map(::hydrateFromCache))
+        }
+        _uiState.value.addons
+            .filter { shouldRefreshManifest(it) }
+            .distinctBy { it.manifestUrl }
+            .forEach { refreshAddon(it.manifestUrl) }
+    }
+
+    private fun hydrateFromCache(addon: ManagedAddon): ManagedAddon {
+        if (addon.manifest != null) return addon
+        val cached = manifestCache[addon.manifestUrl] ?: return addon
+        val parsed = runCatching {
+            AddonManifestParser.parse(addon.manifestUrl, cached.payload)
+        }.getOrNull() ?: return addon
+        return addon.copy(
+            manifest = parsed,
+            isRefreshing = false,
+            errorMessage = null,
+        )
+    }
+
+    private fun shouldRefreshManifest(addon: ManagedAddon): Boolean {
+        if (!addon.enabled) return false
+        // A pending addon (no manifest yet, e.g. cold start with no cache) must always
+        // be fetched. refreshAddon() de-dupes against an in-flight job.
+        if (addon.manifest == null) return true
+        if (addon.isRefreshing) return false
+        return manifestCache[addon.manifestUrl]?.isStale(AddonManifestClock.nowEpochMs()) == true
+    }
+
+    private fun upsertManifestCache(manifestUrl: String, payload: String) {
+        manifestCache = manifestCache + (
+            manifestUrl to CachedManifestEntry(
+                payload = payload,
+                fetchedAtMillis = AddonManifestClock.nowEpochMs(),
+            )
+        )
+        persistManifestCache()
+    }
+
+    private fun removeManifestCacheEntry(manifestUrl: String) {
+        if (manifestCache.containsKey(manifestUrl)) {
+            manifestCache = manifestCache - manifestUrl
+            persistManifestCache()
+        }
+    }
+
+    private fun persistManifestCache() {
+        AddonStorage.saveManifestCache(currentProfileId, AddonManifestCacheCodec.encode(manifestCache))
     }
 
     private fun resolveEffectiveProfileId(profileId: Int): Int {

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/addons/AddonManifestCacheTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/addons/AddonManifestCacheTest.kt
@@ -1,0 +1,55 @@
+package com.nuvio.app.features.addons
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AddonManifestCacheTest {
+
+    @Test
+    fun `codec round-trips entries unchanged`() {
+        val entries = mapOf(
+            "https://addon-a.example/manifest.json" to CachedManifestEntry(
+                payload = """{"id":"a","name":"A"}""",
+                fetchedAtMillis = 1_700_000_000_000L,
+            ),
+            "https://addon-b.example/manifest.json?token=x" to CachedManifestEntry(
+                payload = """{"id":"b","name":"B","resources":[]}""",
+                fetchedAtMillis = 1_700_000_100_000L,
+            ),
+        )
+
+        val decoded = AddonManifestCacheCodec.decode(AddonManifestCacheCodec.encode(entries))
+
+        assertEquals(entries, decoded)
+    }
+
+    @Test
+    fun `decode tolerates null, blank and malformed blobs`() {
+        assertTrue(AddonManifestCacheCodec.decode(null).isEmpty())
+        assertTrue(AddonManifestCacheCodec.decode("").isEmpty())
+        assertTrue(AddonManifestCacheCodec.decode("   ").isEmpty())
+        assertTrue(AddonManifestCacheCodec.decode("{not-json").isEmpty())
+        assertTrue(AddonManifestCacheCodec.decode("""{"unexpected":true}""").isEmpty())
+    }
+
+    @Test
+    fun `entry is fresh inside ttl and stale at the boundary`() {
+        val now = 1_700_000_000_000L
+        val entry = CachedManifestEntry(payload = "{}", fetchedAtMillis = now - MANIFEST_CACHE_TTL_MS + 1)
+
+        assertFalse(entry.isStale(now))
+
+        val atBoundary = CachedManifestEntry(payload = "{}", fetchedAtMillis = now - MANIFEST_CACHE_TTL_MS)
+        assertTrue(atBoundary.isStale(now))
+    }
+
+    @Test
+    fun `entry older than ttl is stale`() {
+        val now = 1_700_000_000_000L
+        val entry = CachedManifestEntry(payload = "{}", fetchedAtMillis = now - MANIFEST_CACHE_TTL_MS - 1)
+
+        assertTrue(entry.isStale(now))
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonManifestClock.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonManifestClock.ios.kt
@@ -1,0 +1,9 @@
+package com.nuvio.app.features.addons
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.posix.time
+
+actual object AddonManifestClock {
+    @OptIn(ExperimentalForeignApi::class)
+    actual fun nowEpochMs(): Long = time(null) * 1000L
+}

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.ios.kt
@@ -25,6 +25,7 @@ import platform.Foundation.NSUserDefaults
 actual object AddonStorage {
     private const val addonUrlsKey = "installed_manifest_urls"
     private const val addonEnabledStatesKey = "installed_manifest_enabled_states"
+    private const val manifestCacheKey = "addon_manifest_cache"
 
     actual fun loadInstalledAddonUrls(profileId: Int): List<String> =
         NSUserDefaults.standardUserDefaults
@@ -57,6 +58,16 @@ actual object AddonStorage {
         NSUserDefaults.standardUserDefaults.setObject(
             payload,
             forKey = "${addonEnabledStatesKey}_$profileId",
+        )
+    }
+
+    actual fun loadManifestCache(profileId: Int): String? =
+        NSUserDefaults.standardUserDefaults.stringForKey("${manifestCacheKey}_$profileId")
+
+    actual fun saveManifestCache(profileId: Int, json: String) {
+        NSUserDefaults.standardUserDefaults.setObject(
+            json,
+            forKey = "${manifestCacheKey}_$profileId",
         )
     }
 }


### PR DESCRIPTION
## Summary

Installed addon manifests are not persisted. Every cold start re-fetches each
enabled addon's `manifest.json` from the network, so when an addon origin is
slow or unstable and returns 5xx, the addon row shows "Request failed with
HTTP 500" on the Addons screen and the addon is excluded from catalog/meta
lookups until a later successful fetch.

This PR ports the manifest caching behavior NuvioTV already has
(`AddonRepositoryImpl`, 6h disk TTL + stale-while-revalidate):

- Persist the raw manifest payloads per profile
  (`SharedPreferences` on Android, `NSUserDefaults` on iOS).
- Hydrate installed addons from the cache on cold start so the Addons screen
  and meta/details lookups never depend on the addon server being reachable.
- Revalidate stale entries (> 6h TTL) in the background. On revalidation
  failure the cached manifest is kept and the failure stays silent; an
  explicit manual refresh (per-addon refresh action / refresh all) still
  surfaces the error.
- Remove the cache entry when the addon is removed.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

User-visible: with an unstable addon server (e.g. a community metadata addon
with intermittent high latency / 5xx), a cold app start shows "Request failed
with HTTP 500" for installed addons and the addon becomes unusable until the
server recovers. NuvioTV does not exhibit this because its manifest cache is
persisted; this change aligns NuvioMobile with that behavior.

## Issue or approval

No linked upstream issue - reported behavior on a community addon with an
unstable origin; opened as a draft PR for review.

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Manifest persistence/cache behavior only. No changes to the HTTP client,
  timeout configuration, catalog or stream fetch paths, or the Addons UI
  rendering (the existing stale-error branch already handles the case where a
  cached manifest coexists with a failed manual refresh).

## Testing

- Added `AddonManifestCacheTest` (commonTest): codec round-trip, malformed/
  missing blob tolerance, and TTL boundary semantics.
- Full Gradle build and on-device verification still pending (draft PR).

## Screenshots / Video (UI changes only)

Not a UI change.

## Breaking changes

None.

## Linked issues

No linked issue - behavior fix opened as draft PR (see Issue or approval).
