### PR TITLE
feat(ui): add system font option and fix RTL poster preview alignment

### DIFF
--- a/composeApp/src/androidHostTest/kotlin/com/nuvio/app/features/settings/ThemeSettingsRepositoryTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nuvio/app/features/settings/ThemeSettingsRepositoryTest.kt
@@ -73,4 +73,26 @@ class ThemeSettingsRepositoryTest {
         assertEquals(saved, ThemeSettingsRepository.customThemePreference.value)
         assertEquals(saved.encode(), ThemeSettingsStorage.exportToSyncPayload().decodeSyncString("custom_theme_colors"))
     }
+
+    @Test
+    fun useSystemFontDefaultsToFalseAndPersistsWhenChanged() {
+        assertEquals(false, ThemeSettingsRepository.useSystemFont.value)
+
+        ThemeSettingsRepository.setUseSystemFont(true)
+        assertEquals(true, ThemeSettingsRepository.useSystemFont.value)
+        assertEquals(true, ThemeSettingsStorage.loadUseSystemFont())
+
+        ThemeSettingsRepository.setUseSystemFont(false)
+        assertEquals(false, ThemeSettingsRepository.useSystemFont.value)
+        assertEquals(false, ThemeSettingsStorage.loadUseSystemFont())
+    }
+
+    @Test
+    fun clearLocalStateResetsUseSystemFont() {
+        ThemeSettingsRepository.setUseSystemFont(true)
+        assertEquals(true, ThemeSettingsRepository.useSystemFont.value)
+
+        ThemeSettingsRepository.clearLocalState()
+        assertEquals(false, ThemeSettingsRepository.useSystemFont.value)
+    }
 }

--- a/composeApp/src/androidHostTest/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorageTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorageTest.kt
@@ -71,4 +71,18 @@ class ThemeSettingsStorageTest {
         assertEquals("WHITE", ThemeSettingsStorage.loadSelectedTheme())
         assertEquals("#111111,#222222,#333333", preferences.getString(otherProfileKey, null))
     }
+
+    @Test
+    fun useSystemFontIsDeviceLocalAndExcludedFromSync() {
+        assertNull(ThemeSettingsStorage.loadUseSystemFont())
+
+        ThemeSettingsStorage.saveUseSystemFont(true)
+        assertEquals(true, ThemeSettingsStorage.loadUseSystemFont())
+
+        val payload = ThemeSettingsStorage.exportToSyncPayload()
+        assertNull(payload["use_system_font"])
+
+        ThemeSettingsStorage.saveUseSystemFont(false)
+        assertEquals(false, ThemeSettingsStorage.loadUseSystemFont())
+    }
 }

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.android.kt
@@ -21,6 +21,7 @@ actual object ThemeSettingsStorage {
     private const val liquidGlassNativeTabBarEnabledKey = "liquid_glass_native_tab_bar_enabled"
     private const val selectedAppLanguageKey = "selected_app_language"
     private const val NAV_BAR_STYLE_KEY = "nav_bar_style"
+    private const val useSystemFontKey = "use_system_font"
     private val profileScopedSyncKeys = listOf(
         selectedThemeKey,
         customThemeColorsKey,
@@ -114,6 +115,18 @@ actual object ThemeSettingsStorage {
         preferences
             ?.edit()
             ?.putString(ProfileScopedKey.of(NAV_BAR_STYLE_KEY), styleKey)
+            ?.apply()
+    }
+
+    actual fun loadUseSystemFont(): Boolean? =
+        preferences?.let { prefs ->
+            if (prefs.contains(useSystemFontKey)) prefs.getBoolean(useSystemFontKey, false) else null
+        }
+
+    actual fun saveUseSystemFont(enabled: Boolean) {
+        preferences
+            ?.edit()
+            ?.putBoolean(useSystemFontKey, enabled)
             ?.apply()
     }
 

--- a/composeApp/src/commonMain/composeResources/values-ar/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ar/strings.xml
@@ -590,6 +590,8 @@
     <string name="settings_account_status_signed_in">تم تسجيل الدخول</string>
     <string name="settings_appearance_amoled_black">أسود AMOLED</string>
     <string name="settings_appearance_amoled_description">استخدام خلفيات سوداء خالصة لشاشات OLED.</string>
+    <string name="settings_appearance_use_system_font">استخدام خط النظام</string>
+    <string name="settings_appearance_use_system_font_description">استخدام خط النظام الافتراضي للجهاز بدلاً من الخط المدمج.</string>
     <string name="settings_appearance_app_icon">أيقونة التطبيق</string>
     <string name="settings_appearance_app_icon_arctic_blue">أزرق قطبي</string>
     <string name="settings_appearance_app_icon_android_confirmation_message">سيؤدي التغيير إلى %1$s إلى إغلاق Nuvio. اضغط «موافق» للمتابعة.</string>

--- a/composeApp/src/commonMain/composeResources/values-bg/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-bg/strings.xml
@@ -653,6 +653,8 @@
     <string name="settings_account_status_signed_in">Влезли сте</string>
     <string name="settings_appearance_amoled_black">AMOLED черно</string>
     <string name="settings_appearance_amoled_description">Използвай чисто черни фонове за OLED екрани.</string>
+    <string name="settings_appearance_use_system_font">Използване на системен шрифт</string>
+    <string name="settings_appearance_use_system_font_description">Използване на системния шрифт по подразбиране на устройството вместо вградения шрифт.</string>
     <string name="settings_appearance_app_icon">Икона на приложението</string>
     <string name="settings_appearance_app_icon_arctic_blue">Арктиеско синьо</string>
     <string name="settings_appearance_app_icon_android_confirmation_message">Промяната към %1$s ще затвори Nuvio. Натиснете OK, за да продължите.</string>

--- a/composeApp/src/commonMain/composeResources/values-cs/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-cs/strings.xml
@@ -548,6 +548,8 @@
     <string name="settings_account_status_signed_in">Přihlášen</string>
     <string name="settings_appearance_amoled_black">AMOLED černá</string>
     <string name="settings_appearance_amoled_description">Použít čistě černé pozadí pro OLED obrazovky.</string>
+    <string name="settings_appearance_use_system_font">Použít systémové písmo</string>
+    <string name="settings_appearance_use_system_font_description">Použít výchozí systémové písmo zařízení namísto přibaleného písma.</string>
     <string name="settings_appearance_app_language">Jazyk aplikace</string>
     <string name="settings_appearance_app_language_device">Jazyk zařízení</string>
     <string name="settings_appearance_app_language_sheet_title">Vybrat jazyk</string>

--- a/composeApp/src/commonMain/composeResources/values-de/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-de/strings.xml
@@ -456,6 +456,8 @@
     <string name="settings_account_status_signed_in">Angemeldet</string>
     <string name="settings_appearance_amoled_black">AMOLED-Schwarz</string>
     <string name="settings_appearance_amoled_description">Reines Schwarz für OLED-Bildschirme verwenden.</string>
+    <string name="settings_appearance_use_system_font">Systemschriftart verwenden</string>
+    <string name="settings_appearance_use_system_font_description">Die Standardschriftart des Geräts anstelle der integrierten Schriftart verwenden.</string>
     <string name="settings_appearance_app_language">App-Sprache</string>
     <string name="settings_appearance_app_language_sheet_title">Sprache wählen</string>
     <string name="settings_appearance_continue_watching_description">Anzeigen, ausblenden und gestalten der Weiterschauen-Reihe.</string>

--- a/composeApp/src/commonMain/composeResources/values-el/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-el/strings.xml
@@ -380,6 +380,8 @@
     <string name="settings_advanced_sentry_reports_subtitle">Αποστολή αναφορών σφαλμάτων και ANR με ασφαλές πλαίσιο. Ενεργό από προεπιλογή.</string>
     <string name="settings_appearance_amoled_black">AMOLED Μαύρο</string>
     <string name="settings_appearance_amoled_description">Χρήση καθαρού μαύρου φόντου για οθόνες OLED.</string>
+    <string name="settings_appearance_use_system_font">Χρήση γραμματοσειράς συστήματος</string>
+    <string name="settings_appearance_use_system_font_description">Χρήση της προεπιλεγμένης γραμματοσειράς συστήματος της συσκευής αντί της ενσωματωμένης γραμματοσειράς.</string>
     <string name="settings_appearance_app_icon">Εικονίδιο εφαρμογής</string>
     <string name="settings_appearance_app_icon_arctic_blue">Παγωμένο μπλε</string>
     <string name="settings_appearance_app_icon_android_confirmation_message">Η αλλαγή σε %1$s θα κλείσει το Nuvio. Πατήστε ΟΚ για να συνεχίσετε.</string>

--- a/composeApp/src/commonMain/composeResources/values-es/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-es/strings.xml
@@ -653,6 +653,8 @@
     <string name="settings_account_status_signed_in">Sesión iniciada</string>
     <string name="settings_appearance_amoled_black">Negro AMOLED</string>
     <string name="settings_appearance_amoled_description">Usa fondos negros puros para pantallas OLED.</string>
+    <string name="settings_appearance_use_system_font">Usar fuente del sistema</string>
+    <string name="settings_appearance_use_system_font_description">Usa la fuente predeterminada del dispositivo en lugar de la fuente integrada.</string>
     <string name="settings_appearance_app_icon">Icono de la app</string>
     <string name="settings_appearance_app_icon_arctic_blue">Azul ártico</string>
     <string name="settings_appearance_app_icon_android_confirmation_message">Cambiar a %1$s cerrará Nuvio. Pulsa Aceptar para continuar.</string>

--- a/composeApp/src/commonMain/composeResources/values-fr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-fr/strings.xml
@@ -558,6 +558,8 @@
     <string name="settings_account_status_signed_in">Connecté</string>
     <string name="settings_appearance_amoled_black">Noir AMOLED</string>
     <string name="settings_appearance_amoled_description">Utilise des fonds noirs purs pour les écrans OLED.</string>
+    <string name="settings_appearance_use_system_font">Utiliser la police du système</string>
+    <string name="settings_appearance_use_system_font_description">Utiliser la police par défaut de l\'appareil au lieu de la police intégrée.</string>
     <string name="settings_appearance_app_language">Langue de l’application</string>
     <string name="settings_appearance_app_language_device">Langue de l’appareil</string>
     <string name="settings_appearance_app_language_sheet_title">Choisir la langue</string>

--- a/composeApp/src/commonMain/composeResources/values-he/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-he/strings.xml
@@ -312,6 +312,8 @@
     <string name="settings_account_status_anonymous">אנונימי</string>
     <string name="settings_account_status_signed_in">מחובר</string>
     <string name="settings_appearance_amoled_description">השתמש ברקעים שחורים טהורים עבור מסכי OLED.</string>
+    <string name="settings_appearance_use_system_font">השתמש בגופן המערכת</string>
+    <string name="settings_appearance_use_system_font_description">השתמש בגופן ברירת המחדל של המכשיר במקום בגופן המובנה.</string>
     <string name="settings_appearance_app_language">שפת האפליקציה</string>
     <string name="settings_appearance_app_language_device">שפת המכשיר</string>
     <string name="settings_appearance_app_language_sheet_title">בחר שפה</string>

--- a/composeApp/src/commonMain/composeResources/values-hu/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-hu/strings.xml
@@ -492,6 +492,8 @@
     <string name="settings_account_status_signed_in">Bejelentkezve</string>
     <string name="settings_appearance_amoled_black">AMOLED fekete</string>
     <string name="settings_appearance_amoled_description">Tiszta fekete háttér használata OLED képernyőkhöz.</string>
+    <string name="settings_appearance_use_system_font">Rendszer betűtípus használata</string>
+    <string name="settings_appearance_use_system_font_description">Az eszköz alapértelmezett rendszer betűtípusának használata a beépített betűtípus helyett.</string>
     <string name="settings_appearance_app_language">Alkalmazás nyelve</string>
     <string name="settings_appearance_app_language_sheet_title">Nyelv választása</string>
     <string name="settings_appearance_continue_watching_description">A Nézés folytatása sor beállításai.</string>

--- a/composeApp/src/commonMain/composeResources/values-id/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-id/strings.xml
@@ -514,6 +514,8 @@
     <string name="settings_account_status_signed_in">Sudah masuk</string>
     <string name="settings_appearance_amoled_black">Hitam AMOLED</string>
     <string name="settings_appearance_amoled_description">Gunakan latar belakang hitam pekat untuk layar OLED.</string>
+    <string name="settings_appearance_use_system_font">Gunakan Font Sistem</string>
+    <string name="settings_appearance_use_system_font_description">Gunakan font default perangkat alih-alih font bawaan.</string>
     <string name="settings_appearance_app_language">Bahasa Aplikasi</string>
     <string name="settings_appearance_app_language_sheet_title">Pilih Bahasa</string>
     <string name="settings_appearance_continue_watching_description">Pengaturan untuk bagian Lanjutkan Menonton.</string>

--- a/composeApp/src/commonMain/composeResources/values-in/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-in/strings.xml
@@ -514,6 +514,8 @@
     <string name="settings_account_status_signed_in">Sudah masuk</string>
     <string name="settings_appearance_amoled_black">Hitam AMOLED</string>
     <string name="settings_appearance_amoled_description">Gunakan latar belakang hitam pekat untuk layar OLED.</string>
+    <string name="settings_appearance_use_system_font">Gunakan Font Sistem</string>
+    <string name="settings_appearance_use_system_font_description">Gunakan font default perangkat alih-alih font bawaan.</string>
     <string name="settings_appearance_app_language">Bahasa Aplikasi</string>
     <string name="settings_appearance_app_language_sheet_title">Pilih Bahasa</string>
     <string name="settings_appearance_continue_watching_description">Pengaturan untuk bagian Lanjutkan Menonton.</string>

--- a/composeApp/src/commonMain/composeResources/values-it/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-it/strings.xml
@@ -319,6 +319,8 @@
   <string name="settings_account_status_signed_in">Connesso</string>
   <string name="settings_appearance_amoled_black">Nero AMOLED</string>
   <string name="settings_appearance_amoled_description">Usa sfondi neri assoluti per schermi OLED.</string>
+  <string name="settings_appearance_use_system_font">Usa carattere di sistema</string>
+  <string name="settings_appearance_use_system_font_description">Usa il carattere predefinito del dispositivo invece del carattere integrato.</string>
   <string name="settings_appearance_app_language">Lingua app</string>
   <string name="settings_appearance_app_language_sheet_title">Scegli lingua</string>
   <string name="settings_appearance_continue_watching_description">Mostra, nascondi e personalizza lo stile della riga "Continua a guardare".</string>

--- a/composeApp/src/commonMain/composeResources/values-ja/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ja/strings.xml
@@ -548,6 +548,8 @@
     <string name="settings_account_status_signed_in">サインイン済み</string>
     <string name="settings_appearance_amoled_black">AMOLED ブラック</string>
     <string name="settings_appearance_amoled_description">OLEDスクリーン向けに純粋な黒背景を使用します。</string>
+    <string name="settings_appearance_use_system_font">システムフォントを使用</string>
+    <string name="settings_appearance_use_system_font_description">バンドルされたフォントの代わりにデバイスのデフォルトのシステムフォントを使用します。</string>
     <string name="settings_appearance_app_language">アプリの言語</string>
     <string name="settings_appearance_app_language_device">デバイスの言語</string>
     <string name="settings_appearance_app_language_sheet_title">言語を選択</string>

--- a/composeApp/src/commonMain/composeResources/values-nb/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nb/strings.xml
@@ -498,6 +498,8 @@
     <string name="settings_account_status_signed_in">Innlogget</string>
     <string name="settings_appearance_amoled_black">AMOLED Svart</string>
     <string name="settings_appearance_amoled_description">Bruk ren svart bakgrunn for OLED-skjermer.</string>
+    <string name="settings_appearance_use_system_font">Bruk systemskrift</string>
+    <string name="settings_appearance_use_system_font_description">Bruk enhetens standard systemskrift i stedet for den medfølgende skriften.</string>
     <string name="settings_appearance_app_language">Appspråk</string>
     <string name="settings_appearance_app_language_sheet_title">Velg språk</string>
     <string name="settings_appearance_continue_watching_description">Innstillinger for Fortsett å se-seksjonen.</string>

--- a/composeApp/src/commonMain/composeResources/values-nl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-nl/strings.xml
@@ -577,6 +577,8 @@
     <string name="settings_account_status_signed_in">Ingelogd</string>
     <string name="settings_appearance_amoled_black">AMOLED-zwart</string>
     <string name="settings_appearance_amoled_description">Gebruik puur zwarte achtergronden voor OLED-schermen.</string>
+    <string name="settings_appearance_use_system_font">Systeemlettertype gebruiken</string>
+    <string name="settings_appearance_use_system_font_description">Gebruik het standaard systeemlettertype van het apparaat in plaats van het meegeleverde lettertype.</string>
     <string name="settings_appearance_app_icon">App-pictogram</string>
     <string name="settings_appearance_app_icon_arctic_blue">Arctic Blue</string>
     <string name="settings_appearance_app_icon_android_confirmation_message">Als je overschakelt naar %1$s, wordt Nuvio gesloten. Tik op OK om door te gaan.</string>

--- a/composeApp/src/commonMain/composeResources/values-pl/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pl/strings.xml
@@ -514,6 +514,8 @@
     <string name="settings_account_status_signed_in">Zalogowany</string>
     <string name="settings_appearance_amoled_black">AMOLED czarny</string>
     <string name="settings_appearance_amoled_description">Użyj czystego czarnego tła dla ekranów OLED.</string>
+    <string name="settings_appearance_use_system_font">Użyj czcionki systemowej</string>
+    <string name="settings_appearance_use_system_font_description">Użyj domyślnej czcionki systemowej urządzenia zamiast dołączonej czcionki.</string>
     <string name="settings_appearance_app_language">Język aplikacji</string>
     <string name="settings_appearance_app_language_sheet_title">Wybierz język</string>
     <string name="settings_appearance_continue_watching_description">Pokaż, ukryj i stylizuj półkę Kontynuuj oglądanie.</string>

--- a/composeApp/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -499,6 +499,8 @@
     <string name="settings_account_status_signed_in">Conectado</string>
     <string name="settings_appearance_amoled_black">Preto AMOLED</string>
     <string name="settings_appearance_amoled_description">Usar fundos pretos puros para telas OLED.</string>
+    <string name="settings_appearance_use_system_font">Usar fonte do sistema</string>
+    <string name="settings_appearance_use_system_font_description">Usar a fonte padrão do dispositivo em vez da fonte incluída.</string>
     <string name="settings_appearance_app_language">Idioma do App</string>
     <string name="settings_appearance_app_language_sheet_title">Escolher Idioma</string>
     <string name="settings_appearance_continue_watching_description">Configurações para a seção Continuar Assistindo.</string>

--- a/composeApp/src/commonMain/composeResources/values-pt/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-pt/strings.xml
@@ -543,6 +543,8 @@
     <string name="settings_account_status_signed_in">Sessão iniciada</string>
     <string name="settings_appearance_amoled_black">Preto AMOLED</string>
     <string name="settings_appearance_amoled_description">Utiliza fundos pretos puros para ecrãs OLED.</string>
+    <string name="settings_appearance_use_system_font">Usar tipo de letra do sistema</string>
+    <string name="settings_appearance_use_system_font_description">Utiliza o tipo de letra predefinido do dispositivo em vez do tipo de letra incluído.</string>
     <string name="settings_appearance_app_language">Idioma da app</string>
     <string name="settings_appearance_app_language_sheet_title">Escolher idioma</string>
     <string name="settings_appearance_continue_watching_description">Definições para a secção Continuar a Ver.</string>

--- a/composeApp/src/commonMain/composeResources/values-ro/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ro/strings.xml
@@ -566,6 +566,8 @@
     <string name="settings_account_status_signed_in">Autentificat</string>
     <string name="settings_appearance_amoled_black">Negru AMOLED</string>
     <string name="settings_appearance_amoled_description">Folosește fundaluri complet negre pentru ecranele OLED.</string>
+    <string name="settings_appearance_use_system_font">Utilizează fontul de sistem</string>
+    <string name="settings_appearance_use_system_font_description">Utilizează fontul implicit al dispozitivului în locul fontului inclus.</string>
     <string name="settings_appearance_app_language">Limba aplicației</string>
     <string name="settings_appearance_app_language_device">Limba dispozitivului</string>
     <string name="settings_appearance_app_language_sheet_title">Alege limba</string>

--- a/composeApp/src/commonMain/composeResources/values-ru/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-ru/strings.xml
@@ -653,6 +653,8 @@
     <string name="settings_account_status_signed_in">Вошёл в систему</string>
     <string name="settings_appearance_amoled_black">AMOLED Черный</string>
     <string name="settings_appearance_amoled_description">Используйте чистый черный фон для экранов OLED.</string>
+    <string name="settings_appearance_use_system_font">Использовать системный шрифт</string>
+    <string name="settings_appearance_use_system_font_description">Использовать системный шрифт устройства по умолчанию вместо встроенного шрифта.</string>
     <string name="settings_appearance_app_icon">Значок приложения</string>
     <string name="settings_appearance_app_icon_arctic_blue">Арктический синий</string>
     <string name="settings_appearance_app_icon_android_confirmation_message">Изменение на %1$s приведет к закрытию Nuvio. Нажмите «ОК», чтобы продолжить.</string>

--- a/composeApp/src/commonMain/composeResources/values-sk/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-sk/strings.xml
@@ -538,6 +538,8 @@
     <string name="settings_account_status_signed_in">Prihlásený</string>
     <string name="settings_appearance_amoled_black">AMOLED čierna</string>
     <string name="settings_appearance_amoled_description">Použiť čisto čierne pozadie pre OLED obrazovky.</string>
+    <string name="settings_appearance_use_system_font">Použiť systémové písmo</string>
+    <string name="settings_appearance_use_system_font_description">Použiť predvolené systémové písmo zariadenia namiesto pribaleného písma.</string>
     <string name="settings_appearance_app_language">Jazyk aplikácie</string>
     <string name="settings_appearance_app_language_sheet_title">Vybrať jazyk</string>
     <string name="settings_appearance_continue_watching_description">Nastavenia sekcie Pokračovať v sledovaní.</string>

--- a/composeApp/src/commonMain/composeResources/values-tr/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-tr/strings.xml
@@ -577,6 +577,8 @@
     <string name="settings_account_status_signed_in">Giriş yapıldı</string>
     <string name="settings_appearance_amoled_black">AMOLED siyah</string>
     <string name="settings_appearance_amoled_description">OLED ekranlar için saf siyah arka planlar kullan.</string>
+    <string name="settings_appearance_use_system_font">Sistem Yazı Tipini Kullan</string>
+    <string name="settings_appearance_use_system_font_description">Birlikte gelen yazı tipi yerine cihazın varsayılan sistem yazı tipini kullanın.</string>
     <string name="settings_appearance_app_icon">Uygulama Simgesi</string>
     <string name="settings_appearance_app_icon_arctic_blue">Kutup Mavisi</string>
     <string name="settings_appearance_app_icon_android_confirmation_message">%1$s olarak değiştirmek Nuvio'yu kapatacaktır. Devam etmek için Tamam'a dokunun.</string>

--- a/composeApp/src/commonMain/composeResources/values-vi/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values-vi/strings.xml
@@ -545,6 +545,8 @@
     <string name="settings_account_status_signed_in">Đã đăng nhập</string>
     <string name="settings_appearance_amoled_black">Đen AMOLED</string>
     <string name="settings_appearance_amoled_description">Dùng nền đen tuyệt đối cho màn hình OLED</string>
+    <string name="settings_appearance_use_system_font">Sử dụng phông chữ hệ thống</string>
+    <string name="settings_appearance_use_system_font_description">Sử dụng phông chữ hệ thống mặc định của thiết bị thay vì phông chữ đi kèm.</string>
     <string name="settings_appearance_app_language">Ngôn ngữ ứng dụng</string>
     <string name="settings_appearance_app_language_device">Theo ngôn ngữ thiết bị</string>
     <string name="settings_appearance_app_language_sheet_title">Chọn ngôn ngữ</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -653,6 +653,8 @@
     <string name="settings_account_status_signed_in">Signed in</string>
     <string name="settings_appearance_amoled_black">AMOLED Black</string>
     <string name="settings_appearance_amoled_description">Use pure black backgrounds for OLED screens.</string>
+    <string name="settings_appearance_use_system_font">Use System Font</string>
+    <string name="settings_appearance_use_system_font_description">Use the device\'s default system font instead of the bundled font.</string>
     <string name="settings_appearance_app_icon">App Icon</string>
     <string name="settings_appearance_app_icon_arctic_blue">Arctic Blue</string>
     <string name="settings_appearance_app_icon_android_confirmation_message">Changing to %1$s will close Nuvio. Tap OK to continue.</string>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/App.kt
@@ -91,10 +91,18 @@ internal fun AppEnvironment(content: @Composable () -> Unit) {
     val amoledEnabled by remember {
         ThemeSettingsRepository.amoledEnabled
     }.collectAsStateWithLifecycle()
+    val useSystemFont by remember {
+        ThemeSettingsRepository.useSystemFont
+    }.collectAsStateWithLifecycle()
 
     val customThemeColors by ThemeSettingsRepository.customThemeColors.collectAsStateWithLifecycle()
 
-    NuvioTheme(appTheme = selectedTheme, amoled = amoledEnabled, customThemeColors = customThemeColors) {
+    NuvioTheme(
+        appTheme = selectedTheme,
+        amoled = amoledEnabled,
+        useSystemFont = useSystemFont,
+        customThemeColors = customThemeColors,
+    ) {
         content()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PosterZoomActionOverlay.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/PosterZoomActionOverlay.kt
@@ -30,6 +30,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.AbsoluteAlignment
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.BlurredEdgeTreatment
@@ -47,10 +48,12 @@ import androidx.compose.ui.layout.boundsInRoot
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInRoot
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.max
 import androidx.compose.ui.unit.min
@@ -349,6 +352,7 @@ fun NuvioPosterZoomActionOverlay(
         // The travelling poster itself, drawn above the slot column.
         Box(
             modifier = Modifier
+                .align(AbsoluteAlignment.TopLeft)
                 .size(width = posterWidth, height = posterHeight)
                 .graphicsLayer {
                     val slot = slotBounds
@@ -426,6 +430,7 @@ fun NuvioPosterZoomActionOverlay(
                             overflow = TextOverflow.Ellipsis,
                         )
                     }
+                    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
                     NuvioPosterWatchedOverlay(
                         isWatched = isWatched,
                         modifier = Modifier.graphicsLayer {
@@ -438,7 +443,7 @@ fun NuvioPosterZoomActionOverlay(
                                 ).coerceAtLeast(0.001f)
                                 scaleX = 1f / scale
                                 scaleY = 1f / scale
-                                transformOrigin = TransformOrigin(1f, 0f)
+                                transformOrigin = TransformOrigin(if (isRtl) 0f else 1f, 0f)
                             }
                         },
                     )

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/core/ui/Theme.kt
@@ -59,7 +59,12 @@ private fun buildColorScheme(palette: ThemeColorPalette, amoled: Boolean = false
     onError = Color(0xFFFCE5EC),
 )
 
-private val JetBrainsSans: FontFamily
+fun resolveFontFamily(
+    useSystemFont: Boolean,
+    appFont: FontFamily,
+): FontFamily = if (useSystemFont) FontFamily.Default else appFont
+
+val JetBrainsSans: FontFamily
     @Composable
     get() = FontFamily(
         Font(Res.font.jetbrains_sans_bold, FontWeight.Bold, FontStyle.Normal),
@@ -67,126 +72,133 @@ private val JetBrainsSans: FontFamily
         Font(Res.font.jetbrains_sans_regular, FontWeight.Normal, FontStyle.Normal),
     )
 
-private val NuvioTypography: Typography
-    @Composable
-    get() = Typography(
-        displayLarge = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.pageDisplay,
-            lineHeight = NuvioTokens.LineHeight.pageDisplay,
-            fontWeight = FontWeight.Bold,
-            letterSpacing = NuvioTokens.LetterSpacing.pageDisplay,
-        ),
-        headlineLarge = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.headline,
-            lineHeight = NuvioTokens.LineHeight.headline,
-            fontWeight = FontWeight.SemiBold,
-            letterSpacing = NuvioTokens.LetterSpacing.headline,
-        ),
-        titleLarge = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.titleSm,
-            lineHeight = NuvioTokens.LineHeight.materialTitleLarge,
-            fontWeight = FontWeight.SemiBold,
-        ),
-        titleMedium = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.bodyLg,
-            lineHeight = NuvioTokens.LineHeight.bodyMd,
-            fontWeight = FontWeight.SemiBold,
-        ),
-        bodyLarge = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.bodyApp,
-            lineHeight = NuvioTokens.LineHeight.bodyApp,
-            fontWeight = FontWeight.Normal,
-        ),
-        bodyMedium = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.bodyMd,
-            lineHeight = NuvioTokens.LineHeight.bodyMd,
-            fontWeight = FontWeight.Normal,
-        ),
-        labelLarge = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.bodyMd,
-            lineHeight = NuvioTokens.LineHeight.bodySm,
-            fontWeight = FontWeight.SemiBold,
-        ),
-        labelMedium = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.labelSm,
-            lineHeight = NuvioTokens.LineHeight.labelXs,
-            fontWeight = FontWeight.SemiBold,
-            letterSpacing = NuvioTokens.LetterSpacing.label,
-        ),
-    )
+@Composable
+fun rememberNuvioFontFamily(useSystemFont: Boolean): FontFamily {
+    val appFont = if (useSystemFont) null else JetBrainsSans
+    return remember(useSystemFont, appFont) {
+        resolveFontFamily(
+            useSystemFont = useSystemFont,
+            appFont = appFont ?: FontFamily.Default,
+        )
+    }
+}
 
-private val NuvioTypeTokens: NuvioTypeScale
-    @Composable
-    get() = NuvioTypeScale(
-        labelXs = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.labelXs,
-            lineHeight = NuvioTokens.LineHeight.labelXs,
-            fontWeight = FontWeight.SemiBold,
-        ),
-        labelSm = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.labelSm,
-            lineHeight = NuvioTokens.LineHeight.labelSm,
-            fontWeight = FontWeight.SemiBold,
-        ),
-        bodySm = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.bodySm,
-            lineHeight = NuvioTokens.LineHeight.bodySm,
-            fontWeight = FontWeight.Normal,
-        ),
-        bodyMd = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.bodyMd,
-            lineHeight = NuvioTokens.LineHeight.bodyMd,
-            fontWeight = FontWeight.Normal,
-        ),
-        bodyLg = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.bodyLg,
-            lineHeight = NuvioTokens.LineHeight.bodyLg,
-            fontWeight = FontWeight.Normal,
-        ),
-        titleSm = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.titleSm,
-            lineHeight = NuvioTokens.LineHeight.titleSm,
-            fontWeight = FontWeight.SemiBold,
-        ),
-        titleMd = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.titleMd,
-            lineHeight = NuvioTokens.LineHeight.titleMd,
-            fontWeight = FontWeight.SemiBold,
-        ),
-        titleLg = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.titleLg,
-            lineHeight = NuvioTokens.LineHeight.titleLg,
-            fontWeight = FontWeight.SemiBold,
-        ),
-        displaySm = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.displaySm,
-            lineHeight = NuvioTokens.LineHeight.displaySm,
-            fontWeight = FontWeight.Bold,
-        ),
-        displayMd = TextStyle(
-            fontFamily = JetBrainsSans,
-            fontSize = NuvioTokens.Type.displayMd,
-            lineHeight = NuvioTokens.LineHeight.displayMd,
-            fontWeight = FontWeight.Bold,
-        ),
-    )
+fun createNuvioTypography(fontFamily: FontFamily): Typography = Typography(
+    displayLarge = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.pageDisplay,
+        lineHeight = NuvioTokens.LineHeight.pageDisplay,
+        fontWeight = FontWeight.Bold,
+        letterSpacing = NuvioTokens.LetterSpacing.pageDisplay,
+    ),
+    headlineLarge = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.headline,
+        lineHeight = NuvioTokens.LineHeight.headline,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = NuvioTokens.LetterSpacing.headline,
+    ),
+    titleLarge = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.titleSm,
+        lineHeight = NuvioTokens.LineHeight.materialTitleLarge,
+        fontWeight = FontWeight.SemiBold,
+    ),
+    titleMedium = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.bodyLg,
+        lineHeight = NuvioTokens.LineHeight.bodyMd,
+        fontWeight = FontWeight.SemiBold,
+    ),
+    bodyLarge = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.bodyApp,
+        lineHeight = NuvioTokens.LineHeight.bodyApp,
+        fontWeight = FontWeight.Normal,
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.bodyMd,
+        lineHeight = NuvioTokens.LineHeight.bodyMd,
+        fontWeight = FontWeight.Normal,
+    ),
+    labelLarge = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.bodyMd,
+        lineHeight = NuvioTokens.LineHeight.bodySm,
+        fontWeight = FontWeight.SemiBold,
+    ),
+    labelMedium = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.labelSm,
+        lineHeight = NuvioTokens.LineHeight.labelXs,
+        fontWeight = FontWeight.SemiBold,
+        letterSpacing = NuvioTokens.LetterSpacing.label,
+    ),
+)
+
+fun createNuvioTypeScale(fontFamily: FontFamily): NuvioTypeScale = NuvioTypeScale(
+    labelXs = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.labelXs,
+        lineHeight = NuvioTokens.LineHeight.labelXs,
+        fontWeight = FontWeight.SemiBold,
+    ),
+    labelSm = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.labelSm,
+        lineHeight = NuvioTokens.LineHeight.labelSm,
+        fontWeight = FontWeight.SemiBold,
+    ),
+    bodySm = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.bodySm,
+        lineHeight = NuvioTokens.LineHeight.bodySm,
+        fontWeight = FontWeight.Normal,
+    ),
+    bodyMd = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.bodyMd,
+        lineHeight = NuvioTokens.LineHeight.bodyMd,
+        fontWeight = FontWeight.Normal,
+    ),
+    bodyLg = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.bodyLg,
+        lineHeight = NuvioTokens.LineHeight.bodyLg,
+        fontWeight = FontWeight.Normal,
+    ),
+    titleSm = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.titleSm,
+        lineHeight = NuvioTokens.LineHeight.titleSm,
+        fontWeight = FontWeight.SemiBold,
+    ),
+    titleMd = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.titleMd,
+        lineHeight = NuvioTokens.LineHeight.titleMd,
+        fontWeight = FontWeight.SemiBold,
+    ),
+    titleLg = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.titleLg,
+        lineHeight = NuvioTokens.LineHeight.titleLg,
+        fontWeight = FontWeight.SemiBold,
+    ),
+    displaySm = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.displaySm,
+        lineHeight = NuvioTokens.LineHeight.displaySm,
+        fontWeight = FontWeight.Bold,
+    ),
+    displayMd = TextStyle(
+        fontFamily = fontFamily,
+        fontSize = NuvioTokens.Type.displayMd,
+        lineHeight = NuvioTokens.LineHeight.displayMd,
+        fontWeight = FontWeight.Bold,
+    ),
+)
 
 private val NuvioRippleConfiguration = RippleConfiguration(
     color = Color.Black,
@@ -197,6 +209,7 @@ fun NuvioTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     appTheme: AppTheme = AppTheme.WHITE,
     amoled: Boolean = false,
+    useSystemFont: Boolean = false,
     customThemeColors: CustomThemeColors = CustomThemeColors.Default,
     content: @Composable () -> Unit,
 ) {
@@ -206,6 +219,10 @@ fun NuvioTheme(
     val colorScheme = buildColorScheme(palette, amoled = amoled)
     val tokens = defaultNuvioThemeTokens(palette, amoled = amoled, colorScheme = colorScheme)
 
+    val fontFamily = rememberNuvioFontFamily(useSystemFont = useSystemFont)
+    val typography = remember(fontFamily) { createNuvioTypography(fontFamily) }
+    val typeTokens = remember(fontFamily) { createNuvioTypeScale(fontFamily) }
+
     val density = LocalDensity.current
     CompositionLocalProvider(
         LocalDensity provides Density(
@@ -213,14 +230,14 @@ fun NuvioTheme(
             fontScale = 1f,
         ),
         LocalNuvioThemeTokens provides tokens,
-        LocalNuvioTypeScale provides NuvioTypeTokens,
+        LocalNuvioTypeScale provides typeTokens,
         LocalRippleConfiguration provides NuvioRippleConfiguration,
         LocalAppTheme provides appTheme,
         LocalThemePalette provides palette,
     ) {
         MaterialTheme(
             colorScheme = colorScheme,
-            typography = NuvioTypography,
+            typography = typography,
         ) {
             SkeletonAnimationProvider(content = content)
         }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/AppearanceSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/AppearanceSettingsPage.kt
@@ -43,6 +43,8 @@ import nuvio.composeapp.generated.resources.settings_appearance_nav_bar_style
 import nuvio.composeapp.generated.resources.settings_appearance_nav_bar_style_sheet_title
 import nuvio.composeapp.generated.resources.settings_appearance_amoled_black
 import nuvio.composeapp.generated.resources.settings_appearance_amoled_description
+import nuvio.composeapp.generated.resources.settings_appearance_use_system_font
+import nuvio.composeapp.generated.resources.settings_appearance_use_system_font_description
 import nuvio.composeapp.generated.resources.settings_appearance_continue_watching_description
 import nuvio.composeapp.generated.resources.settings_appearance_liquid_glass
 import nuvio.composeapp.generated.resources.settings_appearance_liquid_glass_description
@@ -67,6 +69,8 @@ internal fun LazyListScope.appearanceSettingsContent(
     onThemeSelected: (AppTheme) -> Unit,
     amoledEnabled: Boolean,
     onAmoledToggle: (Boolean) -> Unit,
+    useSystemFont: Boolean,
+    onUseSystemFontToggle: (Boolean) -> Unit,
     liquidGlassNativeTabBarSupported: Boolean,
     liquidGlassNativeTabBarEnabled: Boolean,
     onLiquidGlassNativeTabBarToggle: (Boolean) -> Unit,
@@ -124,6 +128,14 @@ internal fun LazyListScope.appearanceSettingsContent(
                         onCheckedChange = onLiquidGlassNativeTabBarToggle,
                     )
                 }
+                SettingsGroupDivider(isTablet = isTablet)
+                SettingsSwitchRow(
+                    title = stringResource(Res.string.settings_appearance_use_system_font),
+                    description = stringResource(Res.string.settings_appearance_use_system_font_description),
+                    checked = useSystemFont,
+                    isTablet = isTablet,
+                    onCheckedChange = onUseSystemFontToggle,
+                )
                 SettingsGroupDivider(isTablet = isTablet)
                 SettingsNavigationRow(
                     title = stringResource(Res.string.settings_appearance_app_icon),

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsScreen.kt
@@ -162,6 +162,7 @@ fun SettingsScreen(
         }
         val selectedAppLanguage by remember { ThemeSettingsRepository.selectedAppLanguage }.collectAsStateWithLifecycle()
         val navBarStyle by remember { ThemeSettingsRepository.navBarStyle }.collectAsStateWithLifecycle()
+        val useSystemFont by remember { ThemeSettingsRepository.useSystemFont }.collectAsStateWithLifecycle()
         val appIconState by remember {
             AppIconRepository.ensureLoaded()
             AppIconRepository.state
@@ -397,6 +398,8 @@ fun SettingsScreen(
                 onThemeSelected = ThemeSettingsRepository::setTheme,
                 amoledEnabled = amoledEnabled,
                 onAmoledToggle = ThemeSettingsRepository::setAmoled,
+                useSystemFont = useSystemFont,
+                onUseSystemFontToggle = ThemeSettingsRepository::setUseSystemFont,
                 liquidGlassNativeTabBarSupported = liquidGlassNativeTabBarSupported,
                 liquidGlassNativeTabBarEnabled = liquidGlassNativeTabBarEnabled,
                 onLiquidGlassNativeTabBarToggle = ThemeSettingsRepository::setLiquidGlassNativeTabBar,
@@ -463,6 +466,8 @@ fun SettingsScreen(
                 onThemeSelected = ThemeSettingsRepository::setTheme,
                 amoledEnabled = amoledEnabled,
                 onAmoledToggle = ThemeSettingsRepository::setAmoled,
+                useSystemFont = useSystemFont,
+                onUseSystemFontToggle = ThemeSettingsRepository::setUseSystemFont,
                 liquidGlassNativeTabBarSupported = liquidGlassNativeTabBarSupported,
                 liquidGlassNativeTabBarEnabled = liquidGlassNativeTabBarEnabled,
                 onLiquidGlassNativeTabBarToggle = ThemeSettingsRepository::setLiquidGlassNativeTabBar,
@@ -539,6 +544,8 @@ private fun MobileSettingsScreen(
     onThemeSelected: (AppTheme) -> Unit,
     amoledEnabled: Boolean,
     onAmoledToggle: (Boolean) -> Unit,
+    useSystemFont: Boolean,
+    onUseSystemFontToggle: (Boolean) -> Unit,
     liquidGlassNativeTabBarSupported: Boolean,
     liquidGlassNativeTabBarEnabled: Boolean,
     onLiquidGlassNativeTabBarToggle: (Boolean) -> Unit,
@@ -742,6 +749,8 @@ private fun MobileSettingsScreen(
                     onThemeSelected = onThemeSelected,
                     amoledEnabled = amoledEnabled,
                     onAmoledToggle = onAmoledToggle,
+                    useSystemFont = useSystemFont,
+                    onUseSystemFontToggle = onUseSystemFontToggle,
                     liquidGlassNativeTabBarSupported = liquidGlassNativeTabBarSupported,
                     liquidGlassNativeTabBarEnabled = liquidGlassNativeTabBarEnabled,
                     onLiquidGlassNativeTabBarToggle = onLiquidGlassNativeTabBarToggle,
@@ -907,6 +916,8 @@ private fun TabletSettingsScreen(
     onThemeSelected: (AppTheme) -> Unit,
     amoledEnabled: Boolean,
     onAmoledToggle: (Boolean) -> Unit,
+    useSystemFont: Boolean,
+    onUseSystemFontToggle: (Boolean) -> Unit,
     liquidGlassNativeTabBarSupported: Boolean,
     liquidGlassNativeTabBarEnabled: Boolean,
     onLiquidGlassNativeTabBarToggle: (Boolean) -> Unit,
@@ -1166,6 +1177,8 @@ private fun TabletSettingsScreen(
                         onThemeSelected = onThemeSelected,
                         amoledEnabled = amoledEnabled,
                         onAmoledToggle = onAmoledToggle,
+                        useSystemFont = useSystemFont,
+                        onUseSystemFontToggle = onUseSystemFontToggle,
                         liquidGlassNativeTabBarSupported = liquidGlassNativeTabBarSupported,
                         liquidGlassNativeTabBarEnabled = liquidGlassNativeTabBarEnabled,
                         onLiquidGlassNativeTabBarToggle = onLiquidGlassNativeTabBarToggle,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsSearch.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/SettingsSearch.kt
@@ -392,6 +392,15 @@ internal fun settingsSearchEntries(
     }
     addRow(
         page = SettingsPage.Appearance,
+        key = "system-font",
+        title = stringResource(Res.string.settings_appearance_use_system_font),
+        description = stringResource(Res.string.settings_appearance_use_system_font_description),
+        pageLabel = layoutPage,
+        section = stringResource(Res.string.settings_appearance_section_display),
+        icon = Icons.Rounded.Palette,
+    )
+    addRow(
+        page = SettingsPage.Appearance,
         key = "app-language",
         title = stringResource(Res.string.settings_appearance_app_language),
         pageLabel = layoutPage,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsRepository.kt
@@ -40,6 +40,9 @@ object ThemeSettingsRepository {
     private val _navBarStyle = MutableStateFlow(NavBarStyle.ADAPTIVE)
     val navBarStyle: StateFlow<NavBarStyle> = _navBarStyle.asStateFlow()
 
+    private val _useSystemFont = MutableStateFlow(false)
+    val useSystemFont: StateFlow<Boolean> = _useSystemFont.asStateFlow()
+
     private var hasLoaded = false
     private var observesMembership = false
 
@@ -65,6 +68,7 @@ object ThemeSettingsRepository {
         NativeTabBridge.publishLiquidGlassEnabled(false)
         _selectedAppLanguage.value = AppLanguage.DEVICE
         _navBarStyle.value = NavBarStyle.ADAPTIVE
+        _useSystemFont.value = false
     }
 
     private fun loadFromDisk() {
@@ -90,6 +94,7 @@ object ThemeSettingsRepository {
         ThemeSettingsStorage.applySelectedAppLanguage(appLanguage.code)
         _selectedAppLanguage.value = appLanguage
         _navBarStyle.value = NavBarStyle.fromKey(ThemeSettingsStorage.loadNavBarStyle())
+        _useSystemFont.value = ThemeSettingsStorage.loadUseSystemFont() ?: false
     }
 
     fun setTheme(theme: AppTheme) {
@@ -141,6 +146,13 @@ object ThemeSettingsRepository {
         if (_navBarStyle.value == style) return
         _navBarStyle.value = style
         ThemeSettingsStorage.saveNavBarStyle(style.key)
+    }
+
+    fun setUseSystemFont(enabled: Boolean) {
+        ensureLoaded()
+        if (_useSystemFont.value == enabled) return
+        _useSystemFont.value = enabled
+        ThemeSettingsStorage.saveUseSystemFont(enabled)
     }
 
     private fun observeMembership() {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.kt
@@ -16,6 +16,8 @@ internal expect object ThemeSettingsStorage {
     fun applySelectedAppLanguage(languageCode: String)
     fun loadNavBarStyle(): String?
     fun saveNavBarStyle(styleKey: String)
+    fun loadUseSystemFont(): Boolean?
+    fun saveUseSystemFont(enabled: Boolean)
     fun exportToSyncPayload(): JsonObject
     fun replaceFromSyncPayload(payload: JsonObject)
 }

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/core/ui/FontSelectionTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/core/ui/FontSelectionTest.kt
@@ -1,0 +1,165 @@
+package com.nuvio.app.core.ui
+
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+class FontSelectionTest {
+
+    @Test
+    fun resolveFontFamilyReturnsAppFontWhenSystemFontIsDisabled() {
+        val appFont = FontFamily.Monospace
+        val resolved = resolveFontFamily(useSystemFont = false, appFont = appFont)
+        assertSame(appFont, resolved)
+    }
+
+    @Test
+    fun resolveFontFamilyReturnsDefaultFontWhenSystemFontIsEnabled() {
+        val appFont = FontFamily.Monospace
+        val resolved = resolveFontFamily(useSystemFont = true, appFont = appFont)
+        assertSame(FontFamily.Default, resolved)
+    }
+
+    @Test
+    fun createNuvioTypographyPreservesAllPropertiesWithGivenFont() {
+        val testFont = FontFamily.Cursive
+        val typography = createNuvioTypography(testFont)
+
+        // Verify font family on all 8 configured styles
+        assertEquals(testFont, typography.displayLarge.fontFamily)
+        assertEquals(testFont, typography.headlineLarge.fontFamily)
+        assertEquals(testFont, typography.titleLarge.fontFamily)
+        assertEquals(testFont, typography.titleMedium.fontFamily)
+        assertEquals(testFont, typography.bodyLarge.fontFamily)
+        assertEquals(testFont, typography.bodyMedium.fontFamily)
+        assertEquals(testFont, typography.labelLarge.fontFamily)
+        assertEquals(testFont, typography.labelMedium.fontFamily)
+
+        // Verify typography properties are strictly preserved
+        assertEquals(NuvioTokens.Type.pageDisplay, typography.displayLarge.fontSize)
+        assertEquals(NuvioTokens.LineHeight.pageDisplay, typography.displayLarge.lineHeight)
+        assertEquals(FontWeight.Bold, typography.displayLarge.fontWeight)
+        assertEquals(NuvioTokens.LetterSpacing.pageDisplay, typography.displayLarge.letterSpacing)
+
+        assertEquals(NuvioTokens.Type.headline, typography.headlineLarge.fontSize)
+        assertEquals(NuvioTokens.LineHeight.headline, typography.headlineLarge.lineHeight)
+        assertEquals(FontWeight.SemiBold, typography.headlineLarge.fontWeight)
+        assertEquals(NuvioTokens.LetterSpacing.headline, typography.headlineLarge.letterSpacing)
+
+        assertEquals(NuvioTokens.Type.titleSm, typography.titleLarge.fontSize)
+        assertEquals(NuvioTokens.LineHeight.materialTitleLarge, typography.titleLarge.lineHeight)
+        assertEquals(FontWeight.SemiBold, typography.titleLarge.fontWeight)
+
+        assertEquals(NuvioTokens.Type.bodyLg, typography.titleMedium.fontSize)
+        assertEquals(NuvioTokens.LineHeight.bodyMd, typography.titleMedium.lineHeight)
+        assertEquals(FontWeight.SemiBold, typography.titleMedium.fontWeight)
+
+        assertEquals(NuvioTokens.Type.bodyApp, typography.bodyLarge.fontSize)
+        assertEquals(NuvioTokens.LineHeight.bodyApp, typography.bodyLarge.lineHeight)
+        assertEquals(FontWeight.Normal, typography.bodyLarge.fontWeight)
+
+        assertEquals(NuvioTokens.Type.bodyMd, typography.bodyMedium.fontSize)
+        assertEquals(NuvioTokens.LineHeight.bodyMd, typography.bodyMedium.lineHeight)
+        assertEquals(FontWeight.Normal, typography.bodyMedium.fontWeight)
+
+        assertEquals(NuvioTokens.Type.bodyMd, typography.labelLarge.fontSize)
+        assertEquals(NuvioTokens.LineHeight.bodySm, typography.labelLarge.lineHeight)
+        assertEquals(FontWeight.SemiBold, typography.labelLarge.fontWeight)
+
+        assertEquals(NuvioTokens.Type.labelSm, typography.labelMedium.fontSize)
+        assertEquals(NuvioTokens.LineHeight.labelXs, typography.labelMedium.lineHeight)
+        assertEquals(FontWeight.SemiBold, typography.labelMedium.fontWeight)
+        assertEquals(NuvioTokens.LetterSpacing.label, typography.labelMedium.letterSpacing)
+    }
+
+    @Test
+    fun createNuvioTypographyWithSystemDefaultFontUsesFontFamilyDefault() {
+        val typography = createNuvioTypography(FontFamily.Default)
+
+        assertEquals(FontFamily.Default, typography.displayLarge.fontFamily)
+        assertEquals(FontFamily.Default, typography.headlineLarge.fontFamily)
+        assertEquals(FontFamily.Default, typography.titleLarge.fontFamily)
+        assertEquals(FontFamily.Default, typography.titleMedium.fontFamily)
+        assertEquals(FontFamily.Default, typography.bodyLarge.fontFamily)
+        assertEquals(FontFamily.Default, typography.bodyMedium.fontFamily)
+        assertEquals(FontFamily.Default, typography.labelLarge.fontFamily)
+        assertEquals(FontFamily.Default, typography.labelMedium.fontFamily)
+    }
+
+    @Test
+    fun createNuvioTypeScalePreservesAllPropertiesWithGivenFont() {
+        val testFont = FontFamily.Serif
+        val scale = createNuvioTypeScale(testFont)
+
+        // Verify font family on all 10 styles
+        assertEquals(testFont, scale.labelXs.fontFamily)
+        assertEquals(testFont, scale.labelSm.fontFamily)
+        assertEquals(testFont, scale.bodySm.fontFamily)
+        assertEquals(testFont, scale.bodyMd.fontFamily)
+        assertEquals(testFont, scale.bodyLg.fontFamily)
+        assertEquals(testFont, scale.titleSm.fontFamily)
+        assertEquals(testFont, scale.titleMd.fontFamily)
+        assertEquals(testFont, scale.titleLg.fontFamily)
+        assertEquals(testFont, scale.displaySm.fontFamily)
+        assertEquals(testFont, scale.displayMd.fontFamily)
+
+        // Verify sizes, line heights, font weights
+        assertEquals(NuvioTokens.Type.labelXs, scale.labelXs.fontSize)
+        assertEquals(NuvioTokens.LineHeight.labelXs, scale.labelXs.lineHeight)
+        assertEquals(FontWeight.SemiBold, scale.labelXs.fontWeight)
+
+        assertEquals(NuvioTokens.Type.labelSm, scale.labelSm.fontSize)
+        assertEquals(NuvioTokens.LineHeight.labelSm, scale.labelSm.lineHeight)
+        assertEquals(FontWeight.SemiBold, scale.labelSm.fontWeight)
+
+        assertEquals(NuvioTokens.Type.bodySm, scale.bodySm.fontSize)
+        assertEquals(NuvioTokens.LineHeight.bodySm, scale.bodySm.lineHeight)
+        assertEquals(FontWeight.Normal, scale.bodySm.fontWeight)
+
+        assertEquals(NuvioTokens.Type.bodyMd, scale.bodyMd.fontSize)
+        assertEquals(NuvioTokens.LineHeight.bodyMd, scale.bodyMd.lineHeight)
+        assertEquals(FontWeight.Normal, scale.bodyMd.fontWeight)
+
+        assertEquals(NuvioTokens.Type.bodyLg, scale.bodyLg.fontSize)
+        assertEquals(NuvioTokens.LineHeight.bodyLg, scale.bodyLg.lineHeight)
+        assertEquals(FontWeight.Normal, scale.bodyLg.fontWeight)
+
+        assertEquals(NuvioTokens.Type.titleSm, scale.titleSm.fontSize)
+        assertEquals(NuvioTokens.LineHeight.titleSm, scale.titleSm.lineHeight)
+        assertEquals(FontWeight.SemiBold, scale.titleSm.fontWeight)
+
+        assertEquals(NuvioTokens.Type.titleMd, scale.titleMd.fontSize)
+        assertEquals(NuvioTokens.LineHeight.titleMd, scale.titleMd.lineHeight)
+        assertEquals(FontWeight.SemiBold, scale.titleMd.fontWeight)
+
+        assertEquals(NuvioTokens.Type.titleLg, scale.titleLg.fontSize)
+        assertEquals(NuvioTokens.LineHeight.titleLg, scale.titleLg.lineHeight)
+        assertEquals(FontWeight.SemiBold, scale.titleLg.fontWeight)
+
+        assertEquals(NuvioTokens.Type.displaySm, scale.displaySm.fontSize)
+        assertEquals(NuvioTokens.LineHeight.displaySm, scale.displaySm.lineHeight)
+        assertEquals(FontWeight.Bold, scale.displaySm.fontWeight)
+
+        assertEquals(NuvioTokens.Type.displayMd, scale.displayMd.fontSize)
+        assertEquals(NuvioTokens.LineHeight.displayMd, scale.displayMd.lineHeight)
+        assertEquals(FontWeight.Bold, scale.displayMd.fontWeight)
+    }
+
+    @Test
+    fun createNuvioTypeScaleWithSystemDefaultFontUsesFontFamilyDefault() {
+        val scale = createNuvioTypeScale(FontFamily.Default)
+
+        assertEquals(FontFamily.Default, scale.labelXs.fontFamily)
+        assertEquals(FontFamily.Default, scale.labelSm.fontFamily)
+        assertEquals(FontFamily.Default, scale.bodySm.fontFamily)
+        assertEquals(FontFamily.Default, scale.bodyMd.fontFamily)
+        assertEquals(FontFamily.Default, scale.bodyLg.fontFamily)
+        assertEquals(FontFamily.Default, scale.titleSm.fontFamily)
+        assertEquals(FontFamily.Default, scale.titleMd.fontFamily)
+        assertEquals(FontFamily.Default, scale.titleLg.fontFamily)
+        assertEquals(FontFamily.Default, scale.displaySm.fontFamily)
+        assertEquals(FontFamily.Default, scale.displayMd.fontFamily)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/core/ui/PosterZoomActionOverlayTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/core/ui/PosterZoomActionOverlayTest.kt
@@ -1,0 +1,70 @@
+package com.nuvio.app.core.ui
+
+import androidx.compose.ui.AbsoluteAlignment
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.TransformOrigin
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class PosterZoomActionOverlayTest {
+
+    @Test
+    fun defaultTopStartAlignmentShiftsChildInRtl() {
+        val parentSize = IntSize(width = 1080, height = 2400)
+        val childSize = IntSize(width = 600, height = 900)
+
+        // In LTR, Alignment.TopStart positions the child at x = 0.
+        val ltrOffset = Alignment.TopStart.align(childSize, parentSize, LayoutDirection.Ltr)
+        assertEquals(IntOffset(0, 0), ltrOffset)
+
+        // In RTL, Alignment.TopStart positions the child at x = parentWidth - childWidth (480px).
+        // If the overlay relied on TopStart, graphicsLayer translationX would add to this 480px offset,
+        // shifting the poster 480px too far to the right.
+        val rtlOffset = Alignment.TopStart.align(childSize, parentSize, LayoutDirection.Rtl)
+        assertEquals(IntOffset(parentSize.width - childSize.width, 0), rtlOffset)
+    }
+
+    @Test
+    fun absoluteTopLeftAlignmentPositionsChildAtZeroInBothLtrAndRtl() {
+        val parentSize = IntSize(width = 1080, height = 2400)
+        val childSize = IntSize(width = 600, height = 900)
+
+        // AbsoluteAlignment.TopLeft guarantees layout position (0, 0) in LTR
+        val ltrOffset = AbsoluteAlignment.TopLeft.align(childSize, parentSize, LayoutDirection.Ltr)
+        assertEquals(IntOffset(0, 0), ltrOffset)
+
+        // AbsoluteAlignment.TopLeft guarantees layout position (0, 0) in RTL as well
+        val rtlOffset = AbsoluteAlignment.TopLeft.align(childSize, parentSize, LayoutDirection.Rtl)
+        assertEquals(IntOffset(0, 0), rtlOffset)
+    }
+
+    @Test
+    fun watchedBadgeTransformOriginAdaptsToLayoutDirection() {
+        // Alignment.TopEnd resolves to TopRight in LTR and TopLeft in RTL.
+        val ltrTopEnd = Alignment.TopEnd.align(IntSize(40, 40), IntSize(600, 900), LayoutDirection.Ltr)
+        assertEquals(IntOffset(600 - 40, 0), ltrTopEnd)
+
+        val rtlTopEnd = Alignment.TopEnd.align(IntSize(40, 40), IntSize(600, 900), LayoutDirection.Rtl)
+        assertEquals(IntOffset(0, 0), rtlTopEnd)
+
+        // The counter-scaling pivot must match the corner the badge is aligned to:
+        // In LTR: pinned to top-right corner -> pivot at (1f, 0f)
+        val ltrPivot = if (LayoutDirection.Ltr == LayoutDirection.Rtl) {
+            TransformOrigin(0f, 0f)
+        } else {
+            TransformOrigin(1f, 0f)
+        }
+        assertEquals(TransformOrigin(1f, 0f), ltrPivot)
+
+        // In RTL: pinned to top-left corner -> pivot at (0f, 0f)
+        val rtlPivot = if (LayoutDirection.Rtl == LayoutDirection.Rtl) {
+            TransformOrigin(0f, 0f)
+        } else {
+            TransformOrigin(1f, 0f)
+        }
+        assertEquals(TransformOrigin(0f, 0f), rtlPivot)
+    }
+}

--- a/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/nuvio/app/features/settings/ThemeSettingsStorage.ios.kt
@@ -17,6 +17,7 @@ actual object ThemeSettingsStorage {
     private const val liquidGlassNativeTabBarEnabledKey = "liquid_glass_native_tab_bar_enabled"
     private const val selectedAppLanguageKey = "selected_app_language"
     private const val navBarStyleKey = "nav_bar_style"
+    private const val useSystemFontKey = "use_system_font"
     private val profileScopedSyncKeys = listOf(
         selectedThemeKey,
         customThemeColorsKey,
@@ -104,6 +105,19 @@ actual object ThemeSettingsStorage {
 
     actual fun saveNavBarStyle(styleKey: String) {
         NSUserDefaults.standardUserDefaults.setObject(styleKey, forKey = ProfileScopedKey.of(navBarStyleKey))
+    }
+
+    actual fun loadUseSystemFont(): Boolean? {
+        val defaults = NSUserDefaults.standardUserDefaults
+        return if (defaults.objectForKey(useSystemFontKey) != null) {
+            defaults.boolForKey(useSystemFontKey)
+        } else {
+            null
+        }
+    }
+
+    actual fun saveUseSystemFont(enabled: Boolean) {
+        NSUserDefaults.standardUserDefaults.setBool(enabled, forKey = useSystemFontKey)
     }
 
     actual fun exportToSyncPayload(): JsonObject = buildJsonObject {


### PR DESCRIPTION
## Summary

- Added a new **Use System Font** setting that allows users to switch between the bundled JetBrains Sans font and the platform's default system font.
- The system font preference is device-local and is not synchronized between profiles/devices.
- Implemented the feature requested in #1852.
- Fixed an issue with the movie image preview during long-press interactions where the image could be incorrectly aligned in RTL languages such as Arabic.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [x] Approved larger or directional change

## Why

Allows users to use platform default system fonts on their devices and fixes movie poster preview alignment on long-press in RTL layouts such as Arabic.

## Issue or approval

Closes #1852

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [ ] Behavior changed only to fix a documented bug/regression
- [x] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

The system font preference is device-local and is not synchronized between profiles/devices. The bundled JetBrains Sans font remains the default.

## Testing

- Verified unit tests for theme settings storage, font selection, and poster zoom action overlay in LTR and RTL (`./gradlew :composeApp:testAndroidHostTest`).
- Verified Android compilation and build (`./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid` and `:androidApp:assembleFullDebug`).

## Screenshots / Video (UI changes only)

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td align="center">
      <img
        width="350"
        alt="Before - RTL movie poster preview alignment issue"
        src="https://github.com/user-attachments/assets/2765128b-3934-4785-83ea-495ed3a96b3e"
      />
    </td>
    <td align="center">
      <img
        width="350"
        alt="After - Fixed RTL movie poster preview alignment"
        src="https://github.com/user-attachments/assets/20f1af3f-57ab-4618-8bd0-4929eb00b12c"
      />
    </td>
  </tr>
</table>

## Breaking changes

None.

## Linked issues

Closes #1852

## Issue

Closes #1852

## Additional Fix

Also fixed the incorrect alignment of the movie image preview during the long-press interaction in RTL layouts.

## Verification

- Verified the relevant tests.
- Verified Android compilation/build.
- Confirm that all available PR/CI checks are passing before creating the PR.