### PR TITLE
fix(tracking): disable Continue Watching Window when Simkl is the active progress source

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/TrackingSettingsPage.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/settings/TrackingSettingsPage.kt
@@ -144,6 +144,7 @@ internal fun LazyListScope.trackingSettingsContent(
                     isTablet = isTablet,
                     settingsUiState = settingsUiState,
                     traktConnected = true,
+                    simklConnected = simklUiState.mode == SimklConnectionMode.CONNECTED,
                     commentsEnabled = commentsEnabled,
                     onCommentsEnabledChange = onCommentsEnabledChange,
                 )
@@ -287,11 +288,17 @@ private fun TrackingViewingAndDiscovery(
     isTablet: Boolean,
     settingsUiState: TrackingSettingsUiState,
     traktConnected: Boolean,
+    simklConnected: Boolean,
     commentsEnabled: Boolean,
     onCommentsEnabledChange: (Boolean) -> Unit,
 ) {
     var activePickerName by rememberSaveable { mutableStateOf<String?>(null) }
     val activePicker = activePickerName?.let(TrackingViewingPicker::valueOf)
+    val continueWatchingWindowEnabled = isTraktContinueWatchingWindowEnabled(
+        watchProgressSource = settingsUiState.watchProgressSource,
+        traktConnected = traktConnected,
+        simklConnected = simklConnected,
+    )
     val effectiveRecommendationsSource = effectiveTrackingRecommendationsSource(
         source = settingsUiState.moreLikeThisSource,
         traktConnected = traktConnected,
@@ -315,6 +322,7 @@ private fun TrackingViewingAndDiscovery(
             title = stringResource(Res.string.trakt_continue_watching_window),
             description = stringResource(Res.string.trakt_continue_watching_subtitle),
             value = continueWatchingDaysCapLabel(settingsUiState.continueWatchingDaysCap),
+            enabled = continueWatchingWindowEnabled,
             isTablet = isTablet,
             onClick = { activePickerName = TrackingViewingPicker.CONTINUE_WATCHING.name },
         )
@@ -373,6 +381,7 @@ private fun TrackingPreferenceActionRow(
     onClick: () -> Unit,
     supportingMessage: String? = null,
     isLoading: Boolean = false,
+    enabled: Boolean = true,
 ) {
     val tokens = MaterialTheme.nuvio
     SettingsNavigationRow(
@@ -381,6 +390,7 @@ private fun TrackingPreferenceActionRow(
             description,
             supportingMessage?.takeIf(String::isNotBlank),
         ).joinToString("\n"),
+        enabled = enabled,
         isTablet = isTablet,
         trailingContent = {
             Row(
@@ -576,6 +586,20 @@ internal fun effectiveTrackingRecommendationsSource(
     } else {
         source
     }
+
+internal fun isTraktContinueWatchingWindowEnabled(
+    watchProgressSource: WatchProgressSource,
+    traktConnected: Boolean,
+    simklConnected: Boolean,
+): Boolean {
+    val effectiveSource = effectiveWatchProgressSource(watchProgressSource) { provider ->
+        when (provider) {
+            TrackingProviderId.TRAKT -> traktConnected
+            TrackingProviderId.SIMKL -> simklConnected
+        }
+    }
+    return effectiveSource == WatchProgressSource.TRAKT
+}
 
 @Composable
 private fun AnimeIdPreferenceSection(

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/settings/TrackingSettingsPresentationTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/settings/TrackingSettingsPresentationTest.kt
@@ -1,6 +1,7 @@
 package com.nuvio.app.features.settings
 
 import com.nuvio.app.features.simkl.SimklConnectionMode
+import com.nuvio.app.features.tracking.WatchProgressSource
 import com.nuvio.app.features.trakt.MoreLikeThisSourcePreference
 import com.nuvio.app.features.trakt.TraktConnectionMode
 import kotlin.test.Test
@@ -60,5 +61,13 @@ class TrackingSettingsPresentationTest {
             effectiveTrackingRecommendationsSource(stored, traktConnected = true),
         )
         assertEquals(MoreLikeThisSourcePreference.TRAKT, stored)
+    }
+
+    @Test
+    fun `Trakt continue watching window is only enabled while Trakt is the active watch progress source`() {
+        assertTrue(isTraktContinueWatchingWindowEnabled(WatchProgressSource.TRAKT, true, false))
+        assertFalse(isTraktContinueWatchingWindowEnabled(WatchProgressSource.SIMKL, true, true))
+        assertFalse(isTraktContinueWatchingWindowEnabled(WatchProgressSource.SIMKL, true, false))
+        assertFalse(isTraktContinueWatchingWindowEnabled(WatchProgressSource.NUVIO_SYNC, true, false))
     }
 }


### PR DESCRIPTION
## Summary

The "Continue Watching Window" row on the Tracking settings page stayed active (clickable, not greyed out) even when Simkl was the active watch progress source. That setting only controls Trakt's own continue watching cutoff, so it has no effect once Simkl is active. This PR disables the row whenever Trakt is not the effective watch progress source.

## PR type

- [x] UI glitch/bug fix

## Why

The row's `enabled` state never accounted for which provider is actually resolving watch progress. It was gated only on "Trakt is connected," not on "Trakt is the active source." The setting itself, `continueWatchingDaysCap`, is consumed only by `TraktTrackingProgressProvider.continueWatchingCutoffEpochMs`. Every other provider (Simkl included) inherits the `TrackingProgressProvider` interface default, which ignores it. So the control was interactive while doing nothing.

## Issue or approval

Fixes #1903

## UI / behavior impact

- [x] UI changed only to fix a documented glitch/bug

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only the enabled state of the existing "Continue Watching Window" row is touched. No new UI, no copy changes, no unrelated settings rows changed.

## Testing

- Added a unit test in `TrackingSettingsPresentationTest` covering: Trakt active (enabled), Simkl active (disabled), Simkl selected but disconnected (disabled), and Nuvio local sync active (disabled).
- Ran `./gradlew :composeApp:testAndroidHostTest --tests "com.nuvio.app.features.settings.TrackingSettingsPresentationTest"`, all 4 tests pass.
- No emulator or device available in this environment to capture before/after screenshots. Behavior was verified by reading `WatchProgressRepository.activeProviderContinueWatchingCutoffEpochMs` and confirming only `TraktTrackingProgressProvider` overrides the cutoff. Happy to add screenshots if a maintainer requests them before merge.

## Screenshots / Video

Not captured. No emulator/device available in this environment. See the Testing section above for how the fix was verified instead.

## Breaking changes

None.

## Linked issues

Fixes #1903