### PR TITLE
perf(plugins): pause search during playback and match TV runtime

### DIFF
--- a/composeApp/src/androidFull/kotlin/com/nuvio/app/features/plugins/runtime/PluginRuntime.android.kt
+++ b/composeApp/src/androidFull/kotlin/com/nuvio/app/features/plugins/runtime/PluginRuntime.android.kt
@@ -1,0 +1,16 @@
+package com.nuvio.app.features.plugins.runtime
+
+import android.os.Process
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.asCoroutineDispatcher
+import java.util.concurrent.Executors
+
+internal val pluginDispatcher: CoroutineDispatcher =
+    Executors.newFixedThreadPool(MAX_CONCURRENT_PLUGINS) { runnable ->
+        Thread({
+            Process.setThreadPriority(Process.THREAD_PRIORITY_BACKGROUND)
+            runnable.run()
+        }, "plugin-worker").apply {
+            isDaemon = true
+        }
+    }.asCoroutineDispatcher()

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/features/addons/AddonPlatform.android.kt
@@ -4,9 +4,12 @@ import android.content.Context
 import android.content.SharedPreferences
 import com.nuvio.app.core.diagnostics.SentryNetworkBreadcrumbInterceptor
 import com.nuvio.app.core.network.IPv4FirstDns
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import java.io.IOException
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.network_empty_response_body
 import nuvio.composeapp.generated.resources.network_request_failed_http
@@ -294,17 +297,30 @@ actual suspend fun httpRequestRaw(
                 .build()
         }
 
-        client.newCall(request).execute().use { response ->
-            RawHttpResponse(
-                status = response.code,
-                statusText = response.message,
-                url = response.request.url.toString(),
-                body = readResponseBodyLimited(response.body, maxResponseBodyBytes),
-                headers = response.headers.toMultimap().mapValues { (_, values) ->
-                    values.joinToString(",")
-                }.mapKeys { (name, _) ->
-                    name.lowercase()
-                },
-            )
+        val call = client.newCall(request)
+        val cancelHandle = coroutineContext[Job]?.invokeOnCompletion { cause ->
+            if (cause is CancellationException) {
+                call.cancel()
+            }
+        }
+        try {
+            call.execute().use { response ->
+                RawHttpResponse(
+                    status = response.code,
+                    statusText = response.message,
+                    url = response.request.url.toString(),
+                    body = readResponseBodyLimited(response.body, maxResponseBodyBytes),
+                    headers = response.headers.toMultimap().mapValues { (_, values) ->
+                        values.joinToString(",")
+                    }.mapKeys { (name, _) ->
+                        name.lowercase()
+                    },
+                )
+            }
+        } catch (error: IOException) {
+            if (call.isCanceled()) throw CancellationException("Cancelled HTTP request", error)
+            throw error
+        } finally {
+            cancelHandle?.dispose()
         }
     }

--- a/composeApp/src/androidPlaystore/kotlin/com/nuvio/app/features/plugins/PluginRepository.android.kt
+++ b/composeApp/src/androidPlaystore/kotlin/com/nuvio/app/features/plugins/PluginRepository.android.kt
@@ -35,6 +35,8 @@ actual object PluginRepository {
 
     actual fun setGroupStreamsByRepository(enabled: Boolean) = Unit
 
+    actual fun setLocalPluginSearchPaused(paused: Boolean) = Unit
+
     actual fun getEnabledScrapersForType(type: String): List<PluginScraper> = emptyList()
 
     actual suspend fun testScraper(scraperId: String): Result<List<PluginRuntimeResult>> =

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/StreamDestination.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/StreamDestination.kt
@@ -333,6 +333,7 @@ internal fun StreamDestination(
             )
             if (playerSettings.externalPlayerEnabled) {
                 openExternalPlayback(playerLaunch)
+                StreamsRepository.cancelLoading()
                 StreamsRepository.setOverlayVisible(false)
                 reuseNavigated = true
                 return@LaunchedEffect

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeEffects.kt
@@ -342,6 +342,7 @@ internal fun PlayerScreenRuntime.BindPlayerRuntimeEffects() {
     }
 
     DisposableEffect(Unit) {
+        PlayerStreamsRepository.pauseSearchForPlayback()
         onDispose {
             playerController?.clearNowPlayingInfo()
             P2pStreamingEngine.shutdown()
@@ -677,67 +678,71 @@ internal fun PlayerScreenRuntime.tryRefreshCredentialedSourceAfterError(message:
     controlsVisible = !playerControlsLocked
 
     credentialRefreshJob = scope.launch {
-        PlayerStreamsRepository.loadSources(
-            type = type,
-            videoId = currentVideoId,
-            season = season,
-            episode = episode,
-            forceRefresh = true,
-        )
-
-        var refreshedStream: StreamItem? = null
-        var pollCount = 0
-        while (pollCount < CREDENTIAL_REFRESH_POLL_COUNT && refreshedStream == null) {
-            val state = PlayerStreamsRepository.sourceState.value
-            refreshedStream = findCredentialRefreshCandidate(
-                streams = state.groups.flatMap { it.streams },
-                failedUrl = failedUrl,
-                expectedProviderAddonId = expectedProviderAddonId,
-                expectedProviderName = expectedProviderName,
-                expectedStreamTitle = expectedStreamTitle,
-                expectedBingeGroup = expectedBingeGroup,
+        try {
+            PlayerStreamsRepository.loadSources(
+                type = type,
+                videoId = currentVideoId,
+                season = season,
+                episode = episode,
+                forceRefresh = true,
             )
-            if (
-                refreshedStream != null ||
-                state.emptyStateReason != null ||
-                (!state.isAnyLoading && state.groups.isNotEmpty())
-            ) {
-                break
+
+            var refreshedStream: StreamItem? = null
+            var pollCount = 0
+            while (pollCount < CREDENTIAL_REFRESH_POLL_COUNT && refreshedStream == null) {
+                val state = PlayerStreamsRepository.sourceState.value
+                refreshedStream = findCredentialRefreshCandidate(
+                    streams = state.groups.flatMap { it.streams },
+                    failedUrl = failedUrl,
+                    expectedProviderAddonId = expectedProviderAddonId,
+                    expectedProviderName = expectedProviderName,
+                    expectedStreamTitle = expectedStreamTitle,
+                    expectedBingeGroup = expectedBingeGroup,
+                )
+                if (
+                    refreshedStream != null ||
+                    state.emptyStateReason != null ||
+                    (!state.isAnyLoading && state.groups.isNotEmpty())
+                ) {
+                    break
+                }
+                delay(CREDENTIAL_REFRESH_POLL_INTERVAL_MS)
+                pollCount++
             }
-            delay(CREDENTIAL_REFRESH_POLL_INTERVAL_MS)
-            pollCount++
-        }
 
-        val stream = refreshedStream
-        if (stream == null) {
-            errorMessage = message
-            controlsVisible = !playerControlsLocked
-            return@launch
-        }
+            val stream = refreshedStream
+            if (stream == null) {
+                errorMessage = message
+                controlsVisible = !playerControlsLocked
+                return@launch
+            }
 
-        val refreshedUrl = stream.playableDirectUrl
-        if (refreshedUrl.isNullOrBlank() || refreshedUrl == failedUrl) {
-            errorMessage = message
-            controlsVisible = !playerControlsLocked
-            return@launch
-        }
+            val refreshedUrl = stream.playableDirectUrl
+            if (refreshedUrl.isNullOrBlank() || refreshedUrl == failedUrl) {
+                errorMessage = message
+                controlsVisible = !playerControlsLocked
+                return@launch
+            }
 
-        flushWatchProgress()
-        stopActiveP2pStream()
-        activeSourceUrl = refreshedUrl
-        activeSourceAudioUrl = null
-        activeSourceHeaders = sanitizePlaybackHeaders(stream.behaviorHints.proxyHeaders?.request)
-        activeSourceResponseHeaders = sanitizePlaybackResponseHeaders(stream.behaviorHints.proxyHeaders?.response)
-        activeStreamType = stream.streamType
-        activeStreamTitle = stream.streamLabel
-        activeStreamSubtitle = stream.streamSubtitle
-        activeProviderName = stream.addonName
-        activeProviderAddonId = stream.addonId
-        currentStreamBingeGroup = stream.behaviorHints.bingeGroup
-        activeInitialPositionMs = savedPositionMs
-        activeInitialProgressFraction = null
-        showSourcesPanel = false
-        controlsVisible = true
+            flushWatchProgress()
+            stopActiveP2pStream()
+            activeSourceUrl = refreshedUrl
+            activeSourceAudioUrl = null
+            activeSourceHeaders = sanitizePlaybackHeaders(stream.behaviorHints.proxyHeaders?.request)
+            activeSourceResponseHeaders = sanitizePlaybackResponseHeaders(stream.behaviorHints.proxyHeaders?.response)
+            activeStreamType = stream.streamType
+            activeStreamTitle = stream.streamLabel
+            activeStreamSubtitle = stream.streamSubtitle
+            activeProviderName = stream.addonName
+            activeProviderAddonId = stream.addonId
+            currentStreamBingeGroup = stream.behaviorHints.bingeGroup
+            activeInitialPositionMs = savedPositionMs
+            activeInitialProgressFraction = null
+            showSourcesPanel = false
+            controlsVisible = true
+        } finally {
+            PlayerStreamsRepository.stopSourcesLoading()
+        }
     }
     return true
 }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
@@ -57,6 +57,7 @@ internal fun PlayerScreenRuntime.openExternalSourceUrl(stream: StreamItem): Bool
     showSourcesPanel = false
     showEpisodesPanel = false
     controlsVisible = true
+    PlayerStreamsRepository.pauseSearchForPlayback()
     return true
 }
 
@@ -190,6 +191,7 @@ internal fun PlayerScreenRuntime.switchToP2pSourceStream(stream: StreamItem) {
     activeInitialProgressFraction = null
     showSourcesPanel = false
     controlsVisible = true
+    PlayerStreamsRepository.pauseSearchForPlayback()
 }
 
 internal fun PlayerScreenRuntime.switchToP2pEpisodeStream(
@@ -280,6 +282,7 @@ internal fun PlayerScreenRuntime.switchToSource(stream: StreamItem) {
     activeInitialProgressFraction = null
     showSourcesPanel = false
     controlsVisible = true
+    PlayerStreamsRepository.pauseSearchForPlayback()
 }
 
 internal fun PlayerScreenRuntime.switchToEpisodeStream(stream: StreamItem, episode: MetaVideo) {

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeUi.kt
@@ -301,6 +301,7 @@ private fun PlayerScreenRuntime.RenderPlayerControls(displayedPositionMs: Long, 
                                 lang = sub.language,
                             )
                         }
+                    PlayerStreamsRepository.pauseSearchForPlayback()
                     openExternal(
                         ExternalPlayerPlaybackRequest(
                             sourceUrl = activeSourceUrl,
@@ -517,6 +518,7 @@ private fun PlayerScreenRuntime.RenderPlayerModals(displayedPositionMs: Long) {
         },
         onSourcesPanelDismissed = {
             showSourcesPanel = false
+            PlayerStreamsRepository.stopSourcesLoading()
             controlsVisible = true
         },
         isSeries = isSeries,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerStreamList.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerStreamList.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -18,11 +19,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.nuvio.app.features.debrid.DebridSettingsRepository
+import com.nuvio.app.features.streams.LocalStreamSizeLabelFormat
 import com.nuvio.app.features.streams.StreamBadgeSettingsRepository
 import com.nuvio.app.features.streams.StreamCard
 import com.nuvio.app.features.streams.StreamItem
 import com.nuvio.app.features.streams.StreamsUiState
 import com.nuvio.app.features.streams.isSelectableForPlayback
+import com.nuvio.app.features.streams.rememberStreamSizeLabelFormat
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.compose_player_no_streams_found
 import org.jetbrains.compose.resources.stringResource
@@ -76,6 +79,8 @@ internal fun PlayerStreamList(
 
         else -> {
             val streamKeys = remember(streams) { streams.stablePlayerKeys() }
+            val formatStreamSize = rememberStreamSizeLabelFormat()
+            CompositionLocalProvider(LocalStreamSizeLabelFormat provides formatStreamSize) {
             LazyColumn(
                 modifier = modifier.fillMaxWidth(),
                 verticalArrangement = Arrangement.spacedBy(8.dp),
@@ -103,6 +108,7 @@ internal fun PlayerStreamList(
                         PlayerModalLoading(modifier = Modifier.padding(vertical = 16.dp))
                     }
                 }
+            }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerStreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerStreamsRepository.kt
@@ -104,6 +104,47 @@ object PlayerStreamsRepository {
         )
     }
 
+    fun stopSourcesLoading() {
+        PluginRepository.setLocalPluginSearchPaused(true)
+        cancelSourceJob()
+    }
+
+    fun pauseSearchForPlayback() {
+        PluginRepository.setLocalPluginSearchPaused(true)
+        cancelSourceJob()
+        cancelEpisodeStreamsJob()
+    }
+
+    private fun cancelSourceJob() {
+        val job = sourceJob ?: return
+        job.cancel()
+        sourceJob = null
+        sourceRequestKey = null
+        _sourceState.update { current ->
+            current.copy(
+                isAnyLoading = false,
+                groups = current.groups.map { group ->
+                    if (group.isLoading) group.copy(isLoading = false) else group
+                },
+            )
+        }
+    }
+
+    private fun cancelEpisodeStreamsJob() {
+        val job = episodeStreamsJob ?: return
+        job.cancel()
+        episodeStreamsJob = null
+        episodeStreamsRequestKey = null
+        _episodeStreamsState.update { current ->
+            current.copy(
+                isAnyLoading = false,
+                groups = current.groups.map { group ->
+                    if (group.isLoading) group.copy(isLoading = false) else group
+                },
+            )
+        }
+    }
+
     fun selectSourceFilter(addonId: String?) {
         _sourceState.update { it.copy(selectedFilter = addonId) }
     }
@@ -113,12 +154,14 @@ object PlayerStreamsRepository {
     }
 
     fun clearEpisodeStreams() {
+        PluginRepository.setLocalPluginSearchPaused(true)
         episodeStreamsJob?.cancel()
         episodeStreamsRequestKey = null
         _episodeStreamsState.value = StreamsUiState()
     }
 
     fun clearAll() {
+        PluginRepository.setLocalPluginSearchPaused(true)
         sourceJob?.cancel()
         sourceRequestKey = null
         _sourceState.value = StreamsUiState()
@@ -144,6 +187,7 @@ object PlayerStreamsRepository {
             PluginsUiState(pluginsEnabled = false)
         }
         val requestKey = "$type::$videoId::$season::$episode::pluginsGrouped=${pluginUiState.groupStreamsByRepository}"
+        PluginRepository.setLocalPluginSearchPaused(false)
         val current = stateFlow.value
         if (
             !forceRefresh &&

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
@@ -27,6 +27,8 @@ expect object PluginRepository {
 
     fun setGroupStreamsByRepository(enabled: Boolean)
 
+    fun setLocalPluginSearchPaused(paused: Boolean)
+
     fun getEnabledScrapersForType(type: String): List<PluginScraper>
 
     suspend fun testScraper(scraperId: String): Result<List<PluginRuntimeResult>>

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamBadgeChip.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamBadgeChip.kt
@@ -10,6 +10,8 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -27,6 +29,20 @@ import kotlin.math.round
 import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.streams_size
 import org.jetbrains.compose.resources.stringResource
+
+private const val STREAM_SIZE_PLACEHOLDER = "\uE000"
+
+internal val LocalStreamSizeLabelFormat = staticCompositionLocalOf<(String) -> String> {
+    { sizeLabel -> "SIZE $sizeLabel" }
+}
+
+@Composable
+internal fun rememberStreamSizeLabelFormat(): (String) -> String {
+    val template = stringResource(Res.string.streams_size, STREAM_SIZE_PLACEHOLDER)
+    return remember(template) {
+        { sizeLabel -> template.replace(STREAM_SIZE_PLACEHOLDER, sizeLabel) }
+    }
+}
 
 internal object StreamBadgeChipDefaults {
     val shape = RoundedCornerShape(NuvioTokens.Radius.sm)
@@ -140,7 +156,7 @@ internal fun StreamFileSizeBadge(stream: StreamItem) {
         contentAlignment = Alignment.Center,
     ) {
         Text(
-            text = stringResource(Res.string.streams_size, sizeLabel),
+            text = LocalStreamSizeLabelFormat.current(sizeLabel),
             style = MaterialTheme.typography.labelSmall.copy(
                 fontSize = StreamBadgeChipDefaults.fileSizeFontSize,
                 lineHeight = StreamBadgeChipDefaults.fileSizeLineHeight,

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamModels.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamModels.kt
@@ -1,10 +1,7 @@
 package com.nuvio.app.features.streams
 
 import com.nuvio.app.core.build.AppFeaturePolicy
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.Serializable
-import nuvio.composeapp.generated.resources.*
-import org.jetbrains.compose.resources.getString
 
 @Serializable
 data class StreamSubtitle(
@@ -35,7 +32,7 @@ data class StreamItem(
     val badges: List<StreamBadge> = emptyList(),
 ) {
     val streamLabel: String
-        get() = name ?: runBlocking { getString(Res.string.stream_default_name) }
+        get() = name?.takeIf { it.isNotBlank() } ?: "Stream"
 
     val streamSubtitle: String?
         get() = description

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsRepository.kt
@@ -48,6 +48,7 @@ object StreamsRepository {
         "$type::$videoId::$season::$episode::$manualSelection"
 
     fun load(type: String, videoId: String, parentMetaId: String? = null, season: Int? = null, episode: Int? = null, manualSelection: Boolean = false) {
+        PluginRepository.setLocalPluginSearchPaused(false)
         load(
             type = type,
             videoId = videoId,
@@ -60,6 +61,7 @@ object StreamsRepository {
     }
 
     fun reload(type: String, videoId: String, parentMetaId: String? = null, season: Int? = null, episode: Int? = null, manualSelection: Boolean = false) {
+        PluginRepository.setLocalPluginSearchPaused(false)
         load(
             type = type,
             videoId = videoId,
@@ -621,6 +623,7 @@ object StreamsRepository {
     }
 
     fun cancelLoading() {
+        PluginRepository.setLocalPluginSearchPaused(true)
         activeJob?.cancel()
         activeJob = null
         _uiState.update { current ->
@@ -644,6 +647,7 @@ object StreamsRepository {
     }
 
     fun clear() {
+        PluginRepository.setLocalPluginSearchPaused(true)
         activeJob?.cancel()
         activeJob = null
         activeRequestKey = null

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/streams/StreamsScreen.kt
@@ -47,6 +47,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -909,11 +910,16 @@ internal fun StreamList(
     val hasAnyStreams = filteredGroups.any { it.streams.isNotEmpty() }
     val anyLoading = filteredGroups.any { it.isLoading }
     val torrentNotSupportedText = stringResource(Res.string.streams_torrent_not_supported)
+    val fetchingText = stringResource(Res.string.streams_fetching)
+    val findingStreamsText = stringResource(Res.string.streams_finding_streams)
+    val checkingMoreAddonsText = stringResource(Res.string.streams_checking_more_addons)
+    val formatStreamSize = rememberStreamSizeLabelFormat()
     val streamBadgeSettings by remember {
         StreamBadgeSettingsRepository.ensureLoaded()
         StreamBadgeSettingsRepository.uiState
     }.collectAsStateWithLifecycle()
 
+    CompositionLocalProvider(LocalStreamSizeLabelFormat provides formatStreamSize) {
     LazyColumn(
         modifier = modifier.fillMaxWidth(),
         contentPadding = PaddingValues(
@@ -925,7 +931,7 @@ internal fun StreamList(
         when {
             hasGroups && anyLoading && !hasAnyStreams -> {
                 item {
-                    LoadingStateBlock()
+                    LoadingStateBlock(findingStreamsText = findingStreamsText)
                 }
             }
 
@@ -947,6 +953,7 @@ internal fun StreamList(
                         showAddonLogo = streamBadgeSettings.showAddonLogo,
                         badgePlacement = streamBadgeSettings.badgePlacement,
                         torrentNotSupportedText = torrentNotSupportedText,
+                        fetchingText = fetchingText,
                         onStreamSelected = onStreamSelected,
                         onStreamLongPress = onStreamLongPress,
                         resumePositionMs = resumePositionMs,
@@ -955,7 +962,7 @@ internal fun StreamList(
                 }
                 if (anyLoading) {
                     item {
-                        FooterLoadingBlock()
+                        FooterLoadingBlock(checkingMoreAddonsText = checkingMoreAddonsText)
                     }
                 }
                 item {
@@ -963,6 +970,7 @@ internal fun StreamList(
                 }
             }
         }
+    }
     }
 }
 
@@ -976,6 +984,7 @@ private fun LazyListScope.streamSection(
     showAddonLogo: Boolean,
     badgePlacement: StreamBadgePlacement,
     torrentNotSupportedText: String,
+    fetchingText: String,
     onStreamSelected: (stream: StreamItem, resumePositionMs: Long?, resumeProgressFraction: Float?) -> Unit,
     onStreamLongPress: (StreamItem) -> Unit,
     resumePositionMs: Long?,
@@ -988,6 +997,7 @@ private fun LazyListScope.streamSection(
             StreamSectionHeader(
                 addonName = group.addonName,
                 isLoading = group.isLoading,
+                fetchingText = fetchingText,
             )
         }
     }
@@ -1079,6 +1089,7 @@ internal fun streamCardRenderKey(
 private fun StreamSectionHeader(
     addonName: String,
     isLoading: Boolean,
+    fetchingText: String,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -1104,7 +1115,7 @@ private fun StreamSectionHeader(
                 )
                 Spacer(modifier = Modifier.width(6.dp))
                 Text(
-                    text = stringResource(Res.string.streams_fetching),
+                    text = fetchingText,
                     style = MaterialTheme.typography.labelSmall.copy(fontSize = 12.sp),
                     color = MaterialTheme.colorScheme.primary,
                 )
@@ -1255,7 +1266,10 @@ private fun Long.toPlaybackClock(): String {
 // ---------------------------------------------------------------------------
 
 @Composable
-private fun LoadingStateBlock(modifier: Modifier = Modifier) {
+private fun LoadingStateBlock(
+    findingStreamsText: String,
+    modifier: Modifier = Modifier,
+) {
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -1268,7 +1282,7 @@ private fun LoadingStateBlock(modifier: Modifier = Modifier) {
             modifier = Modifier.size(32.dp),
         )
         Text(
-            text = stringResource(Res.string.streams_finding_streams),
+            text = findingStreamsText,
             style = MaterialTheme.typography.bodySmall.copy(
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Medium,
@@ -1336,7 +1350,10 @@ private fun EmptyStateBlock(
 }
 
 @Composable
-private fun FooterLoadingBlock(modifier: Modifier = Modifier) {
+private fun FooterLoadingBlock(
+    checkingMoreAddonsText: String,
+    modifier: Modifier = Modifier,
+) {
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -1350,7 +1367,7 @@ private fun FooterLoadingBlock(modifier: Modifier = Modifier) {
         )
         Spacer(modifier = Modifier.width(8.dp))
         Text(
-            text = stringResource(Res.string.streams_checking_more_addons),
+            text = checkingMoreAddonsText,
             style = MaterialTheme.typography.bodySmall.copy(
                 fontSize = 12.sp,
                 fontWeight = FontWeight.Medium,

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/PluginRepository.kt
@@ -331,6 +331,10 @@ actual object PluginRepository {
         persist()
     }
 
+    actual fun setLocalPluginSearchPaused(paused: Boolean) {
+        PluginRuntime.setSearchPaused(paused)
+    }
+
     actual fun getEnabledScrapersForType(type: String): List<PluginScraper> {
         initialize()
         if (!_uiState.value.pluginsEnabled) return emptyList()
@@ -347,12 +351,13 @@ actual object PluginRepository {
         val mediaType = if (scraper.supportsType("movie")) "movie" else "tv"
         val season = if (mediaType == "tv") 1 else null
         val episode = if (mediaType == "tv") 1 else null
-        return executeScraper(
+        return executeScraperInternal(
             scraper = scraper,
             tmdbId = "603",
             mediaType = mediaType,
             season = season,
             episode = episode,
+            respectSearchPause = false,
         )
     }
 
@@ -362,6 +367,22 @@ actual object PluginRepository {
         mediaType: String,
         season: Int?,
         episode: Int?,
+    ): Result<List<PluginRuntimeResult>> = executeScraperInternal(
+        scraper = scraper,
+        tmdbId = tmdbId,
+        mediaType = mediaType,
+        season = season,
+        episode = episode,
+        respectSearchPause = true,
+    )
+
+    private suspend fun executeScraperInternal(
+        scraper: PluginScraper,
+        tmdbId: String,
+        mediaType: String,
+        season: Int?,
+        episode: Int?,
+        respectSearchPause: Boolean,
     ): Result<List<PluginRuntimeResult>> {
         val resolvedTmdbId = resolvePluginTmdbId(
             tmdbId = tmdbId,
@@ -376,6 +397,7 @@ actual object PluginRepository {
                 season = season,
                 episode = episode,
                 scraperId = scraper.id,
+                respectSearchPause = respectSearchPause,
             )
         }
     }

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/PluginRuntime.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/PluginRuntime.kt
@@ -8,13 +8,20 @@ import com.nuvio.app.features.plugins.runtime.host.HostApiRegistry
 import com.nuvio.app.features.plugins.runtime.host.HostFunctions
 import com.nuvio.app.features.plugins.runtime.js.JsBindings
 import com.nuvio.app.features.plugins.runtime.js.JsRuntime
-import com.dokar.quickjs.binding.function
 import com.nuvio.app.features.plugins.runtime.network.FetchBridge
 import com.nuvio.app.features.plugins.runtime.network.UrlBridge
 import com.nuvio.app.features.plugins.runtime.wasm.WasmBridge
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
-import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import kotlinx.serialization.json.Json
@@ -30,10 +37,17 @@ import nuvio.composeapp.generated.resources.Res
 import nuvio.composeapp.generated.resources.generic_unknown
 import org.jetbrains.compose.resources.getString
 
-private const val PLUGIN_TIMEOUT_MS = 60_000L
+internal const val MAX_CONCURRENT_PLUGINS = 10
+internal const val PLUGIN_TIMEOUT_MS = 60_000L
 
 internal object PluginRuntime {
     private val json = Json { ignoreUnknownKeys = true }
+    private val scraperSemaphore = Semaphore(MAX_CONCURRENT_PLUGINS)
+    private val searchPaused = MutableStateFlow(false)
+
+    fun setSearchPaused(paused: Boolean) {
+        searchPaused.value = paused
+    }
 
     suspend fun executePlugin(
         code: String,
@@ -42,77 +56,67 @@ internal object PluginRuntime {
         season: Int?,
         episode: Int?,
         scraperId: String,
-    ): List<PluginRuntimeResult> = withContext(Dispatchers.Default) {
-        val scraperSettingsJson = PluginStorage.loadScraperSettings(scraperId) ?: "{}"
-        val scraperSettingsMap = runCatching {
-            json.decodeFromString<Map<String, JsonElement>>(scraperSettingsJson)
-        }.getOrElse { emptyMap() }
+        respectSearchPause: Boolean = true,
+    ): List<PluginRuntimeResult> {
+        suspend fun run(): List<PluginRuntimeResult> {
+            val scraperSettingsJson = PluginStorage.loadScraperSettings(scraperId) ?: "{}"
+            val scraperSettingsMap = runCatching {
+                json.decodeFromString<Map<String, JsonElement>>(scraperSettingsJson)
+            }.getOrElse { emptyMap() }
 
-        withTimeout(PLUGIN_TIMEOUT_MS) {
-            executePluginInternal(
-                code = code,
-                tmdbId = tmdbId,
-                mediaType = mediaType,
-                season = season,
-                episode = episode,
-                scraperId = scraperId,
-                scraperSettings = scraperSettingsMap,
-            )
+            return scraperSemaphore.withPermit {
+                withContext(pluginDispatcher) {
+                    withTimeout(PLUGIN_TIMEOUT_MS) {
+                        executePluginInternal(
+                            code = code,
+                            tmdbId = tmdbId,
+                            mediaType = mediaType,
+                            season = season,
+                            episode = episode,
+                            scraperId = scraperId,
+                            scraperSettings = scraperSettingsMap,
+                        )
+                    }
+                }
+            }
+        }
+
+        return if (respectSearchPause) {
+            runWhenSearchActive { run() }
+        } else {
+            run()
         }
     }
 
     suspend fun getPluginSettingsLayout(
         code: String,
         scraperId: String,
-    ): String? = withContext(Dispatchers.Default) {
-        withTimeout(PLUGIN_TIMEOUT_MS) {
-            val jsRuntime = JsRuntime()
-            val deferred = CompletableDeferred<String?>()
+    ): String? = scraperSemaphore.withPermit {
+        withContext(pluginDispatcher) {
+            withTimeout(PLUGIN_TIMEOUT_MS) {
+                val jsRuntime = JsRuntime()
+                val deferred = CompletableDeferred<String?>()
+                try {
+                    jsRuntime.use {
+                        HostFunctions(
+                            scraperId = scraperId,
+                            scraperSettingsJson = "{}",
+                            onResult = { deferred.complete(it) },
+                        ).register(this)
+                        FetchBridge().register(this)
+                        UrlBridge().register(this)
+                        CryptoBridge().register(this)
 
-            try {
-                jsRuntime.use {
-                    val polyfillCode = JsBindings.buildPolyfillCode(
-                        scraperIdJson = JsonPrimitive(scraperId).toString(),
-                        settingsJson = "{}"
-                    )
-                    evaluate<Any?>(polyfillCode)
-
-                    val wrappedCode = """
-                        var module = { exports: {} };
-                        var exports = module.exports;
-                        (function() {
-                            $code
-                        })();
-                    """.trimIndent()
-                    evaluate<Any?>(wrappedCode)
-
-                    val callCode = """
-                        (async function() {
-                            try {
-                                var onSettings = (typeof module !== 'undefined' && module.exports && module.exports.onSettings) || globalThis.onSettings;
-                                if (typeof onSettings === 'function') {
-                                    var layout = await onSettings();
-                                    __capture_settings_result(JSON.stringify(layout || []));
-                                } else {
-                                    __capture_settings_result("[]");
-                                }
-                            } catch (e) {
-                                console.error("onSettings error:", e);
-                                __capture_settings_result("[]");
-                            }
-                        })();
-                    """.trimIndent()
-                    
-                    function("__capture_settings_result") { args: Array<Any?> ->
-                        deferred.complete(args.getOrNull(0)?.toString())
-                        null
+                        evaluateCached({ JsRuntime.polyfillBytecode(this) }, JsBindings.staticPolyfillCode)
+                        evaluate<Any?>(wrapPluginModule(code))
+                        evaluateCached({ JsRuntime.settingsCallBytecode(this) }, JsBindings.staticSettingsCallCode)
+                        deferred.await()
                     }
-                    
-                    evaluate<Any?>(callCode)
-                    deferred.await()
+                } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                    throw cancelled
+                } catch (_: Exception) {
+                    null
                 }
-            } catch (e: Exception) {
-                null
             }
         }
     }
@@ -128,10 +132,26 @@ internal object PluginRuntime {
     ): List<PluginRuntimeResult> {
         val jsRuntime = JsRuntime()
         val deferred = CompletableDeferred<String>()
+        val settingsJson = JsonObject(scraperSettings).toString()
+        val callArgsJson = JsonObject(
+            mapOf(
+                "tmdbId" to JsonPrimitive(tmdbId),
+                "mediaType" to JsonPrimitive(mediaType),
+                "season" to (season?.let(::JsonPrimitive) ?: JsonNull),
+                "episode" to (episode?.let(::JsonPrimitive) ?: JsonNull),
+            ),
+        ).toString()
 
         val domBridge = DomBridge()
         val hostRegistry = HostApiRegistry().apply {
-            addModule(HostFunctions(scraperId) { deferred.complete(it) })
+            addModule(
+                HostFunctions(
+                    scraperId = scraperId,
+                    scraperSettingsJson = settingsJson,
+                    callArgsJson = callArgsJson,
+                    onResult = { deferred.complete(it) },
+                ),
+            )
             addModule(FetchBridge())
             addModule(UrlBridge())
             addModule(CryptoBridge())
@@ -142,53 +162,34 @@ internal object PluginRuntime {
         try {
             jsRuntime.use {
                 hostRegistry.registerAll(this)
-
-                val settingsJson = JsonObject(scraperSettings).toString()
-                val polyfillCode = JsBindings.buildPolyfillCode(
-                    scraperIdJson = JsonPrimitive(scraperId).toString(),
-                    settingsJson = settingsJson,
-                )
-                evaluate<Any?>(polyfillCode)
-
-                val wrappedCode = """
-                    var module = { exports: {} };
-                    var exports = module.exports;
-                    (function() {
-                        $code
-                    })();
-                """.trimIndent()
-                evaluate<Any?>(wrappedCode)
-
-                val tmdbIdArg = JsonPrimitive(tmdbId).toString()
-                val mediaTypeArg = JsonPrimitive(mediaType).toString()
-                val seasonArg = season?.toString() ?: "undefined"
-                val episodeArg = episode?.toString() ?: "undefined"
-                val callCode = """
-                    (async function() {
-                        try {
-                            var getStreams = module.exports.getStreams || globalThis.getStreams;
-                            if (!getStreams) {
-                                console.error("getStreams function not found on module.exports or globalThis");
-                                __capture_result(JSON.stringify([]));
-                                return;
-                            }
-                            var result = await getStreams($tmdbIdArg, $mediaTypeArg, $seasonArg, $episodeArg);
-                            __capture_result(JSON.stringify(result || []));
-                        } catch (e) {
-                            console.error("getStreams error:", e && e.message ? e.message : e, e && e.stack ? e.stack : "");
-                            __capture_result(JSON.stringify([]));
-                        }
-                    })();
-                """.trimIndent()
-                evaluate<Any?>(callCode)
-                
+                evaluateCached({ JsRuntime.polyfillBytecode(this) }, JsBindings.staticPolyfillCode)
+                evaluate<Any?>(wrapPluginModule(code))
+                evaluateCached({ JsRuntime.callBytecode(this) }, JsBindings.staticCallCode)
                 deferred.await()
             }
-            
-            // Result is captured inside use block, but returned outside to satisfy compiler
             return parseJsonResults(deferred.await())
         } finally {
             domBridge.clear()
+        }
+    }
+
+    private fun wrapPluginModule(code: String): String = """
+        var module = { exports: {} };
+        var exports = module.exports;
+        (function() {
+            $code
+        })();
+    """.trimIndent()
+
+    private suspend fun com.dokar.quickjs.QuickJs.evaluateCached(
+        bytecode: com.dokar.quickjs.QuickJs.() -> ByteArray,
+        source: String,
+    ) {
+        val compiled = runCatching { bytecode() }.getOrNull()
+        if (compiled != null) {
+            evaluate<Any?>(compiled)
+        } else {
+            evaluate<Any?>(source)
         }
     }
 
@@ -251,22 +252,30 @@ internal object PluginRuntime {
     private fun JsonObject.stringOrNull(key: String): String? =
         this[key]?.jsonPrimitive?.contentOrNull?.takeIf { it.isNotBlank() && !it.contains("[object") }
 
-    private fun toJsonElement(value: Any?): JsonElement = when (value) {
-        null -> JsonNull
-        is JsonElement -> value
-        is String -> JsonPrimitive(value)
-        is Boolean -> JsonPrimitive(value)
-        is Int -> JsonPrimitive(value)
-        is Long -> JsonPrimitive(value)
-        is Float -> JsonPrimitive(value)
-        is Double -> JsonPrimitive(value)
-        is Number -> JsonPrimitive(value.toDouble())
-        is Map<*, *> -> JsonObject(
-            value.entries
-                .filter { it.key is String }
-                .associate { (it.key as String) to toJsonElement(it.value) },
-        )
-        is Iterable<*> -> JsonArray(value.map(::toJsonElement))
-        else -> JsonPrimitive(value.toString())
+    private suspend fun <T> runWhenSearchActive(block: suspend () -> T): T {
+        while (true) {
+            searchPaused.first { !it }
+            try {
+                return coroutineScope {
+                    val watcher = launch {
+                        searchPaused.first { it }
+                        throw CancellationException(PAUSED_MESSAGE)
+                    }
+                    try {
+                        block()
+                    } finally {
+                        watcher.cancel()
+                    }
+                }
+            } catch (cancelled: CancellationException) {
+                currentCoroutineContext().ensureActive()
+                if (searchPaused.value || cancelled.message == PAUSED_MESSAGE) {
+                    continue
+                }
+                throw cancelled
+            }
+        }
     }
+
+    private const val PAUSED_MESSAGE = "plugin-search-paused"
 }

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/dom/DomBridge.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/dom/DomBridge.kt
@@ -12,6 +12,7 @@ import kotlin.random.Random
 internal class DomBridge : HostModule {
     private val documentCache = mutableMapOf<String, Document>()
     private val elementCache = mutableMapOf<String, Element>()
+    private val loadedDocIds = mutableListOf<String>()
     private var idCounter = 0
     private val containsRegex = Regex(""":contains\([\"']([^\"']+)[\"']\)""")
 
@@ -20,6 +21,8 @@ internal class DomBridge : HostModule {
             val html = args.getOrNull(0)?.toString() ?: ""
             val docId = "doc_${idCounter++}_${Random.nextInt(0, Int.MAX_VALUE)}"
             documentCache[docId] = Ksoup.parse(html)
+            loadedDocIds.add(docId)
+            evictOldestDocumentsIfNeeded()
             docId
         }
 
@@ -114,5 +117,19 @@ internal class DomBridge : HostModule {
     fun clear() {
         documentCache.clear()
         elementCache.clear()
+        loadedDocIds.clear()
+    }
+
+    private fun evictOldestDocumentsIfNeeded() {
+        while (loadedDocIds.size > MAX_CACHED_DOCUMENTS) {
+            val evictedId = loadedDocIds.removeAt(0)
+            documentCache.remove(evictedId)
+            val staleKeys = elementCache.keys.filter { it.startsWith("$evictedId:") }
+            staleKeys.forEach { elementCache.remove(it) }
+        }
+    }
+
+    private companion object {
+        const val MAX_CACHED_DOCUMENTS = 8
     }
 }

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/host/HostFunctions.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/host/HostFunctions.kt
@@ -7,7 +7,9 @@ import com.dokar.quickjs.binding.function
 
 internal class HostFunctions(
     private val scraperId: String,
-    private val onResult: (String) -> Unit
+    private val scraperSettingsJson: String,
+    private val callArgsJson: String = "{}",
+    private val onResult: (String) -> Unit,
 ) : HostModule {
     private val log = Logger.withTag("PluginRuntime")
 
@@ -35,6 +37,9 @@ internal class HostFunctions(
             }
         }
 
+        runtime.function("__get_scraper_id") { scraperId }
+        runtime.function("__get_scraper_settings") { scraperSettingsJson }
+        runtime.function("__get_call_args") { callArgsJson }
         runtime.function("__capture_result") { args ->
             onResult(args.getOrNull(0)?.toString() ?: "[]")
             null

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/js/JsBindings.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/js/JsBindings.kt
@@ -1,10 +1,9 @@
 package com.nuvio.app.features.plugins.runtime.js
 
 internal object JsBindings {
-    fun buildPolyfillCode(scraperIdJson: String, settingsJson: String): String {
-        return """
-            globalThis.SCRAPER_ID = $scraperIdJson;
-            globalThis.SCRAPER_SETTINGS = $settingsJson;
+    val staticPolyfillCode: String = """
+            globalThis.SCRAPER_ID = __get_scraper_id();
+            globalThis.SCRAPER_SETTINGS = JSON.parse(__get_scraper_settings());
             if (typeof globalThis.global === 'undefined') globalThis.global = globalThis;
             if (typeof globalThis.window === 'undefined') globalThis.window = globalThis;
             if (typeof globalThis.self === 'undefined') globalThis.self = globalThis;
@@ -21,7 +20,44 @@ internal object JsBindings {
             ${objectPolyfill()}
             ${stringPolyfill()}
         """.trimIndent()
-    }
+
+    val staticCallCode: String = """
+            (async function() {
+                try {
+                    var getStreams = module.exports.getStreams || globalThis.getStreams;
+                    if (!getStreams) {
+                        console.error("getStreams function not found on module.exports or globalThis");
+                        __capture_result(JSON.stringify([]));
+                        return;
+                    }
+                    var args = JSON.parse(__get_call_args());
+                    var season = args.season == null ? undefined : args.season;
+                    var episode = args.episode == null ? undefined : args.episode;
+                    var result = await getStreams(args.tmdbId, args.mediaType, season, episode);
+                    __capture_result(JSON.stringify(result || []));
+                } catch (e) {
+                    console.error("getStreams error:", e && e.message ? e.message : e, e && e.stack ? e.stack : "");
+                    __capture_result(JSON.stringify([]));
+                }
+            })();
+        """.trimIndent()
+
+    val staticSettingsCallCode: String = """
+            (async function() {
+                try {
+                    var onSettings = (typeof module !== 'undefined' && module.exports && module.exports.onSettings) || globalThis.onSettings;
+                    if (typeof onSettings === 'function') {
+                        var layout = await onSettings();
+                        __capture_result(JSON.stringify(layout || []));
+                    } else {
+                        __capture_result("[]");
+                    }
+                } catch (e) {
+                    console.error("onSettings error:", e);
+                    __capture_result("[]");
+                }
+            })();
+        """.trimIndent()
 
     private fun fetchPolyfill() = """
         function __normalize_fetch_headers(headers) {
@@ -47,7 +83,7 @@ internal object JsBindings {
             var headers = __normalize_fetch_headers(options.headers);
             var body = options.body || '';
             var followRedirects = options.redirect !== 'manual';
-            var result = __native_fetch(url, method, JSON.stringify(headers), body, followRedirects);
+            var result = await __native_fetch(url, method, JSON.stringify(headers), body, followRedirects);
             var parsed = JSON.parse(result);
             return {
                 ok: parsed.ok,

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/js/JsRuntime.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/js/JsRuntime.kt
@@ -2,15 +2,46 @@ package com.nuvio.app.features.plugins.runtime.js
 
 import com.dokar.quickjs.QuickJs
 import com.dokar.quickjs.quickJs
+import com.nuvio.app.features.plugins.runtime.PLUGIN_TIMEOUT_MS
+import com.nuvio.app.features.plugins.runtime.pluginDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.ContinuationInterceptor
+import kotlin.coroutines.coroutineContext
 
-internal class JsRuntime(
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
-) {
+internal class JsRuntime {
     suspend fun <T> use(block: suspend QuickJs.() -> T): T {
+        val dispatcher = (coroutineContext[ContinuationInterceptor] as? CoroutineDispatcher)
+            ?: pluginDispatcher
         return quickJs(dispatcher) {
+            evaluationTimeoutMillis = PLUGIN_TIMEOUT_MS
             block()
         }
+    }
+
+    companion object {
+        @Volatile
+        private var cachedPolyfillBytecode: ByteArray? = null
+
+        @Volatile
+        private var cachedCallBytecode: ByteArray? = null
+
+        @Volatile
+        private var cachedSettingsCallBytecode: ByteArray? = null
+
+        fun polyfillBytecode(runtime: QuickJs): ByteArray =
+            cachedPolyfillBytecode ?: runtime.compile(JsBindings.staticPolyfillCode, "polyfill.js", false).also {
+                cachedPolyfillBytecode = it
+            }
+
+        fun callBytecode(runtime: QuickJs): ByteArray =
+            cachedCallBytecode ?: runtime.compile(JsBindings.staticCallCode, "call.js", false).also {
+                cachedCallBytecode = it
+            }
+
+        fun settingsCallBytecode(runtime: QuickJs): ByteArray =
+            cachedSettingsCallBytecode
+                ?: runtime.compile(JsBindings.staticSettingsCallCode, "settings-call.js", false).also {
+                    cachedSettingsCallBytecode = it
+                }
     }
 }

--- a/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/network/FetchBridge.kt
+++ b/composeApp/src/fullCommonMain/kotlin/com/nuvio/app/features/plugins/runtime/network/FetchBridge.kt
@@ -2,10 +2,9 @@ package com.nuvio.app.features.plugins.runtime.network
 
 import co.touchlab.kermit.Logger
 import com.dokar.quickjs.QuickJs
-import com.dokar.quickjs.binding.function
+import com.dokar.quickjs.binding.asyncFunction
 import com.nuvio.app.features.addons.httpRequestRaw
 import com.nuvio.app.features.plugins.runtime.host.HostModule
-import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
@@ -20,7 +19,7 @@ internal class FetchBridge : HostModule {
     private val json = Json { ignoreUnknownKeys = true }
 
     override fun register(runtime: QuickJs) {
-        runtime.function("__native_fetch") { args ->
+        runtime.asyncFunction("__native_fetch") { args ->
             val url = args.getOrNull(0)?.toString() ?: ""
             val method = args.getOrNull(1)?.toString() ?: "GET"
             val headersJson = args.getOrNull(2)?.toString() ?: "{}"
@@ -28,6 +27,8 @@ internal class FetchBridge : HostModule {
             val followRedirects = args.getOrNull(4) as? Boolean ?: true
             try {
                 performNativeFetch(url, method, headersJson, body, followRedirects)
+            } catch (cancelled: kotlinx.coroutines.CancellationException) {
+                throw cancelled
             } catch (t: Throwable) {
                 log.e(t) { "Fetch bridge error for $method $url" }
                 JsonObject(
@@ -44,7 +45,7 @@ internal class FetchBridge : HostModule {
         }
     }
 
-    private fun performNativeFetch(
+    private suspend fun performNativeFetch(
         url: String,
         method: String,
         headersJson: String,
@@ -56,15 +57,13 @@ internal class FetchBridge : HostModule {
             headers["User-Agent"] = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
         }
 
-        val response = runBlocking {
-            httpRequestRaw(
-                method = method,
-                url = url,
-                headers = headers,
-                body = body,
-                followRedirects = followRedirects,
-            )
-        }
+        val response = httpRequestRaw(
+            method = method,
+            url = url,
+            headers = headers,
+            body = body,
+            followRedirects = followRedirects,
+        )
 
         val responseHeaders = response.headers.mapKeys { (key, _) -> key.lowercase() }
             .mapValues { (_, value) -> truncateString(value, MAX_FETCH_HEADER_VALUE_CHARS) }
@@ -72,8 +71,8 @@ internal class FetchBridge : HostModule {
             mapOf(
                 "ok" to JsonPrimitive(response.status in 200..299),
                 "status" to JsonPrimitive(response.status),
-                "statusText" to JsonPrimitive(response.statusText),
                 "url" to JsonPrimitive(response.url),
+                "statusText" to JsonPrimitive(response.statusText),
                 "body" to JsonPrimitive(response.body),
                 "headers" to JsonObject(responseHeaders.mapValues { JsonPrimitive(it.value) }),
             ),

--- a/composeApp/src/iosAppStore/kotlin/com/nuvio/app/features/plugins/PluginRepository.ios.kt
+++ b/composeApp/src/iosAppStore/kotlin/com/nuvio/app/features/plugins/PluginRepository.ios.kt
@@ -35,6 +35,8 @@ actual object PluginRepository {
 
     actual fun setGroupStreamsByRepository(enabled: Boolean) = Unit
 
+    actual fun setLocalPluginSearchPaused(paused: Boolean) = Unit
+
     actual fun getEnabledScrapersForType(type: String): List<PluginScraper> = emptyList()
 
     actual suspend fun testScraper(scraperId: String): Result<List<PluginRuntimeResult>> =

--- a/composeApp/src/iosFull/kotlin/com/nuvio/app/features/plugins/runtime/PluginRuntime.ios.kt
+++ b/composeApp/src/iosFull/kotlin/com/nuvio/app/features/plugins/runtime/PluginRuntime.ios.kt
@@ -1,0 +1,10 @@
+package com.nuvio.app.features.plugins.runtime
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.IO
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal val pluginDispatcher: CoroutineDispatcher =
+    Dispatchers.IO.limitedParallelism(MAX_CONCURRENT_PLUGINS)


### PR DESCRIPTION

## Summary

- Port the NuvioTV plugin runtime model to mobile: a bounded background scraper pool, one-shot bytecode for the static polyfill/call scripts, OkHttp cancellation when the coroutine cancels, and an LRU DOM cache.
- Pause local plugin search when playback is the focus (player start, source/episode switch, panel dismiss, external player). Resume it for the streams screen, sources panel, next-episode search, and credential refresh.
- Keep addon HTTP fetches running. Plugin settings/test scrapers ignore the playback pause gate.
- Stop calling Compose Multiplatform `stringResource` inside stream LazyColumn items. That API uses `runBlocking` on the main thread; under plugin load it ANR'd the streams list.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [x] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

On weak phones, local plugin search kept using unbounded Default work, recompiled a large JS polyfill per scraper, and continued after the player started. TV already pauses that search during playback. Mobile did not, so the device stayed busy during watch.

Tapping the streams list then hit an ANR: main thread parked in `stringResource` -> `runBlocking` while composing section headers, waiting on a saturated Default dispatcher. DropBox on Xiaomi `24129PN74G` recorded input dispatch timeout (5000ms MotionEvent DOWN) in `StreamSectionHeader`.

## Issue or approval
reproduced on a physical Xiaomi `24129PN74G` (`com.nuviodebug.com`) during plugin search and internal playback. No GitHub issue was opened; this restores the existing TV pause/runtime behavior and unblocks the streams list.

## UI / behavior impact

- [x] No UI change
- [ ] No behavior change
- [ ] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

- Addon HTTP stream fetches are not paused; only local plugin scrapers are.
- Plugin settings UI and `testScraper` are not gated by player pause.
- Crypto-js WebJar and TMDB key injection from TV were not ported.
- Stream list copy is unchanged; only where those strings are resolved.

## Testing

- `:androidApp:compileFullDebugKotlin` succeeded after the runtime, pause, and ANR changes.
- Installed full debug on Xiaomi `24129PN74G` (`c49108`), package `com.nuviodebug.com`. TV device was not used.
- Confirmed the ANR dump: `data_app_anr` at 2026-09-11 16:51, process `com.nuviodebug.com`, main thread TimedWaiting in `stringResource` / `runBlocking` during `StreamsScreen` LazyList measure.
- Manual intent: start playback from the streams screen and confirm local scrapers stop; open sources / next-episode search and confirm they run again; tap the streams list while plugins are fetching and confirm it still scrolls.

## Screenshots / Video

Not a UI change

## Breaking changes

None

## Linked issues
 local plugin search did not pause when the internal or external player started, unlike TV, so scrapers kept burning CPU during playback. On the streams screen the same load ANR'd the UI: main thread blocked in Compose `stringResource` `runBlocking` inside `StreamSectionHeader` while Default/OkHttp workers were busy (plugin hosts, TMDB, addon fetches). This PR documents that device-reproduced failure and restores TV pause plus a bounded plugin runtime so the list stays responsive.
