### PR TITLE
fix(updater): remove readTimeout from APK download client on Android

### DIFF
--- a/composeApp/src/androidFull/kotlin/com/nuvio/app/features/updater/AndroidAppUpdaterPlatform.kt
+++ b/composeApp/src/androidFull/kotlin/com/nuvio/app/features/updater/AndroidAppUpdaterPlatform.kt
@@ -27,8 +27,7 @@ object AndroidAppUpdaterPlatform {
 
     private val httpClient = OkHttpClient.Builder()
         .connectTimeout(60, TimeUnit.SECONDS)
-        .readTimeout(60, TimeUnit.SECONDS)
-        .writeTimeout(60, TimeUnit.SECONDS)
+        // No readTimeout — applies per chunk, not per download; kills slow streams.
         .followRedirects(true)
         .followSslRedirects(true)
         .build()


### PR DESCRIPTION
## Summary

Remove `readTimeout` from the `OkHttpClient` used to download APK updates on Android. `connectTimeout` is kept. This mirrors how the desktop updater already works.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [x] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

OkHttp enforces `readTimeout` per socket `read()` call, not per full download. On a slow network a single chunk can take longer than the 60 s limit, causing a `SocketTimeoutException` mid-stream. The desktop updater uses `java.net.http.HttpClient` with no read timeout for exactly this reason. Removing `readTimeout` from the Android download client brings it in line with the desktop implementation.

## Issue or approval

No linked issue: single-line removal matching existing desktop behaviour, no user-visible change.

## UI / behavior impact

- [x] No UI change
- [x] No behavior change

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

Only `AndroidAppUpdaterPlatform.kt` is changed. No UI, no other logic, no other platforms touched. TV is a separate repo and is out of scope.

## Testing

- Built `assembleFullDebug` successfully, no errors.
- Change is a strict constraint removal; it cannot cause a new failure path.
- Manual slow-network test recommended before release: throttle to ~100 Kbps and trigger an update download.

## Screenshots / Video

Not a UI change. No screenshots required.

## Breaking changes

None.

## Linked issues

No linked issue: single-line maintenance fix matching existing desktop behaviour.