### PR TITLE
fix(android): correct bottom navigation behavior in RTL

### DIFF
--- a/composeApp/src/androidHostTest/kotlin/com/nuvio/app/core/ui/FloatingNavigationBarRtlTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/com/nuvio/app/core/ui/FloatingNavigationBarRtlTest.kt
@@ -1,0 +1,187 @@
+package com.nuvio.app.core.ui
+
+import com.nuvio.app.core.ui.jelly.JellyMotion
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FloatingNavigationBarRtlTest {
+
+    private fun settle(motion: JellyMotion) {
+        repeat(120) {
+            motion.advance(1.0 / 60)
+        }
+    }
+
+    @Test
+    fun `visualNavIndex maps LTR destinations to identity positions`() {
+        val count = 4
+        // LTR first item
+        assertEquals(0, visualNavIndex(logicalIndex = 0, count = count, isRtl = false))
+        // LTR middle items
+        assertEquals(1, visualNavIndex(logicalIndex = 1, count = count, isRtl = false))
+        assertEquals(2, visualNavIndex(logicalIndex = 2, count = count, isRtl = false))
+        // LTR last item
+        assertEquals(3, visualNavIndex(logicalIndex = 3, count = count, isRtl = false))
+    }
+
+    @Test
+    fun `visualNavIndex maps RTL destinations to mirrored positions`() {
+        val count = 4
+        // RTL first logical destination (Home) is visually on the far right (index 3)
+        assertEquals(3, visualNavIndex(logicalIndex = 0, count = count, isRtl = true))
+        // RTL middle destinations (Search and Library)
+        assertEquals(2, visualNavIndex(logicalIndex = 1, count = count, isRtl = true))
+        assertEquals(1, visualNavIndex(logicalIndex = 2, count = count, isRtl = true))
+        // RTL last logical destination (Settings) is visually on the far left (index 0)
+        assertEquals(0, visualNavIndex(logicalIndex = 3, count = count, isRtl = true))
+    }
+
+    @Test
+    fun `logicalNavIndex correctly restores logical destination from visual touch position in RTL and LTR`() {
+        val count = 4
+        for (isRtl in listOf(false, true)) {
+            for (logical in 0 until count) {
+                val visual = visualNavIndex(logical, count, isRtl)
+                val restored = logicalNavIndex(visual, count, isRtl)
+                assertEquals(logical, restored, "Mismatch for logical=$logical, isRtl=$isRtl")
+            }
+        }
+    }
+
+    @Test
+    fun `visual and logical mapping handles boundary conditions gracefully`() {
+        val count = 4
+        assertEquals(-1, visualNavIndex(-1, count, isRtl = true))
+        assertEquals(-1, visualNavIndex(-1, count, isRtl = false))
+        assertEquals(-1, logicalNavIndex(-1, count, isRtl = true))
+        assertEquals(10, visualNavIndex(10, count, isRtl = true))
+    }
+
+    @Test
+    fun `RTL JellyMotion indicator positions and animates in correct direction`() {
+        val count = 4
+        // Initial logical destination is Home (0) -> in RTL, visual position is 3 (rightmost)
+        val initialVisual = visualNavIndex(0, count, isRtl = true)
+        val motion = JellyMotion(initialVisual, count)
+        motion.resize(320f, 64f, count)
+        assertEquals(3f, motion.frame.position)
+
+        // Navigate to Search (logical 1) -> in RTL, visual target is 2 (moving right to left)
+        val searchVisual = visualNavIndex(1, count, isRtl = true)
+        motion.select(searchVisual)
+        // Advance slightly to check direction of animation
+        motion.advance(1.0 / 60)
+        assertTrue(motion.frame.position < 3f, "Indicator should move to the left (decreasing position)")
+
+        settle(motion)
+        assertEquals(2f, motion.frame.position, 0.001f, "Active indicator must match Search visual destination")
+
+        // Navigate to Settings (logical 3) -> in RTL, visual target is 0 (far left)
+        val settingsVisual = visualNavIndex(3, count, isRtl = true)
+        motion.select(settingsVisual)
+        settle(motion)
+        assertEquals(0f, motion.frame.position, 0.001f, "Active indicator must match Settings visual destination")
+
+        // Navigate back to Home (logical 0) -> in RTL, visual target is 3 (moving left to right)
+        motion.select(initialVisual)
+        motion.advance(1.0 / 60)
+        assertTrue(motion.frame.position > 0f, "Indicator should move to the right (increasing position)")
+        settle(motion)
+        assertEquals(3f, motion.frame.position, 0.001f, "Active indicator must return to Home visual destination")
+    }
+
+    @Test
+    fun `RTL touch and drag maps to correct logical destinations`() {
+        val count = 4
+        val initialVisual = visualNavIndex(0, count, isRtl = true) // 3
+        val motion = JellyMotion(initialVisual, count)
+        motion.resize(320f, 64f, count) // tabWidth = (320 - 8) / 4 = 78
+
+        // User taps on the right side (where Home is located in RTL)
+        motion.begin(280f, 32f)
+        val tappedVisual = motion.finish()
+        assertEquals(3, tappedVisual)
+        assertEquals(0, logicalNavIndex(tappedVisual, count, isRtl = true), "Right tap must select Home")
+
+        // User taps on the left side (where Settings is located in RTL)
+        motion.begin(40f, 32f)
+        val leftVisual = motion.finish()
+        assertEquals(0, leftVisual)
+        assertEquals(3, logicalNavIndex(leftVisual, count, isRtl = true), "Left tap must select Settings")
+
+        // User drags from Home (right side) leftward towards Search
+        motion.begin(280f, 32f)
+        motion.drag(-80f, 0f)
+        val draggedVisual = motion.finish()
+        assertEquals(2, draggedVisual)
+        assertEquals(1, logicalNavIndex(draggedVisual, count, isRtl = true), "Drag left from Home must select Search")
+    }
+
+    @Test
+    fun `JellyTabTargets coverage calculation correctly tracks visual index in RTL`() {
+        val count = 4
+        val isRtl = true
+
+        // When Home (logical 0) is selected, pill settles at visual 3 (rightmost)
+        val homeMotion = JellyMotion(visualNavIndex(0, count, isRtl), count)
+        homeMotion.resize(320f, 64f, count)
+
+        // For logical tab 0 (Home), visual index is 3
+        val homeVisualIndex = visualNavIndex(0, count, isRtl)
+        val homeCoverage = (1f - abs(homeMotion.frame.position - homeVisualIndex)).coerceIn(0f, 1f)
+        assertEquals(1f, homeCoverage, "Home tab must receive full coverage when selected in RTL")
+
+        // Other tabs must receive 0 coverage
+        val searchVisualIndex = visualNavIndex(1, count, isRtl) // 2
+        val searchCoverage = (1f - abs(homeMotion.frame.position - searchVisualIndex)).coerceIn(0f, 1f)
+        assertEquals(0f, searchCoverage, "Search tab must receive 0 coverage when Home is selected in RTL")
+
+        // When Settings (logical 3) is selected, pill settles at visual 0 (leftmost)
+        val settingsMotion = JellyMotion(visualNavIndex(3, count, isRtl), count)
+        settingsMotion.resize(320f, 64f, count)
+
+        val settingsVisualIndex = visualNavIndex(3, count, isRtl) // 0
+        val settingsCoverage = (1f - abs(settingsMotion.frame.position - settingsVisualIndex)).coerceIn(0f, 1f)
+        assertEquals(1f, settingsCoverage, "Settings tab must receive full coverage when selected in RTL")
+    }
+
+    @Test
+    fun `LTR active-state and indicator behavior remains completely unaffected`() {
+        val count = 4
+        val isRtl = false
+
+        // LTR first item (Home = 0)
+        val homeMotion = JellyMotion(visualNavIndex(0, count, isRtl), count)
+        homeMotion.resize(320f, 64f, count)
+        assertEquals(0f, homeMotion.frame.position)
+
+        // LTR middle item (Search = 1)
+        homeMotion.select(visualNavIndex(1, count, isRtl))
+        settle(homeMotion)
+        assertEquals(1f, homeMotion.frame.position)
+
+        // LTR middle item (Library = 2)
+        homeMotion.select(visualNavIndex(2, count, isRtl))
+        settle(homeMotion)
+        assertEquals(2f, homeMotion.frame.position)
+
+        // LTR last item (Settings = 3)
+        homeMotion.select(visualNavIndex(3, count, isRtl))
+        settle(homeMotion)
+        assertEquals(3f, homeMotion.frame.position)
+
+        // Touch left tap in LTR selects Home (0)
+        homeMotion.begin(40f, 32f)
+        val tappedVisual = homeMotion.finish()
+        assertEquals(0, tappedVisual)
+        assertEquals(0, logicalNavIndex(tappedVisual, count, isRtl))
+
+        // Touch right tap in LTR selects Settings (3)
+        homeMotion.begin(280f, 32f)
+        val rightVisual = homeMotion.finish()
+        assertEquals(3, rightVisual)
+        assertEquals(3, logicalNavIndex(rightVisual, count, isRtl))
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/FloatingNavigationBar.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/FloatingNavigationBar.android.kt
@@ -30,7 +30,9 @@ import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import com.nuvio.app.core.ui.glass.GlassBarSurface
 import com.nuvio.app.core.ui.jelly.JellyMotion
@@ -61,15 +63,19 @@ internal actual fun FloatingNavigationBar(
         animationSpec = tween(NuvioTokens.Motion.sheetEnterMillis, easing = NuvioTokens.Motion.standard),
         label = "jelly_labels",
     )
+    val layoutDirection = LocalLayoutDirection.current
+    val isRtl = layoutDirection == LayoutDirection.Rtl
     val selectedIndex = items.indexOfFirst { it.selected }
-    val motion = remember { JellyMotion(selectedIndex, items.size) }
+    val visualSelectedIndex = visualNavIndex(selectedIndex, items.size, isRtl)
+    val motion = remember(items.size, isRtl) { JellyMotion(visualSelectedIndex, items.size) }
     val currentItems by rememberUpdatedState(items)
+    val currentIsRtl by rememberUpdatedState(isRtl)
     val density = LocalDensity.current
     val trackHeight = 48.dp + (if (compactSize) 8.dp else 16.dp) * labelFraction
     val horizontalPadding = 58.dp - 30.dp * labelFraction
 
-    LaunchedEffect(selectedIndex, items.size) {
-        motion.select(selectedIndex)
+    LaunchedEffect(visualSelectedIndex, items.size) {
+        motion.select(visualSelectedIndex)
     }
     LaunchedEffect(motion.running) {
         if (!motion.running) return@LaunchedEffect
@@ -97,7 +103,7 @@ internal actual fun FloatingNavigationBar(
                 .onSizeChanged {
                     motion.resize(it.width / density.density, it.height / density.density, items.size)
                 }
-                .pointerInput(motion, density, items.size) {
+                .pointerInput(motion, density, items.size, isRtl) {
                     awaitEachGesture {
                         val down = awaitFirstDown(requireUnconsumed = false, pass = PointerEventPass.Initial)
                         motion.begin(down.position.x / density.density, down.position.y / density.density)
@@ -116,15 +122,20 @@ internal actual fun FloatingNavigationBar(
                                 if (change.pressed && change.isConsumed && !claimed) break
                                 motion.drag(delta.x / density.density, delta.y / density.density)
                                 if (!change.pressed) {
-                                    val index = motion.finish()
+                                    val visualIndex = motion.finish()
+                                    val logicalIndex = logicalNavIndex(visualIndex, currentItems.size, currentIsRtl)
                                     finished = true
-                                    if (claimed || !change.isConsumed) currentItems.getOrNull(index)?.onClick?.invoke()
+                                    if (claimed || !change.isConsumed) currentItems.getOrNull(logicalIndex)?.onClick?.invoke()
                                     change.consume()
                                     break
                                 }
                             }
                         } finally {
-                            if (!finished) motion.cancel(currentItems.indexOfFirst { it.selected })
+                            if (!finished) {
+                                val currentSelectedIndex = currentItems.indexOfFirst { it.selected }
+                                val currentVisualIndex = visualNavIndex(currentSelectedIndex, currentItems.size, currentIsRtl)
+                                motion.cancel(currentVisualIndex)
+                            }
                         }
                     }
                 },
@@ -197,3 +208,9 @@ internal actual fun FloatingNavigationBar(
         }
     }
 }
+
+internal fun visualNavIndex(logicalIndex: Int, count: Int, isRtl: Boolean): Int =
+    if (logicalIndex in 0 until count && isRtl) count - 1 - logicalIndex else logicalIndex
+
+internal fun logicalNavIndex(visualIndex: Int, count: Int, isRtl: Boolean): Int =
+    if (visualIndex in 0 until count && isRtl) count - 1 - visualIndex else visualIndex

--- a/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/jelly/JellyTabs.kt
+++ b/composeApp/src/androidMain/kotlin/com/nuvio/app/core/ui/jelly/JellyTabs.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.nuvio.app.core.ui.FloatingNavigationItem
@@ -38,6 +40,7 @@ import com.nuvio.app.core.ui.accentBrush
 import com.nuvio.app.core.ui.gradientMask
 import com.nuvio.app.core.ui.nuvio
 import com.nuvio.app.core.ui.themePalette
+import com.nuvio.app.core.ui.visualNavIndex
 import org.jetbrains.compose.resources.painterResource
 import kotlin.math.abs
 
@@ -107,6 +110,7 @@ internal fun JellyTabTargets(
     compactSize: Boolean,
     modifier: Modifier,
 ) {
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
     Row(modifier.padding(horizontal = 4.dp).selectableGroup()) {
         items.forEachIndexed { index, item ->
             Box(
@@ -127,10 +131,11 @@ internal fun JellyTabTargets(
                 contentAlignment = Alignment.Center,
             ) {
                 if (item.content != null) {
+                    val visualIndex = visualNavIndex(index, items.size, isRtl)
                     Column(
                         modifier = Modifier.graphicsLayer {
                             val frame = motion.frame
-                            val coverage = (1f - abs(frame.position - index)).coerceIn(0f, 1f)
+                            val coverage = (1f - abs(frame.position - visualIndex)).coerceIn(0f, 1f)
                             val scale = 1f + (frame.contentScale - 1f) * coverage
                             scaleX = scale
                             scaleY = scale


### PR DESCRIPTION
## Summary

Fixes the bottom navigation bar active indicator positioning and gesture mapping when the app uses an RTL layout (e.g. Arabic):
- Maps logical navigation indexes to visual coordinates (`count - 1 - index`) when updating `JellyMotion` under `LayoutDirection.Rtl`.
- Converts visual gesture results from touch and drag back to logical indexes before dispatching navigation click events.
- Aligns tab target content scaling and coverage calculation in `JellyTabs` with visual item positions in RTL.
- Preserves exact identity index mapping in LTR layouts.

## PR type

- [ ] Reproducible bug fix
- [x] UI glitch/bug fix
- [ ] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Compose `Row` automatically mirrors the visual order of tabs under RTL layouts (e.g. placing the first destination on the right). However, `JellyMotion` calculates indicator pill positions in visual coordinate space where index 0 is always the leftmost slot. Passing logical indexes directly caused the active indicator to target the opposite visual slot, touch/drag gestures to select the wrong logical tab, and tab scaling to highlight the incorrect item in RTL.

## Issue or approval

Fixes #1925

## UI / behavior impact

- [ ] No UI change
- [ ] No behavior change
- [x] UI changed only to fix a documented glitch/bug
- [x] Behavior changed only to fix a documented bug/regression
- [ ] UI change has explicit maintainer approval
- [ ] Behavior change has explicit maintainer approval

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

This fix is strictly confined to Android bottom navigation index mapping in `FloatingNavigationBar.android.kt` and `JellyTabs.kt`. It intentionally does not alter other navigation surfaces, platform targets, styling tokens, or unrelated components.

## Testing

- **Automated Tests**:
  - Added unit test suite `FloatingNavigationBarRtlTest` in `androidHostTest` covering:
    - Logical-to-visual index mapping under RTL (`count - 1 - index`) and identity mapping in LTR.
    - Restoration of logical destinations from visual touch coordinates.
    - Handling of boundary conditions and invalid indices.
    - `JellyMotion` indicator settlement and directional animation under RTL.
    - Touch tap and drag gesture resolution to logical destinations in RTL and LTR.
    - `JellyTabTargets` coverage and scale tracking across RTL items.
  - Verified `JellyMotionTest` and executed `:composeApp:testAndroidHostTest`.
  - Built full Android variant via `:androidApp:assembleFullDebug`.
- **Manual Verification**:
  - Tested on a physical Android 14 device in Arabic (RTL). Confirmed that the active jelly pill follows the selected tab smoothly across all pages, and taps/drags land on the correct destination.
  - Confirmed English (LTR) navigation remains completely unaffected and operates identically to before.

## Screenshots / Video

### Before

https://github.com/user-attachments/assets/131678c2-d6c2-4d20-bfec-dbb3855f0728

### After

https://github.com/user-attachments/assets/f64115b0-7006-4356-8c0a-74ffa2d95e68

## Breaking changes

None.

## Linked issues

Fixes #1925
