### PR TITLE
fix(player): support autoplay for externally selected episodes

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/PlayerScreenRuntimeSourceActions.kt
@@ -10,6 +10,8 @@ import com.nuvio.app.features.downloads.DownloadItem
 import com.nuvio.app.features.downloads.DownloadsRepository
 import com.nuvio.app.features.p2p.P2pSettingsRepository
 import com.nuvio.app.features.p2p.P2pStreamingEngine
+import com.nuvio.app.features.player.skip.NextEpisodeInfo
+import com.nuvio.app.features.player.skip.PlayerNextEpisodeRules
 import com.nuvio.app.features.streams.StreamItem
 import com.nuvio.app.features.streams.StreamLinkCacheRepository
 import com.nuvio.app.features.watchprogress.WatchProgressRepository
@@ -390,6 +392,50 @@ internal fun PlayerScreenRuntime.playNextEpisode() {
             episodeStreamsPanelState = EpisodeStreamsPanelState(
                 showStreams = true,
                 selectedEpisode = nextVideo,
+            )
+            showEpisodesPanel = true
+        },
+        onSearchingChanged = { nextEpisodeAutoPlaySearching = it },
+        onSourceNameChanged = { nextEpisodeAutoPlaySourceName = it },
+        onCountdownChanged = { nextEpisodeAutoPlayCountdown = it },
+        onNextEpisodeCardVisibleChanged = { showNextEpisodeCard = it },
+    )?.let { job ->
+        nextEpisodeAutoPlayJob = job
+    }
+}
+
+/**
+ * Plays an episode selected outside the player UI through the same download,
+ * source resolution, and autoplay policy as next-episode playback.
+ */
+internal fun PlayerScreenRuntime.playEpisodeAtIndex(index: Int) {
+    val targetEpisode = PlayerNextEpisodeRules.resolvePlayableEpisodeAtIndex(playerMetaVideos, index) ?: return
+    scope.launchPlayerNextEpisodeAutoPlay(
+        previousJob = nextEpisodeAutoPlayJob,
+        nextEpisodeInfo = NextEpisodeInfo(
+            videoId = targetEpisode.id,
+            season = targetEpisode.season ?: return,
+            episode = targetEpisode.episode ?: return,
+            title = targetEpisode.title,
+            thumbnail = targetEpisode.thumbnail,
+            overview = targetEpisode.overview,
+            released = targetEpisode.released,
+            hasAired = true,
+            isWatched = false,
+            unairedMessage = null,
+        ),
+        allEpisodes = playerMetaVideos,
+        parentMetaId = parentMetaId,
+        parentMetaType = parentMetaType,
+        contentType = contentType,
+        settings = playerSettingsUiState,
+        currentStreamBingeGroup = currentStreamBingeGroup,
+        onDownloadedEpisodeSelected = { item, episode -> switchToDownloadedEpisode(item, episode) },
+        onEpisodeStreamSelected = { stream, episode -> switchToEpisodeStream(stream, episode) },
+        onManualSelectionRequired = { episode ->
+            episodeStreamsPanelState = EpisodeStreamsPanelState(
+                showStreams = true,
+                selectedEpisode = episode,
             )
             showEpisodesPanel = true
         },

--- a/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
+++ b/composeApp/src/commonMain/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRules.kt
@@ -4,6 +4,9 @@ import com.nuvio.app.features.details.MetaVideo
 
 object PlayerNextEpisodeRules {
 
+    fun resolvePlayableEpisodeAtIndex(videos: List<MetaVideo>, index: Int): MetaVideo? =
+        videos.getOrNull(index)?.takeIf { hasEpisodeAired(it.released) }
+
     fun resolveNextEpisode(
         videos: List<MetaVideo>,
         currentSeason: Int?,

--- a/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRulesTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/nuvio/app/features/player/skip/PlayerNextEpisodeRulesTest.kt
@@ -1,0 +1,29 @@
+package com.nuvio.app.features.player.skip
+
+import com.nuvio.app.features.details.MetaVideo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class PlayerNextEpisodeRulesTest {
+    @Test
+    fun resolvesAiredEpisodeAtItsOriginalIndex() {
+        val episodes = listOf(
+            MetaVideo(id = "s1e2", title = "Episode 2", released = "2020-01-02"),
+            MetaVideo(id = "s1e1", title = "Episode 1", released = "2020-01-01"),
+        )
+
+        assertEquals("s1e1", PlayerNextEpisodeRules.resolvePlayableEpisodeAtIndex(episodes, 1)?.id)
+    }
+
+    @Test
+    fun rejectsInvalidAndUnairedEpisodeIndices() {
+        val episodes = listOf(
+            MetaVideo(id = "future", title = "Future", released = "2999-01-01"),
+        )
+
+        assertNull(PlayerNextEpisodeRules.resolvePlayableEpisodeAtIndex(episodes, -1))
+        assertNull(PlayerNextEpisodeRules.resolvePlayableEpisodeAtIndex(episodes, 1))
+        assertNull(PlayerNextEpisodeRules.resolvePlayableEpisodeAtIndex(episodes, 0))
+    }
+}


### PR DESCRIPTION
## Summary

Adds a shared `playEpisodeAtIndex` action for external player integrations. It resolves an aired episode from its original metadata index and sends it through the existing download, stream-resolution, and autoplay pipeline.

## PR type

- [ ] Reproducible bug fix
- [ ] UI glitch/bug fix
- [x] Behavior bug/regression fix
- [ ] Small maintenance only, with no UI or behavior change
- [ ] Docs accuracy fix
- [ ] Translation/localization only
- [ ] Approved larger or directional change

## Why

Desktop MPRIS Previous needs to start the resolved previous episode using the same autoplay policy as Next. The shared player previously had no action for an externally selected episode, so Desktop could only open the stream picker instead of applying the configured autoplay flow.

## Issue or approval

Approved by a maintainer in #653: https://github.com/NuvioMedia/NuvioDesktop/pull/653.

## UI / behavior impact

- [x] No UI change
- [x] Behavior changed only to fix a documented bug/regression

## Policy check

- [x] I have read and understood `CONTRIBUTING.md`.
- [x] This PR is small, focused, and limited to one problem.
- [x] This PR is not cosmetic-only.
- [x] Any UI change fixes a linked glitch/bug and includes visual proof, or this PR has no UI change.
- [x] Any behavior change fixes a linked bug/regression or has explicit approval, or this PR has no behavior change.
- [x] This PR does not bundle unrelated refactors, cleanups, formatting, or drive-by changes.
- [x] This PR does not add dependencies, architecture changes, migrations, or product-direction changes without explicit approval.
- [x] I listed the testing performed below.

## Scope boundaries

No UI, player controls, MPRIS, dependency, or platform-specific changes are included. This PR only adds the shared autoplay action required by the approved Desktop MPRIS fix.

## Testing

- `./gradlew :composeApp:testAndroidHostTest --tests com.nuvio.app.features.player.skip.PlayerNextEpisodeRulesTest --no-daemon`
- Verified that valid original indices resolve aired episodes and that invalid or unaired selections are rejected.

## Screenshots / Video

Not a UI change.

## Breaking changes

None.

## Linked issues

Approved Desktop MPRIS fix in #653: https://github.com/NuvioMedia/NuvioDesktop/pull/653.
